### PR TITLE
Attempt to fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   target_branch: gh-pages
-  local_dir: ${TRAVIS_BUILD_DIR}/dist/doc
+  keep-history: true
+  local_dir: /dist/doc
   on:
     branch: master
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  - [X] The commit message follows our guidelines

* **What kind of change does this PR introduce?**
This is an attempt to fix an error occurring when travis tries to deploy the documentation to the gh-page branch 

* **What is the current behavior?** 
The travis build errors due to the following: `rsync: change_dir "/home/travis/build/usgs/neic-glass3/home/travis/build/usgs/neic-glass3/dist/doc" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1183) [sender=3.1.0]
Could not copy /home/travis/build/usgs/neic-glass3/home/travis/build/usgs/neic-glass3/dist/doc.
 `
* **What is the new behavior?**
Hopefully a successful deploy, however this can only be tested when a PR is merged into master

* **Does this PR introduce a breaking change?** 
No

* **Other information**:
I will merge this PR immediately after the build succeeds, as this is the only way to test the post build deploy step.