### PR TITLE
Various Crash and Memory Leak fixes

### DIFF
--- a/config/src/config.cpp
+++ b/config/src/config.cpp
@@ -70,9 +70,6 @@ void Config::loadConfigfile() {
 		configline += currentline;
 	}
 
-	logger::log("debug",
-				"config::load_configfile: read from configfile: " + configline);
-
 	// set the whole config line as our current config
 	if (setConfigString(configline) == true)
 		logger::log(

--- a/doc/GlassConfiguration.md
+++ b/doc/GlassConfiguration.md
@@ -9,7 +9,6 @@ An example `glass_init.d` configuration file:
   "PickMax": 10000,
   "SitePickMax": 30,
   "CorrelationMax": 1000,
-  "Track": false,
   "PickDuplicateWindow": 2.5,
   "NumNucleationThreads": 5,
   "NumHypoThreads": 5,
@@ -90,16 +89,15 @@ detection performance.
 maximum size is reached, glass will start expiring the oldest correlations from
 this list as new correlations are received. This value is used for computational
 performance tuning.
-* **Track** - A mostly depreciated flag controlling whether tracking debug
-statements are logged.
 * **PickDuplicateWindow** - The time window (+/-) within which to consider a
 pick a duplicate of an existing pick from the same station.
 * **NumNucleationThreads** - The number of nucleation/detection threads to run
 in glass. This value should always be at least one. The upper limit depends
-on local machine capabilities.
+on local machine capabilities. This value is used for computational performance 
+tuning.
 * **NumHypoThreads** - The number of hypocenter location threads to run in
 glass.  In general this value should be equal to **NumNucleationThreads** to
-avoid race conditions.
+avoid race conditions. This value is used for computational performance tuning.
 * **WebBackgroundUpdate** - A flag indicating whether to process station updates
 to grids on a background thread. If station updates are not processed on a
 background thread, glass will halt while the updates are processed.

--- a/glass-app/CMakeLists.txt
+++ b/glass-app/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.4)
 
 # ----- PROJECT VERSION NUMBER ----- #
 set (glass-app_VERSION_MAJOR 0)
-set (glass-app_VERSION_MINOR 4)
+set (glass-app_VERSION_MINOR 5)
 set (glass-app_VERSION_PATCH 0)
 
 # ----- PROJECT ----- #

--- a/glass-app/input/input.cpp
+++ b/glass-app/input/input.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <memory>
 
 namespace glass {
 // Construction/Destruction
@@ -240,7 +241,9 @@ bool input::setup(json::Object *config) {
 					"input::setup(): Defaulting to 30 for ShutdownWait");
 	} else {
 		m_iShutdownWait = (*config)["ShutdownWait"].ToInt();
-		logger::log("info", "input::setup(): Using ShutdownWait: "
+		logger::log(
+				"info",
+				"input::setup(): Using ShutdownWait: "
 						+ std::to_string(m_iShutdownWait));
 	}
 
@@ -304,7 +307,7 @@ void input::clear() {
 }
 
 // get next data from input
-json::Object* input::getData() {
+std::shared_ptr<json::Object> input::getData() {
 	// just get the value from the queue
 	return (m_DataQueue->getDataFromQueue());
 }
@@ -444,7 +447,7 @@ bool input::readFiles(std::string extension, const std::string &inputdir,
 				continue;
 
 			// parse the line
-			json::Object * newdata = parse(extension, line);
+			std::shared_ptr<json::Object> newdata = parse(extension, line);
 
 			// validate the data
 			if (validate(extension, newdata) == true) {
@@ -493,7 +496,8 @@ bool input::readFiles(std::string extension, const std::string &inputdir,
 }
 
 // parse a json object from an input string
-json::Object* input::parse(std::string extension, std::string input) {
+std::shared_ptr<json::Object> input::parse(std::string extension,
+											std::string input) {
 	// choose the parser based on the extension
 	// global pick
 	if (((extension == GPICK_EXTENSION) || (extension == GPICKS_EXTENSION))
@@ -511,7 +515,8 @@ json::Object* input::parse(std::string extension, std::string input) {
 }
 
 // validate a json object
-bool input::validate(std::string extension, json::Object* input) {
+bool input::validate(std::string extension,
+						std::shared_ptr<json::Object> input) {
 	// choose the validator based on the extension
 	// global pick
 	if (((extension == GPICK_EXTENSION) || (extension == GPICKS_EXTENSION))

--- a/glass-app/input/input.h
+++ b/glass-app/input/input.h
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <memory>
 
 #define GPICK_EXTENSION "gpick"
 #define GPICKS_EXTENSION "gpicks"
@@ -111,7 +112,7 @@ class input : public util::iInput, public util::ThreadBaseClass {
 	 *
 	 * \return Returns a pointer to a json::Object containing the data.
 	 */
-	json::Object* getData() override;
+	std::shared_ptr<json::Object> getData() override;
 
 	/**
 	 * \brief input data count function
@@ -261,7 +262,8 @@ class input : public util::iInput, public util::ThreadBaseClass {
 	 * \param extension - A std::string containing the extension to parse
 	 * \return returns a pointer to a json::Object containing the parsed data
 	 */
-	virtual json::Object* parse(std::string extension, std::string input);
+	virtual std::shared_ptr<json::Object> parse(std::string extension,
+												std::string input);
 
 	/**
 	 * \brief validate data function
@@ -272,7 +274,8 @@ class input : public util::iInput, public util::ThreadBaseClass {
 	 * \param input - A json::Object containing the data to validate
 	 * \return returns true if valid, false otherwise
 	 */
-	virtual bool validate(std::string extension, json::Object* input);
+	virtual bool validate(std::string extension,
+							std::shared_ptr<json::Object> input);
 
 	/**
 	 * \brief cleanup file function

--- a/glass-app/tests/input_unittest.cpp
+++ b/glass-app/tests/input_unittest.cpp
@@ -4,6 +4,7 @@
 #include <fileutil.h>
 
 #include <string>
+#include <memory>
 
 #define CONFIGFILENAME "inputtest.d"
 #define TESTPATH "testdata"
@@ -246,7 +247,7 @@ TEST_F(InputTest, Run) {
 	ASSERT_TRUE(std::ifstream(jsonorigfile).good()) << "jsonorigfile archived";
 	ASSERT_TRUE(std::ifstream(badfile).good()) << "badfile errored";
 
-	json::Object* data = InputThread->getData();
+	std::shared_ptr<json::Object> data = InputThread->getData();
 
 	// assert input data ok
 	ASSERT_TRUE(data != NULL) << "input data is not null";

--- a/glass-app/tests/output_unittest.cpp
+++ b/glass-app/tests/output_unittest.cpp
@@ -93,7 +93,7 @@ class AssociatorStub : public util::iAssociator {
 	virtual ~AssociatorStub() {
 	}
 
-	void sendToAssociator(std::shared_ptr<json::Object> message) override {
+	void sendToAssociator(std::shared_ptr<json::Object> &message) override {
 		if (message == NULL) {
 			return;
 		}
@@ -111,17 +111,23 @@ class AssociatorStub : public util::iAssociator {
 		}
 
 		if (id == OUTPUTID) {
-			Output->sendToOutput(GetDataFromFile(hypofile));
+			std::shared_ptr<json::Object> hypo = GetDataFromFile(hypofile);
+			Output->sendToOutput(hypo);
 		} else if (id == OUTPUT2ID) {
 			if (sentone == false) {
-				Output->sendToOutput(GetDataFromFile(hypo2file));
+				std::shared_ptr<json::Object> hypo2 = GetDataFromFile(
+						hypo2file);
+				Output->sendToOutput(hypo2);
 				sentone = true;
 			} else {
-				Output->sendToOutput(GetDataFromFile(hypo2updatefile));
+				std::shared_ptr<json::Object> hypo2Update = GetDataFromFile(
+						hypo2updatefile);
+				Output->sendToOutput(hypo2Update);
 			}
 
 		} else if (id == OUTPUT3ID) {
-			Output->sendToOutput(GetDataFromFile(hypo3file));
+			std::shared_ptr<json::Object> hypo3 = GetDataFromFile(hypo3file);
+			Output->sendToOutput(hypo3);
 		}
 	}
 	bool sentone;
@@ -232,7 +238,8 @@ class OutputTest : public ::testing::Test {
 				new json::Object(json::Deserialize(EMPTYCONFIG))));
 	}
 
-	void CheckData(std::shared_ptr<json::Object> dataone, std::shared_ptr<json::Object> datatwo) {
+	void CheckData(std::shared_ptr<json::Object> dataone,
+					std::shared_ptr<json::Object> datatwo) {
 		if (dataone == NULL) {
 			return;
 		}

--- a/glass-broker-app/CMakeLists.txt
+++ b/glass-broker-app/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.4)
 
 # ----- PROJECT VERSION NUMBER ----- #
 set (glass-broker-app_VERSION_MAJOR 0)
-set (glass-broker-app_VERSION_MINOR 4)
+set (glass-broker-app_VERSION_MINOR 5)
 set (glass-broker-app_VERSION_PATCH 0)
 
 # ----- PROJECT ----- #

--- a/glass-broker-app/input/input.cpp
+++ b/glass-broker-app/input/input.cpp
@@ -253,7 +253,7 @@ void input::clear() {
 }
 
 // get next data from input
-json::Object* input::getData() {
+std::shared_ptr<json::Object> input::getData() {
 	// just get the value from the queue
 	return (m_DataQueue->getDataFromQueue());
 }
@@ -275,7 +275,7 @@ bool input::work() {
 
 	if (message != "") {
 		logger::log("trace", "input::work(): Got message: " + message);
-		json::Object* newdata = NULL;
+		std::shared_ptr<json::Object> newdata;
 		try {
 			newdata = m_JSONParser->parse(message);
 		} catch (const std::exception &e) {

--- a/glass-broker-app/input/input.h
+++ b/glass-broker-app/input/input.h
@@ -18,6 +18,7 @@
 #include <queue>
 #include <mutex>
 #include <string>
+#include <memory>
 
 namespace glass {
 /**
@@ -101,7 +102,7 @@ class input : public util::iInput, public util::ThreadBaseClass {
 	 *
 	 * \return Returns a pointer to a json::Object containing the data.
 	 */
-	json::Object* getData() override;
+	std::shared_ptr<json::Object> getData() override;
 
 	/**
 	 * \brief input data count function

--- a/glasscore/CMakeLists.txt
+++ b/glasscore/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.4)
 
 # ----- PROJECT VERSION NUMBER ----- #
 set (glasscore_VERSION_MAJOR 0)
-set (glasscore_VERSION_MINOR 4)
+set (glasscore_VERSION_MINOR 5)
 set (glasscore_VERSION_PATCH 0)
 
 # ----- PROJECT ----- #

--- a/glasscore/glasslib/include/Correlation.h
+++ b/glasscore/glasslib/include/Correlation.h
@@ -217,7 +217,7 @@ class CCorrelation {
 	 * \brief Association string getter
 	 * \return the association string
 	 */
-	const std::string& getAss();
+	const std::string& getAss() const;
 
 	/**
 	 * \brief Association string setter
@@ -336,7 +336,7 @@ class CCorrelation {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex correlationMutex;
+	mutable std::recursive_mutex correlationMutex;
 };
 }  // namespace glasscore
 #endif  // CORRELATION_H

--- a/glasscore/glasslib/include/Correlation.h
+++ b/glasscore/glasslib/include/Correlation.h
@@ -205,7 +205,7 @@ class CCorrelation {
 	 * \brief Hypo getter
 	 * \return the hypo
 	 */
-	const std::shared_ptr<CHypo>& getHypo() const;
+	const std::shared_ptr<CHypo> getHypo() const;
 
 	/**
 	 * \brief Site getter

--- a/glasscore/glasslib/include/Correlation.h
+++ b/glasscore/glasslib/include/Correlation.h
@@ -84,7 +84,7 @@ class CCorrelation {
 	 * \param correlationId - An integer containing the correlation id to use.
 	 * \param pSiteList - A pointer to the CSiteList class
 	 */
-	CCorrelation(json::Object *correlation, int correlationId,
+	CCorrelation(std::shared_ptr<json::Object> correlation, int correlationId,
 					CSiteList *pSiteList);
 
 	/**

--- a/glasscore/glasslib/include/Correlation.h
+++ b/glasscore/glasslib/include/Correlation.h
@@ -258,10 +258,10 @@ class CCorrelation {
 	std::shared_ptr<CSite> pSite;
 
 	/**
-	 * \brief A std::vector of std::shared_ptr's to CHypo objects
+	 * \brief A std::weak_ptr to a CHypo object
 	 * representing the links between this correlation and associated hypocenter
 	 */
-	std::shared_ptr<CHypo> pHypo;
+	std::weak_ptr<CHypo> wpHypo;
 
 	/**
 	 * \brief A std::string containing a character representing the action

--- a/glasscore/glasslib/include/Correlation.h
+++ b/glasscore/glasslib/include/Correlation.h
@@ -142,8 +142,6 @@ class CCorrelation {
 	void addHypo(std::shared_ptr<CHypo> hyp, std::string ass = "", bool force =
 							false);
 
-	void setAss(std::string ass);
-
 	/**
 	 * \brief Remove hypo reference to this correlation
 	 *
@@ -161,7 +159,97 @@ class CCorrelation {
 
 	void clearHypo();
 
-	// Local Attributes
+	/**
+	 * \brief Correlation value getter
+	 * \return the correlation value
+	 */
+	double getCorrelation() const;
+
+	/**
+	 * \brief Latitude getter
+	 * \return the latitude
+	 */
+	double getLat() const;
+
+	/**
+	 * \brief Longitude getter
+	 * \return the longitude
+	 */
+	double getLon() const;
+
+	/**
+	 * \brief Depth getter
+	 * \return the depth
+	 */
+	double getZ() const;
+
+	/**
+	 * \brief Origin time getter
+	 * \return the origin time
+	 */
+	double getTOrg() const;
+
+	/**
+	 * \brief Correlation id getter
+	 * \return the correlation id
+	 */
+	int getIdCorrelation() const;
+
+	/**
+	 * \brief Json correlation getter
+	 * \return the json correlation
+	 */
+	const std::shared_ptr<json::Object>& getJCorrelation() const;
+
+	/**
+	 * \brief Hypo getter
+	 * \return the hypo
+	 */
+	const std::shared_ptr<CHypo>& getHypo() const;
+
+	/**
+	 * \brief Site getter
+	 * \return the site
+	 */
+	const std::shared_ptr<CSite>& getSite() const;
+
+	/**
+	 * \brief Association string getter
+	 * \return the association string
+	 */
+	const std::string& getAss();
+
+	/**
+	 * \brief Association string setter
+	 * \param ass - the association string
+	 */
+	void setAss(std::string ass);
+
+	/**
+	 * \brief Phase getter
+	 * \return the phase
+	 */
+	const std::string& getPhs() const;
+
+	/**
+	 * \brief Pid getter
+	 * \return the pid
+	 */
+	const std::string& getPid() const;
+
+	/**
+	 * \brief Correlation time getter
+	 * \return the correlation time
+	 */
+	double getTCorrelation() const;
+
+	/**
+	 * \brief Creation time getter
+	 * \return the creation time
+	 */
+	double getTGlassCreate() const;
+
+ private:
 	/**
 	 * \brief A std::shared_ptr to a CSite object
 	 * representing the link between this correlation and the site it was
@@ -241,7 +329,14 @@ class CCorrelation {
 	 */
 	std::shared_ptr<json::Object> jCorrelation;
 
-	std::mutex correlationMutex;
+	/**
+	 * \brief A recursive_mutex to control threading access to CCorrelation.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	std::recursive_mutex correlationMutex;
 };
 }  // namespace glasscore
 #endif  // CORRELATION_H

--- a/glasscore/glasslib/include/CorrelationList.h
+++ b/glasscore/glasslib/include/CorrelationList.h
@@ -81,7 +81,7 @@ class CCorrelationList {
 	 * \return Returns true if the communication was handled by CCorrelationList,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CCorrelationList add correlation function
@@ -103,7 +103,7 @@ class CCorrelationList {
 	 * \return Returns true if the correlation was usable and added by CCorrelationList,
 	 * false otherwise
 	 */
-	bool addCorrelation(json::Object *com);
+	bool addCorrelation(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CCorrelationList get correlation function

--- a/glasscore/glasslib/include/CorrelationList.h
+++ b/glasscore/glasslib/include/CorrelationList.h
@@ -182,6 +182,60 @@ class CCorrelationList {
 														double tDuration = 2.5);
 
 	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass() const;
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief CSiteList getter
+	 * \return the CSiteList pointer
+	 */
+	const CSiteList* getSiteList() const;
+
+	/**
+	 * \brief CSiteList setter
+	 * \param siteList - the CSiteList pointer
+	 */
+	void setSiteList(CSiteList* siteList);
+
+	/**
+	 * \brief nCorrelation getter
+	 * \return the nCorrelation
+	 */
+	int getNCorrelation() const;
+
+	/**
+	 * \brief nCorrelationMax getter
+	 * \return the nCorrelationMax
+	 */
+	int getNCorrelationMax() const;
+
+	/**
+	 * \brief nCorrelationMax Setter
+	 * \param correlationMax - the nCorrelationMax
+	 */
+	void setNCorrelationMax(int correlationMax);
+
+	/**
+	 * \brief nCorrelationTotal getter
+	 * \return the nCorrelationTotal
+	 */
+	int getNCorrelationTotal() const;
+
+	/**
+	 * \brief Get the current size of the correlation list
+	 */
+	int getVCorrelationSize() const;
+
+ private:
+	/**
 	 * \brief A pointer to the parent CGlass class, used to send output,
 	 * look up site information, encode/decode time, get configuration values,
 	 * call association functions, and debug flags
@@ -233,7 +287,16 @@ class CCorrelationList {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex m_vCorrelationMutex;
+	mutable std::recursive_mutex m_vCorrelationMutex;
+
+	/**
+	 * \brief A recursive_mutex to control threading access to CCorrelationList.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	mutable std::recursive_mutex m_CorrelationListMutex;
 };
 }   // namespace glasscore
 #endif  // CORRELATIONLIST_H

--- a/glasscore/glasslib/include/Detection.h
+++ b/glasscore/glasslib/include/Detection.h
@@ -95,7 +95,7 @@ class CDetection {
 	 * \brief CGlass getter
 	 * \return the CGlass pointer
 	 */
-	const CGlass* getGlass();
+	const CGlass* getGlass() const;
 
 	/**
 	 * \brief CGlass setter
@@ -112,13 +112,13 @@ class CDetection {
 	CGlass *pGlass;
 
 	/**
-		 * \brief A recursive_mutex to control threading access to CDetection.
-		 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
-		 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
-		 * However a recursive_mutex allows us to maintain the original class
-		 * design as delivered by the contractor.
-		 */
-		std::recursive_mutex detectionMutex;
+	 * \brief A recursive_mutex to control threading access to CDetection.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	mutable std::recursive_mutex detectionMutex;
 };
 }  // namespace glasscore
 #endif  // DETECTION_H

--- a/glasscore/glasslib/include/Detection.h
+++ b/glasscore/glasslib/include/Detection.h
@@ -69,7 +69,7 @@ class CDetection {
 	 * \return Returns true if the communication was handled by CDetection,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Process detection message
@@ -89,7 +89,7 @@ class CDetection {
 	 * \param com -  A pointer to a json::object containing the incoming
 	 * 'Detection' message
 	 */
-	bool process(json::Object *com);
+	bool process(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CGlass getter

--- a/glasscore/glasslib/include/Detection.h
+++ b/glasscore/glasslib/include/Detection.h
@@ -91,13 +91,34 @@ class CDetection {
 	 */
 	bool process(json::Object *com);
 
-	// Local Attributes
+	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass();
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+ private:
 	/**
 	 * \brief A pointer to the parent CGlass class, used to send output,
 	 * look up site information, encode/decode time, get configuration
 	 * values, call association functions, and debug flags
 	 */
 	CGlass *pGlass;
+
+	/**
+		 * \brief A recursive_mutex to control threading access to CDetection.
+		 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+		 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+		 * However a recursive_mutex allows us to maintain the original class
+		 * design as delivered by the contractor.
+		 */
+		std::recursive_mutex detectionMutex;
 };
 }  // namespace glasscore
 #endif  // DETECTION_H

--- a/glasscore/glasslib/include/Glass.h
+++ b/glasscore/glasslib/include/Glass.h
@@ -121,19 +121,6 @@ class CGlass {
 	void clear();
 
 	/**
-	 * \brief CGlass input synchronization confirmation function
-	 *
-	 * The function used by CGlass to confirm that glasscore has processed
-	 * all previously sent input data.  Once glasscore has completed
-	 * processing all input, a confirmation "pong" message is sent.
-	 *
-	 * \param com - A pointer to a json::object containing the
-	 * confirmation query.
-	 * \return Always returns true
-	 */
-	bool ping(json::Object *com);
-
-	/**
 	 * \brief CGlass earth model test function
 	 *
 	 * This function is used by CGlass to test the loading and

--- a/glasscore/glasslib/include/Glass.h
+++ b/glasscore/glasslib/include/Glass.h
@@ -222,7 +222,7 @@ class CGlass {
 	CPickList*& getPickList();
 	CSiteList*& getSiteList();
 	std::shared_ptr<traveltime::CTravelTime>& getTrvDefault();
-	traveltime::CTTT*& getTTT();
+	std::shared_ptr<traveltime::CTTT>& getTTT();
 	CWebList*& getWebList();
 	double getSdAssociate() const;
 	double getSdPrune() const;
@@ -319,7 +319,7 @@ class CGlass {
 	 * \brief A pointer to a CTTT object containing the travel
 	 * time phases and branches used by glasscore for association
 	 */
-	traveltime::CTTT *pTTT;
+	std::shared_ptr<traveltime::CTTT> pTTT;
 
 	/**
 	 * \brief the std::mutex for traveltimes

--- a/glasscore/glasslib/include/Glass.h
+++ b/glasscore/glasslib/include/Glass.h
@@ -177,25 +177,60 @@ class CGlass {
 	double sig_laplace_pdf(double tdif, double sig);
 
 	/**
+	 * \brief An IGlassSend interface pointer used to send communication
+	 * (such as output data), to outside the glasscore library
+	 */
+	glasscore::IGlassSend *piSend;
+
+	/**
 	 * \brief check to see if each thread is still functional
 	 *
 	 * Checks each thread to see if it is still responsive.
 	 */
 	bool statusCheck();
+	double getAvgDelta() const;
+	double getAvgSigma() const;
+	double getBeamMatchingAzimuthWindow() const;
+	double getBeamMatchingDistanceWindow() const;
+	int getCorrelationCancelAge() const;
+	double getCorrelationMatchingTWindow() const;
+	double getCorrelationMatchingXWindow() const;
+	double getCutFactor() const;
+	double getCutMin() const;
+	double getCutPercentage() const;
+	double getReportThresh() const;
+	double getThresh() const;
+	double getExpAffinity() const;
+	bool getGraphicsOut() const;
+	const std::string& getGraphicsOutFolder() const;
+	double getGraphicsStepKm() const;
+	int getGraphicsSteps() const;
+	int getCycleLimit() const;
+	bool getMinimizeTtLocator() const;
+	int getCorrelationMax() const;
+	int getCount() const;
+	int getDetect() const;
+	int getHypoMax() const;
+	int getNucleate() const;
+	int getPickMax() const;
+	double getReportCut() const;
+	int getSitePickMax() const;
+	CCorrelationList*& getCorrelationList();
+	CDetection*& getDetection();
+	CHypoList*& getHypoList();
+	double getPickDuplicateWindow() const;
+	CPickList*& getPickList();
+	CSiteList*& getSiteList();
+	std::shared_ptr<traveltime::CTravelTime>& getTrvDefault();
+	traveltime::CTTT*& getTTT();
+	CWebList*& getWebList();
+	double getSdAssociate() const;
+	double getSdPrune() const;
+	const std::string& getWeb() const;
+	bool getTestLocator() const;
+	bool getTestTimes() const;
 
-	// Local Attributes
-	/**
-	 * \brief A std::string used in debugging to keep track of the id of the
-	 * last pick added to glass.
-	 */
-	std::string sTrack;
-
-	/**
-	 * \brief A boolean set to true to turn on process tracking using
-	 * printf strings (saved in sTrack)
-	 */
-	bool bTrack;
-
+ private:
 	/**
 	 * \brief A double value containing the default number of picks that
 	 * that need to be gathered to trigger the nucleation of an event.
@@ -270,12 +305,6 @@ class CGlass {
 	double dCutMin;
 
 	/**
-	 * \brief An IGlassSend interface pointer used to send communication
-	 * (such as output data), to outside the glasscore library
-	 */
-	glasscore::IGlassSend *piSend;
-
-	/**
 	 * \brief A pointer to a CWeb object containing the detection web
 	 */
 	CWebList *pWebList;
@@ -295,7 +324,7 @@ class CGlass {
 	/**
 	 * \brief the std::mutex for traveltimes
 	 */
-	std::mutex m_TTTMutex;
+	mutable std::mutex m_TTTMutex;
 
 	/**
 	 * \brief A pointer to a CSiteList object containing all the sites
@@ -351,36 +380,6 @@ class CGlass {
 	 * pHypoList
 	 */
 	int nHypoMax;
-
-	/**
-	 * \brief An integer containing the count of the number of times
-	 * Hypo::iterate is called. Used for debugging.
-	 */
-	int nIterate;
-
-	/**
-	 * \brief An integer containing the count of the number of times
-	 * Hypo::localize is called. Used for debugging.
-	 */
-	int nLocate;
-
-	/**
-	 * \brief A string containing the most recent nucleated web. Used for
-	 * debugging.
-	 */
-	std::string sWeb;
-
-	/**
-	 * \brief An integer containing the count of supporting stations for the most
-	 * recently nucleated node. Used for debugging.
-	 */
-	int nCount;
-
-	/**
-	 * \brief A double containing the Bayesian sum for the most recently
-	 * nucleated node. Used for debugging.
-	 */
-	double dSum;
 
 	/**
 	 * \brief Window to check for 'duplicate' picks at same station. If new pick is

--- a/glasscore/glasslib/include/Glass.h
+++ b/glasscore/glasslib/include/Glass.h
@@ -81,7 +81,7 @@ class CGlass {
 	 * \return Returns true if the communication was handled by CGlass,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CGlass communication sending function
@@ -95,7 +95,7 @@ class CGlass {
 	 * \return Returns true if the communication was sent via
 	 * a valid IGlassSend interface pointer, false otherwise
 	 */
-	bool send(json::Object *com);
+	bool send(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CGlass initialization function
@@ -112,7 +112,7 @@ class CGlass {
 	 * \return Returns true if the initialization was successful,
 	 * false otherwise
 	 */
-	bool initialize(json::Object *com);
+	bool initialize(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CGlass clear function

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -705,7 +705,7 @@ class CHypo {
 
 	/**
 	 * \brief CGlass setter
-	 * \param glss - the CGlass pointer
+	 * \param glass - the CGlass pointer
 	 */
 	void setGlass(CGlass* glass);
 

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -745,6 +745,10 @@ class CHypo {
 	 */
 	int getReportCount() const;
 
+	bool isLockedForProcessing();
+	void lockForProcessing();
+	void unlockAfterProcessing();
+
  private:
 	/**
 	 * \brief A pointer to the main CGlass class, used to send output,
@@ -985,6 +989,11 @@ class CHypo {
 	 * design as delivered by the contractor.
 	 */
 	mutable std::recursive_mutex hypoMutex;
+
+	/**
+	 * \brief A mutex to control processing access to CHypo.
+	 */
+	std::mutex processingMutex;
 
 	/**
 	 * \brief A random engine used to generate random numbers

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -515,37 +515,37 @@ class CHypo {
 	 * \brief Latitude getter
 	 * \return the latitude
 	 */
-	double getLat();
+	double getLat() const;
 
 	/**
 	 * \brief Longitude getter
 	 * \return the longitude
 	 */
-	double getLon();
+	double getLon() const;
 
 	/**
 	 * \brief Depth getter
 	 * \return the depth
 	 */
-	double getZ();
+	double getZ() const;
 
 	/**
 	 * \brief Origin time getter
 	 * \return the origin time
 	 */
-	double getTOrg();
+	double getTOrg() const;
 
 	/**
 	 * \brief Bayes value getter
 	 * \return the bayes value
 	 */
-	double getBayes();
+	double getBayes() const;
 
 	/**
 	 * \brief Correlation added flag getter
 	 * \return the correlation added flag
 	 */
-	bool getCorrAdded();
+	bool getCorrAdded() const;
 
 	/**
 	 * \brief Correlation added flag setter
@@ -557,13 +557,13 @@ class CHypo {
 	 * \brief Event reported flag getter
 	 * \return the event reported flag
 	 */
-	bool getEvent();
+	bool getEvent() const;
 
 	/**
 	 * \brief Fixed flag getter
 	 * \return the fixed flag
 	 */
-	bool getFixed();
+	bool getFixed() const;
 
 	/**
 	 * \brief Fixed flag setter
@@ -575,13 +575,13 @@ class CHypo {
 	 * \brief Bayes initial value getter
 	 * \return the intial bayes value
 	 */
-	double getBayesInitial();
+	double getBayesInitial() const;
 
 	/**
 	 * \brief Cut factor getter
 	 * \return the cut factor value
 	 */
-	double getCutFactor();
+	double getCutFactor() const;
 
 	/**
 	 * \brief Cut factor setter
@@ -593,7 +593,7 @@ class CHypo {
 	 * \brief Cut min getter
 	 * \return the cut min value
 	 */
-	double getCutMin();
+	double getCutMin() const;
 
 	/**
 	 * \brief Cut min setter
@@ -605,7 +605,7 @@ class CHypo {
 	 * \brief Cut percentage getter
 	 * \return the cut percentage value
 	 */
-	double getCutPercentage();
+	double getCutPercentage() const;
 
 	/**
 	 * \brief Cut factor setter
@@ -617,7 +617,7 @@ class CHypo {
 	 * \brief Cut getter
 	 * \return the cut value
 	 */
-	int getCut();
+	int getCut() const;
 
 	/**
 	 * \brief Cut setter
@@ -629,7 +629,7 @@ class CHypo {
 	 * \brief Thresh getter
 	 * \return the thresh value
 	 */
-	double getThresh();
+	double getThresh() const;
 
 	/**
 	 * \brief Thresh setter
@@ -641,43 +641,43 @@ class CHypo {
 	 * \brief Gap getter
 	 * \return the gap value
 	 */
-	double getGap();
+	double getGap() const;
 
 	/**
 	 * \brief Kurtosis getter
 	 * \return the kurtosis value
 	 */
-	double getKrt();
+	double getKrt() const;
 
 	/**
 	 * \brief Med distance getter
 	 * \return the med distance value
 	 */
-	double getMed();
+	double getMed() const;
 
 	/**
 	 * \brief Min distance getter
 	 * \return the min distance value
 	 */
-	double getMin();
+	double getMin() const;
 
 	/**
 	 * \brief Residual getter
 	 * \return the residual value
 	 */
-	double getRes();
+	double getRes() const;
 
 	/**
 	 * \brief Sig getter
 	 * \return the sig value
 	 */
-	double getSig();
+	double getSig() const;
 
 	/**
 	 * \brief Cycle getter
 	 * \return the cycle value
 	 */
-	int getCycle();
+	int getCycle() const;
 
 	/**
 	 * \brief Cycle setter
@@ -689,7 +689,7 @@ class CHypo {
 	 * \brief Process count getter
 	 * \return the process count value
 	 */
-	int getProcessCount();
+	int getProcessCount() const;
 
 	/**
 	 * \brief Process count incrementer
@@ -701,7 +701,7 @@ class CHypo {
 	 * \brief CGlass getter
 	 * \return the CGlass pointer
 	 */
-	const CGlass* getGlass();
+	const CGlass* getGlass() const;
 
 	/**
 	 * \brief CGlass setter
@@ -725,13 +725,13 @@ class CHypo {
 	 * \brief Pick vector size getter
 	 * \return the pick vector size
 	 */
-	int getVPickSize();
+	int getVPickSize() const;
 
 	/**
 	 * \brief Correlation vector size getter
 	 * \return the correlation vector size
 	 */
-	int getVCorrSize();
+	int getVCorrSize() const;
 
 	/**
 	 * \brief Creation time getter
@@ -743,7 +743,7 @@ class CHypo {
 	 * \brief Report count getter
 	 * \return the report count
 	 */
-	int getReportCount();
+	int getReportCount() const;
 
  private:
 	/**
@@ -984,7 +984,7 @@ class CHypo {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex hypoMutex;
+	mutable std::recursive_mutex hypoMutex;
 
 	/**
 	 * \brief A random engine used to generate random numbers

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -246,7 +246,7 @@ class CHypo {
 	 *
 	 * \return Returns the generated json object.
 	 */
-	json::Object hypo();
+	std::shared_ptr<json::Object> hypo();
 
 	/**
 	 * \brief Generate Event message

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -21,7 +21,7 @@ namespace glasscore {
 class CGlass;
 class CPick;
 class CCorrelation;
-class CNode;
+class CTrigger;
 
 /**
  * \brief glasscore hypocenter class
@@ -92,7 +92,7 @@ class CHypo {
 	 * \param node - A shared pointer to a CNode object containing the node to
 	 * construct this hypo from.
 	 */
-	explicit CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt);
+	explicit CHypo(std::shared_ptr<CTrigger> trigger, traveltime::CTTT *ttt);
 
 	/**
 	 * \brief CHypo alternate constructor

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -476,6 +476,8 @@ class CHypo {
 	double getBayes(double xlat, double xlon, double xZ, double oT,
 					int nucleate);
 
+	double getResidual(std::string sPhase, double tObs, double tCal);
+
 	/**
 	 * Get the sum of the absolute residuals at a location
 	 *

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -492,13 +492,6 @@ class CHypo {
 	void graphicsOutput();
 
 	/**
-	 * \brief Sets the processing cycle count
-	 *
-	 * \param newCycle - An integer value containing the new cycle count
-	 */
-	void setCycle(int newCycle);
-
-	/**
 	 * \brief Calculate station weights
 	 *
 	 * Calculate the weight of each station for each pick in this
@@ -518,8 +511,241 @@ class CHypo {
 	 */
 	void trap();
 
-	void incrementProcessCount();
+	/**
+	 * \brief Latitude getter
+	 * \return the latitude
+	 */
+	double getLat();
 
+	/**
+	 * \brief Longitude getter
+	 * \return the longitude
+	 */
+	double getLon();
+
+	/**
+	 * \brief Depth getter
+	 * \return the depth
+	 */
+	double getZ();
+
+	/**
+	 * \brief Origin time getter
+	 * \return the origin time
+	 */
+	double getTOrg();
+
+	/**
+	 * \brief Bayes value getter
+	 * \return the bayes value
+	 */
+	double getBayes();
+
+	/**
+	 * \brief Correlation added flag getter
+	 * \return the correlation added flag
+	 */
+	bool getCorrAdded();
+
+	/**
+	 * \brief Correlation added flag setter
+	 * \param corrAdded - the correlation added flag
+	 */
+	void setCorrAdded(bool corrAdded);
+
+	/**
+	 * \brief Event reported flag getter
+	 * \return the event reported flag
+	 */
+	bool getEvent();
+
+	/**
+	 * \brief Fixed flag getter
+	 * \return the fixed flag
+	 */
+	bool getFixed();
+
+	/**
+	 * \brief Fixed flag setter
+	 * \param fixed - the fixed flag
+	 */
+	void setFixed(bool fixed);
+
+	/**
+	 * \brief Bayes initial value getter
+	 * \return the intial bayes value
+	 */
+	double getBayesInitial();
+
+	/**
+	 * \brief Cut factor getter
+	 * \return the cut factor value
+	 */
+	double getCutFactor();
+
+	/**
+	 * \brief Cut factor setter
+	 * \param cutFactor -  the cut factor
+	 */
+	void setCutFactor(double cutFactor);
+
+	/**
+	 * \brief Cut min getter
+	 * \return the cut min value
+	 */
+	double getCutMin();
+
+	/**
+	 * \brief Cut min setter
+	 * \param cutMin - the cut min value
+	 */
+	void setCutMin(double cutMin);
+
+	/**
+	 * \brief Cut percentage getter
+	 * \return the cut percentage value
+	 */
+	double getCutPercentage();
+
+	/**
+	 * \brief Cut factor setter
+	 * \param cutPercentage - the cut percentage value
+	 */
+	void setCutPercentage(double cutPercentage);
+
+	/**
+	 * \brief Cut getter
+	 * \return the cut value
+	 */
+	int getCut();
+
+	/**
+	 * \brief Cut setter
+	 * \param cut - the cut value
+	 */
+	void setCut(double cut);
+
+	/**
+	 * \brief Thresh getter
+	 * \return the thresh value
+	 */
+	double getThresh();
+
+	/**
+	 * \brief Thresh setter
+	 * \param thresh - the thresh value
+	 */
+	void setThresh(double thresh);
+
+	/**
+	 * \brief Gap getter
+	 * \return the gap value
+	 */
+	double getGap();
+
+	/**
+	 * \brief Kurtosis getter
+	 * \return the kurtosis value
+	 */
+	double getKrt();
+
+	/**
+	 * \brief Med distance getter
+	 * \return the med distance value
+	 */
+	double getMed();
+
+	/**
+	 * \brief Min distance getter
+	 * \return the min distance value
+	 */
+	double getMin();
+
+	/**
+	 * \brief Residual getter
+	 * \return the residual value
+	 */
+	double getRes();
+
+	/**
+	 * \brief Sig getter
+	 * \return the sig value
+	 */
+	double getSig();
+
+	/**
+	 * \brief Cycle getter
+	 * \return the cycle value
+	 */
+	int getCycle();
+
+	/**
+	 * \brief Cycle setter
+	 * \param newCycle - the cycle value
+	 */
+	int setCycle(int newCycle);
+
+	/**
+	 * \brief Process count getter
+	 * \return the process count value
+	 */
+	int getProcessCount();
+
+	/**
+	 * \brief Process count incrementer
+	 * \return the process count value
+	 */
+	int incrementProcessCount();
+
+	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass();
+
+	/**
+	 * \brief CGlass setter
+	 * \param glss - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief Pid getter
+	 * \return the Pid
+	 */
+	const std::string& getPid() const;
+
+	/**
+	 * \brief Web Name getter
+	 * \return the Web Name
+	 */
+	const std::string& getWebName() const;
+
+	/**
+	 * \brief Pick vector size getter
+	 * \return the pick vector size
+	 */
+	int getVPickSize();
+
+	/**
+	 * \brief Correlation vector size getter
+	 * \return the correlation vector size
+	 */
+	int getVCorrSize();
+
+	/**
+	 * \brief Creation time getter
+	 * \return the creation time
+	 */
+	double getTCreate() const;
+
+	/**
+	 * \brief Report count getter
+	 * \return the report count
+	 */
+	int getReportCount();
+
+ private:
 	/**
 	 * \brief A pointer to the main CGlass class, used to send output,
 	 * look up travel times, encode/decode time, and call significance
@@ -531,7 +757,7 @@ class CHypo {
 	 * \brief  A std::string with the name of the initiating subnet trigger
 	 * used during the nucleation process
 	 */
-	std::string sWeb;
+	std::string sWebName;
 
 	/**
 	 * \brief An integer containing the number of stations needed to maintain
@@ -575,16 +801,6 @@ class CHypo {
 	 * \brief A double value containing this hypo's depth in kilometers
 	 */
 	double dZ;
-
-	/**
-	 * \brief A boolean indicating whether this hypo needs to be refined.
-	 */
-	bool bRefine;
-
-	/**
-	 * \brief A boolean indicating if a Quake message was sent for this hypo.
-	 */
-	bool bQuake;
 
 	/**
 	 * \brief A boolean indicating if an Event message was sent for this hypo.

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -967,19 +967,19 @@ class CHypo {
 	 * \brief A pointer to a CTravelTime object containing
 	 * travel times for the first phase used to nucleate this hypo
 	 */
-	traveltime::CTravelTime* pTrv1;
+	std::shared_ptr<traveltime::CTravelTime> pTrv1;
 
 	/**
 	 * \brief A pointer to a CTravelTime object containing
 	 * travel times for the second phase used to nucleate this hypo
 	 */
-	traveltime::CTravelTime* pTrv2;
+	std::shared_ptr<traveltime::CTravelTime> pTrv2;
 
 	/**
 	 * \brief A pointer to a CTTT object containing the travel
 	 * time phases and branches used for association and location
 	 */
-	traveltime::CTTT *pTTT;
+	std::shared_ptr<traveltime::CTTT> pTTT;
 
 	/**
 	 * \brief A recursive_mutex to control threading access to CHypo.

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -79,9 +79,9 @@ class CHypo {
 	 */
 	CHypo(double lat, double lon, double z, double time, std::string pid,
 			std::string web, double bayes, double thresh, int cut,
-			traveltime::CTravelTime* firstTrav,
-			traveltime::CTravelTime* secondTrav, traveltime::CTTT *ttt,
-			double resolution = 100);
+			std::shared_ptr<traveltime::CTravelTime> firstTrav,
+			std::shared_ptr<traveltime::CTravelTime> secondTrav,
+			std::shared_ptr<traveltime::CTTT> ttt, double resolution = 100);
 
 	/**
 	 * \brief CHypo alternate constructor
@@ -92,7 +92,8 @@ class CHypo {
 	 * \param node - A shared pointer to a CNode object containing the node to
 	 * construct this hypo from.
 	 */
-	explicit CHypo(std::shared_ptr<CTrigger> trigger, traveltime::CTTT *ttt);
+	explicit CHypo(std::shared_ptr<CTrigger> trigger,
+					std::shared_ptr<traveltime::CTTT> ttt);
 
 	/**
 	 * \brief CHypo alternate constructor
@@ -104,8 +105,9 @@ class CHypo {
 	 * correlation to construct this hypo from.
 	 */
 	explicit CHypo(std::shared_ptr<CCorrelation> corr,
-					traveltime::CTravelTime* firstTrav,
-					traveltime::CTravelTime* secondTrav, traveltime::CTTT *ttt);
+					std::shared_ptr<traveltime::CTravelTime> firstTrav,
+					std::shared_ptr<traveltime::CTravelTime> secondTrav,
+					std::shared_ptr<traveltime::CTTT> ttt);
 
 	/**
 	 * \brief CHypo destructor
@@ -142,9 +144,11 @@ class CHypo {
 	 */
 	bool initialize(double lat, double lon, double z, double time,
 					std::string pid, std::string web, double bayes,
-					double thresh, int cut, traveltime::CTravelTime* firstTrav,
-					traveltime::CTravelTime* secondTrav, traveltime::CTTT *ttt,
-					double resolution = 100);
+					double thresh, int cut,
+					std::shared_ptr<traveltime::CTravelTime> firstTrav,
+					std::shared_ptr<traveltime::CTravelTime> secondTrav,
+					std::shared_ptr<traveltime::CTTT> ttt, double resolution =
+							100);
 
 	/**
 	 * \brief Add pick reference to this hypo

--- a/glasscore/glasslib/include/HypoList.h
+++ b/glasscore/glasslib/include/HypoList.h
@@ -276,11 +276,58 @@ class CHypoList {
 
 	/** \brief Merge event **/
 	// bool merge(std::shared_ptr<CHypo> hyp);
+	/**
+	 * \brief check to see if each thread is still functional
+	 *
+	 * Checks each thread to see if it is still responsive.
+	 */
+	bool statusCheck();
 
+	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass() const;
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief nHypo getter
+	 * \return the nHypo
+	 */
+	int getNHypo() const;
+
+	/**
+	 * \brief nHypoMax getter
+	 * \return the nHypoMax
+	 */
+	int getNHypoMax() const;
+
+	/**
+	 * \brief nHypoMax Setter
+	 * \param hypoMax - the nHypoMax
+	 */
+	void setNHypoMax(int hypoMax);
+
+	/**
+	 * \brief nHypoTotal getter
+	 * \return the nHypoTotal
+	 */
+	int getNHypoTotal() const;
+
+	/**
+	 * \brief Get the current size of the hypocenter list
+	 */
+	int getVHypoSize() const;
+
+ private:
 	/**
 	 * \brief HypoList sort function
 	 */
-
 	void sort();
 
 	/**
@@ -296,13 +343,6 @@ class CHypoList {
 	 * The function that performs the sleep between jobs
 	 */
 	void jobSleep();
-
-	/**
-	 * \brief check to see if each thread is still functional
-	 *
-	 * Checks each thread to see if it is still responsive.
-	 */
-	bool statusCheck();
 
 	/**
 	 * \brief thread status update function
@@ -369,12 +409,16 @@ class CHypoList {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex m_vHypoMutex;
+	mutable std::recursive_mutex m_vHypoMutex;
 
 	/**
-	 * \brief A boolean indicating whether to send Event json messages.
+	 * \brief A recursive_mutex to control threading access to CHypoList.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
 	 */
-	bool bSendEvent;
+	mutable std::recursive_mutex m_HypoListMutex;
 
 	/**
 	 * \brief the std::vector of std::threads

--- a/glasscore/glasslib/include/HypoList.h
+++ b/glasscore/glasslib/include/HypoList.h
@@ -275,7 +275,7 @@ class CHypoList {
 	bool reqHypo(json::Object *com);
 
 	/** \brief Merge event **/
-	bool merge(std::shared_ptr<CHypo> hyp);
+	// bool merge(std::shared_ptr<CHypo> hyp);
 
 	/**
 	 * \brief HypoList sort function

--- a/glasscore/glasslib/include/HypoList.h
+++ b/glasscore/glasslib/include/HypoList.h
@@ -95,7 +95,7 @@ class CHypoList {
 	 * \return Returns true if the communication was handled by CGlass,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Get insertion index for hypo
@@ -272,7 +272,7 @@ class CHypoList {
 	 * \param com - A pointer to a json::object containing the id of the
 	 * hypocenter to use
 	 */
-	bool reqHypo(json::Object *com);
+	bool reqHypo(std::shared_ptr<json::Object> com);
 
 	/** \brief Merge event **/
 	// bool merge(std::shared_ptr<CHypo> hyp);

--- a/glasscore/glasslib/include/IGlassSend.h
+++ b/glasscore/glasslib/include/IGlassSend.h
@@ -8,6 +8,7 @@
 #define IGLASSSEND_H
 
 #include <json.h>
+#include <memory>
 
 namespace glasscore {
 
@@ -30,7 +31,7 @@ struct IGlassSend {
 	 * \param com - A pointer to a json::object containing the data
 	 * to send to glasscore.
 	 */
-	virtual void Send(json::Object *com) = 0;
+	virtual void Send(std::shared_ptr<json::Object> com) = 0;
 };
 }  // namespace glasscore
 #endif  // IGLASSSEND_H

--- a/glasscore/glasslib/include/Link.h
+++ b/glasscore/glasslib/include/Link.h
@@ -22,9 +22,10 @@ class CSite;
 #define LINK_TT2 2  // Second travel time
 
 /**
- * \brief Typedef to simplify use of a site-node link
+ * \brief Typedef to simplify use of a site-node link uses weak_ptr to
+ * prevent a cyclical reference
  */
-typedef std::tuple<std::shared_ptr<CNode>, double, double> NodeLink;
+typedef std::tuple<std::weak_ptr<CNode>, double, double> NodeLink;
 
 /**
  * \brief Typedef to simplify use of a node-site link

--- a/glasscore/glasslib/include/Node.h
+++ b/glasscore/glasslib/include/Node.h
@@ -22,6 +22,7 @@ namespace glasscore {
 class CPick;
 class CSite;
 class CWeb;
+class CTrigger;
 
 /**
  * \brief glasscore detection node class
@@ -138,7 +139,7 @@ class CNode {
 	 * picks used in calculation
 	 * \return Returns true if the node nucleated an event, false otherwise
 	 */
-	bool nucleate(double tOrigin, bool bList = false);
+	std::shared_ptr<CTrigger> nucleate(double tOrigin);
 
 	/**
 	 * \brief CNode significance function
@@ -253,30 +254,6 @@ class CNode {
 	 */
 	const std::string& getPid() const;
 
-	/**
-	 * \brief tOrg getter
-	 * \return the tOrg
-	 */
-	double getTOrg() const;
-
-	/**
-	 * \brief dSum getter
-	 * \return the dSum
-	 */
-	double getSum() const;
-
-	/**
-	 * \brief nCount getter
-	 * \return the nCount
-	 */
-	int getCount() const;
-
-	/**
-	 * \brief vPick getter
-	 * \return the vPick
-	 */
-	const std::vector<std::shared_ptr<CPick>> getVPick() const;
-
  private:
 	/**
 	 * \brief A pointer to the parent CWeb class, used get configuration,
@@ -318,39 +295,10 @@ class CNode {
 	double dResolution;
 
 	/**
-	 * \brief A double value that accumulates the Bayesian
-	 * sum when evaluating the agoric at each node in a web.
-	 * It is compared to the threshold value set for the
-	 * web which owns this node.
-	 */
-	double dSum;
-
-	/**
-	 * \brief A integer value that tallies the number of sites
-	 * that are included in this solution. This value is
-	 * compared against the Nucleation parameter in the
-	 * parameters for the web for which this node is a memeber
-	 */
-	int nCount;
-
-	/**
-	 * \brief A double value with the origin time calculated the last time
-	 * this node was nucleated.
-	 */
-	double tOrg;
-
-	/**
 	 * \brief A boolean flag indicating whether this node is enabled for
 	 * nucleation
 	 */
 	bool bEnabled;
-
-	/**
-	 * \brief A std::vector of std::shared_ptr's to CPick objects
-	 * used in calculating the likelihood of a hypocenter
-	 * centered on this node during the last call to nucleate()
-	 */
-	std::vector<std::shared_ptr<CPick>> vPick;
 
 	/**
 	 * \brief A std::vector of tuples linking node to site

--- a/glasscore/glasslib/include/Node.h
+++ b/glasscore/glasslib/include/Node.h
@@ -271,13 +271,11 @@ class CNode {
 	 */
 	int getCount() const;
 
-	// NOTE: Make private....
 	/**
-	 * \brief A std::vector of std::shared_ptr's to CPick objects
-	 * used in calculating the likelihood of a hypocenter
-	 * centered on this node during the last call to nucleate()
+	 * \brief vPick getter
+	 * \return the vPick
 	 */
-	std::vector<std::shared_ptr<CPick>> vPick;
+	const std::vector<std::shared_ptr<CPick>> getVPick() const;
 
  private:
 	/**
@@ -341,7 +339,18 @@ class CNode {
 	 */
 	double tOrg;
 
+	/**
+	 * \brief A boolean flag indicating whether this node is enabled for
+	 * nucleation
+	 */
 	bool bEnabled;
+
+	/**
+	 * \brief A std::vector of std::shared_ptr's to CPick objects
+	 * used in calculating the likelihood of a hypocenter
+	 * centered on this node during the last call to nucleate()
+	 */
+	std::vector<std::shared_ptr<CPick>> vPick;
 
 	/**
 	 * \brief A std::vector of tuples linking node to site

--- a/glasscore/glasslib/include/Node.h
+++ b/glasscore/glasslib/include/Node.h
@@ -191,13 +191,13 @@ class CNode {
 	 * \brief Site links count getter
 	 * \return the site links count
 	 */
-	int getSiteLinksCount();
+	int getSiteLinksCount() const;
 
 	/**
 	 * \brief Enabled flag getter
 	 * \return the enabled flag
 	 */
-	bool getEnabled();
+	bool getEnabled() const;
 
 	/**
 	 * \brief Enabled flag setter
@@ -233,7 +233,7 @@ class CNode {
 	 * \brief CWeb pointer getter
 	 * \return the CWeb pointer
 	 */
-	CWeb* getWeb();
+	CWeb* getWeb() const;
 
 	/**
 	 * \brief CWeb pointer setter
@@ -257,19 +257,19 @@ class CNode {
 	 * \brief tOrg getter
 	 * \return the tOrg
 	 */
-	double getTOrg();
+	double getTOrg() const;
 
 	/**
 	 * \brief dSum getter
 	 * \return the dSum
 	 */
-	double getSum();
+	double getSum() const;
 
 	/**
 	 * \brief nCount getter
 	 * \return the nCount
 	 */
-	int getCount();
+	int getCount() const;
 
 	// NOTE: Make private....
 	/**
@@ -352,7 +352,7 @@ class CNode {
 	/**
 	 * \brief A mutex to control threading access to vSite.
 	 */
-	std::mutex vSiteMutex;
+	mutable std::mutex vSiteMutex;
 
 	/**
 	 * \brief A recursive_mutex to control threading access to CNode.
@@ -361,7 +361,7 @@ class CNode {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex nodeMutex;
+	mutable std::recursive_mutex nodeMutex;
 };
 }  // namespace glasscore
 #endif  // NODE_H

--- a/glasscore/glasslib/include/Node.h
+++ b/glasscore/glasslib/include/Node.h
@@ -164,14 +164,122 @@ class CNode {
 	 */
 	std::shared_ptr<CSite> getSite(std::string sScnl);
 
+	/**
+	 * \brief CNode get last site function
+	 *
+	 * Get the last site linked to the node
+	 *
+	 * \return Returns a shared pointer to the last CSite object if found, null
+	 * otherwise
+	 */
 	std::shared_ptr<CSite> getLastSite();
 
+	/**
+	 * \brief CNode site link sort function
+	 *
+	 * Sort the list of sites linked to this node
+	 */
 	void sortSiteLinks();
 
+	/**
+	 * \brief Sites string getter
+	 * \return the sites string
+	 */
 	std::string getSitesString();
 
+	/**
+	 * \brief Site links count getter
+	 * \return the site links count
+	 */
 	int getSiteLinksCount();
 
+	/**
+	 * \brief Enabled flag getter
+	 * \return the enabled flag
+	 */
+	bool getEnabled();
+
+	/**
+	 * \brief Enabled flag setter
+	 * \param enable - the enabled flag
+	 */
+	void setEnabled(bool enabled);
+
+	/**
+	 * \brief Latitude getter
+	 * \return the latitude
+	 */
+	double getLat() const;
+
+	/**
+	 * \brief Longitude getter
+	 * \return the longitude
+	 */
+	double getLon() const;
+
+	/**
+	 * \brief Depth getter
+	 * \return the Depth
+	 */
+	double getZ() const;
+
+	/**
+	 * \brief Resolution getter
+	 * \return the Resolution
+	 */
+	double getResolution() const;
+
+	/**
+	 * \brief CWeb pointer getter
+	 * \return the CWeb pointer
+	 */
+	CWeb* getWeb();
+
+	/**
+	 * \brief CWeb pointer setter
+	 * \param web - the CWeb pointer
+	 */
+	void setWeb(CWeb* web);
+
+	/**
+	 * \brief Name getter
+	 * \return the name
+	 */
+	const std::string& getName() const;
+
+	/**
+	 * \brief Pid getter
+	 * \return the pid
+	 */
+	const std::string& getPid() const;
+
+	/**
+	 * \brief tOrg getter
+	 * \return the tOrg
+	 */
+	double getTOrg();
+
+	/**
+	 * \brief dSum getter
+	 * \return the dSum
+	 */
+	double getSum();
+
+	/**
+	 * \brief nCount getter
+	 * \return the nCount
+	 */
+	int getCount();
+
+	// NOTE: Make private....
+	/**
+	 * \brief A std::vector of std::shared_ptr's to CPick objects
+	 * used in calculating the likelihood of a hypocenter
+	 * centered on this node during the last call to nucleate()
+	 */
+	std::vector<std::shared_ptr<CPick>> vPick;
+
+ private:
 	/**
 	 * \brief A pointer to the parent CWeb class, used get configuration,
 	 * values, perform significance calculations, and debug flags
@@ -212,13 +320,6 @@ class CNode {
 	double dResolution;
 
 	/**
-	 * \brief A std::vector of std::shared_ptr's to CPick objects
-	 * used in calculating the likelihood of a hypocenter
-	 * centered on this node during the last call to nucleate()
-	 */
-	std::vector<std::shared_ptr<CPick>> vPick;
-
-	/**
 	 * \brief A double value that accumulates the Bayesian
 	 * sum when evaluating the agoric at each node in a web.
 	 * It is compared to the threshold value set for the
@@ -242,7 +343,6 @@ class CNode {
 
 	bool bEnabled;
 
- private:
 	/**
 	 * \brief A std::vector of tuples linking node to site
 	 * {shared site pointer, travel time 1, travel time 2}
@@ -253,6 +353,15 @@ class CNode {
 	 * \brief A mutex to control threading access to vSite.
 	 */
 	std::mutex vSiteMutex;
+
+	/**
+	 * \brief A recursive_mutex to control threading access to CNode.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	std::recursive_mutex nodeMutex;
 };
 }  // namespace glasscore
 #endif  // NODE_H

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -122,8 +122,6 @@ class CPick {
 	void addHypo(std::shared_ptr<CHypo> hyp, std::string ass = "", bool force =
 							false);
 
-	void setAss(std::string ass);
-
 	/**
 	 * \brief Remove hypo reference to this pick
 	 *
@@ -192,6 +190,12 @@ class CPick {
 	 * \return the association string
 	 */
 	const std::string& getAss();
+
+	/**
+	 * \brief Association string setter
+	 * \param ass - the association string
+	 */
+	void setAss(std::string ass);
 
 	/**
 	 * \brief Phase getter

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -151,7 +151,67 @@ class CPick {
 	 */
 	bool nucleate();
 
-	// Local Attributes
+	/**
+	 * \brief Back azimuth getter
+	 * \return the back azimuth
+	 */
+	double getBackAzimuth() const;
+
+	/**
+	 * \brief Slowness getter
+	 * \return the slowness
+	 */
+	double getSlowness() const;
+
+	/**
+	 * \brief Pick id getter
+	 * \return the pick id
+	 */
+	int getIdPick() const;
+
+	/**
+	 * \brief Json pick getter
+	 * \return the json pick
+	 */
+	const std::shared_ptr<json::Object>& getJPick() const;
+
+	/**
+	 * \brief Hypo getter
+	 * \return the hypo
+	 */
+	const std::shared_ptr<CHypo>& getHypo();
+
+	/**
+	 * \brief Site getter
+	 * \return the site
+	 */
+	const std::shared_ptr<CSite>& getSite() const;
+
+	/**
+	 * \brief Association string getter
+	 * \return the association string
+	 */
+	const std::string& getAss();
+
+	/**
+	 * \brief Phase getter
+	 * \return the phase
+	 */
+	const std::string& getPhs() const;
+
+	/**
+	 * \brief Pid getter
+	 * \return the pid
+	 */
+	const std::string& getPid() const;
+
+	/**
+	 * \brief Pick time getter
+	 * \return the pick time
+	 */
+	double getTPick() const;
+
+ private:
 	/**
 	 * \brief A std::shared_ptr to a CSite object
 	 * representing the link between this pick and the site it was
@@ -208,6 +268,13 @@ class CPick {
 	 */
 	std::shared_ptr<json::Object> jPick;
 
+	/**
+	 * \brief A recursive_mutex to control threading access to CPick.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
 	std::recursive_mutex pickMutex;
 };
 }  // namespace glasscore

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -224,7 +224,7 @@ class CPick {
 	std::shared_ptr<CSite> pSite;
 
 	/**
-	 * \brief A std::vector of std::shared_ptr's to CHypo objects
+	 * \brief A std::weak_ptr to a CHypo object
 	 * representing the links between this pick and associated hypocenter
 	 */
 	std::weak_ptr<CHypo> wpHypo;

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -136,6 +136,9 @@ class CPick {
 	 */
 	void remHypo(std::shared_ptr<CHypo> hyp);
 
+	/**
+	 * \brief Clear any hypo reference to this pick
+	 */
 	void clearHypo();
 
 	/**

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -177,7 +177,7 @@ class CPick {
 	 * \brief Hypo getter
 	 * \return the hypo
 	 */
-	const std::shared_ptr<CHypo>& getHypo();
+	const std::shared_ptr<CHypo>& getHypo() const;
 
 	/**
 	 * \brief Site getter
@@ -189,7 +189,7 @@ class CPick {
 	 * \brief Association string getter
 	 * \return the association string
 	 */
-	const std::string& getAss();
+	const std::string& getAss() const;
 
 	/**
 	 * \brief Association string setter
@@ -279,7 +279,7 @@ class CPick {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex pickMutex;
+	mutable std::recursive_mutex pickMutex;
 };
 }  // namespace glasscore
 #endif  // PICK_H

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -76,7 +76,7 @@ class CPick {
 	 * \param pickId - An integer containing the pick id to use.
 	 * \param pSiteList - A pointer to the CSiteList class
 	 */
-	CPick(json::Object *pick, int pickId, CSiteList *pSiteList);
+	CPick(std::shared_ptr<json::Object> pick, int pickId, CSiteList *pSiteList);
 
 	/**
 	 * \brief CPick destructor

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -228,7 +228,9 @@ class CPick {
 
 	/**
 	 * \brief A std::weak_ptr to a CHypo object
-	 * representing the links between this pick and associated hypocenter
+	 * representing the links between this pick and associated hypocenter.
+	 * A weak_ptr is used here instead of a shared_ptr to prevent a cyclical
+	 * reference between CPick and CHypo.
 	 */
 	std::weak_ptr<CHypo> wpHypo;
 

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -177,7 +177,7 @@ class CPick {
 	 * \brief Hypo getter
 	 * \return the hypo
 	 */
-	const std::shared_ptr<CHypo>& getHypo() const;
+	const std::shared_ptr<CHypo> getHypo() const;
 
 	/**
 	 * \brief Site getter
@@ -227,7 +227,7 @@ class CPick {
 	 * \brief A std::vector of std::shared_ptr's to CHypo objects
 	 * representing the links between this pick and associated hypocenter
 	 */
-	std::shared_ptr<CHypo> pHypo;
+	std::weak_ptr<CHypo> wpHypo;
 
 	/**
 	 * \brief A std::string containing a character representing the action

--- a/glasscore/glasslib/include/PickList.h
+++ b/glasscore/glasslib/include/PickList.h
@@ -91,7 +91,7 @@ class CPickList {
 	 * \return Returns true if the communication was handled by CPickList,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CPickList add pick function
@@ -114,7 +114,7 @@ class CPickList {
 	 * \return Returns true if the pick was usable and added by CPickList,
 	 * false otherwise
 	 */
-	bool addPick(json::Object *pick);
+	bool addPick(std::shared_ptr<json::Object> pick);
 
 	/**
 	 * \brief CPickList get pick function

--- a/glasscore/glasslib/include/PickList.h
+++ b/glasscore/glasslib/include/PickList.h
@@ -193,6 +193,67 @@ class CPickList {
 												double tDuration = 2400.0);
 
 	/**
+	 * \brief check to see if each thread is still functional
+	 *
+	 * Checks each thread to see if it is still responsive.
+	 */
+	bool statusCheck();
+
+	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass() const;
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief CSiteList getter
+	 * \return the CSiteList pointer
+	 */
+	const CSiteList* getSiteList() const;
+
+	/**
+	 * \brief CSiteList setter
+	 * \param siteList - the CSiteList pointer
+	 */
+	void setSiteList(CSiteList* siteList);
+
+	/**
+	 * \brief nPick getter
+	 * \return the nPick
+	 */
+	int getNPick() const;
+
+	/**
+	 * \brief nPickMax getter
+	 * \return the nPickMax
+	 */
+	int getNPickMax() const;
+
+	/**
+	 * \brief nPickMax Setter
+	 * \param correlationMax - the nPickMax
+	 */
+	void setNPickMax(int picknMax);
+
+	/**
+	 * \brief nPickTotal getter
+	 * \return the nPickTotal
+	 */
+	int getNPickTotal() const;
+
+	/**
+	 * \brief Get the current size of the pick list
+	 */
+	int getVPickSize() const;
+
+ private:
+	/**
 	 * \brief Process the next pick on the queue
 	 *
 	 * Attempts to associate and nuclate the next pick on the queue.
@@ -205,13 +266,6 @@ class CPickList {
 	 * The function that performs the sleep between jobs
 	 */
 	void jobSleep();
-
-	/**
-	 * \brief check to see if each thread is still functional
-	 *
-	 * Checks each thread to see if it is still responsive.
-	 */
-	bool statusCheck();
 
 	/**
 	 * \brief thread status update function
@@ -329,7 +383,16 @@ class CPickList {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex m_vPickMutex;
+	mutable std::recursive_mutex m_vPickMutex;
+
+	/**
+	 * \brief A recursive_mutex to control threading access to CPickList.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	mutable std::recursive_mutex m_PickListMutex;
 };
 }  // namespace glasscore
 #endif  // PICKLIST_H

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -217,13 +217,13 @@ class CSite {
 	 * \brief Node link count getter
 	 * \return the node link count
 	 */
-	int getNodeLinksCount();
+	int getNodeLinksCount() const;
 
 	/**
 	 * \brief Use flag getter
 	 * \return the use flag
 	 */
-	bool getUse();
+	bool getUse() const;
 
 	/**
 	 * \brief Use flag setter
@@ -235,7 +235,7 @@ class CSite {
 	 * \brief Use for teleseismic flag getter
 	 * \return the use for teleseismic flag
 	 */
-	bool getUseForTele();
+	bool getUseForTele() const;
 
 	/**
 	 * \brief Use for teleseismic flag setter
@@ -247,7 +247,7 @@ class CSite {
 	 * \brief Quality getter
 	 * \return the quality
 	 */
-	double getQual();
+	double getQual() const;
 
 	/**
 	 * \brief Quality setter
@@ -398,7 +398,7 @@ class CSite {
 	/**
 	 * \brief A mutex to control threading access to vNode.
 	 */
-	std::mutex vNodeMutex;
+	mutable std::mutex vNodeMutex;
 
 	/**
 	 * \brief A std::vector of tuples linking site to node
@@ -413,7 +413,7 @@ class CSite {
 	 * However a recursive_mutex allows us to maintain the original class
 	 * design as delivered by the contractor.
 	 */
-	std::recursive_mutex siteMutex;
+	mutable std::recursive_mutex siteMutex;
 };
 }  // namespace glasscore
 #endif  // SITE_H

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -23,6 +23,7 @@ namespace glasscore {
 class CPick;
 class CNode;
 class CGlass;
+class CTrigger;
 
 /**
  * \brief glasscore site (station) class
@@ -207,13 +208,14 @@ class CSite {
 	 * \param tpick - A double value containing the pick time to nucleate with
 	 * in julian seconds
 	 */
-	void nucleate(double tpick);
+	std::vector<std::shared_ptr<CTrigger>> nucleate(double tpick);
 
 	/**
 	 * \brief Add triggering node to triggered node list if value exceeds
 	 * current value of if named node's web is not yet present.
 	 */
-	void addTrigger(std::shared_ptr<CNode> node);
+	void addTrigger(std::vector<std::shared_ptr<CTrigger>> *vTrigger,
+					std::shared_ptr<CTrigger> trigger);
 
 	/**
 	 * \brief Node link count getter
@@ -311,12 +313,6 @@ class CSite {
 	 */
 	const std::vector<std::shared_ptr<CPick>> getVPick() const;
 
-	/**
-	 * \brief vTrigger getter
-	 * \return the vTrigger
-	 */
-	const std::vector<std::shared_ptr<CNode>> getVTrigger() const;
-
  private:
 	/**
 	 * \brief A mutex to control threading access to vPick.
@@ -324,23 +320,10 @@ class CSite {
 	mutable std::mutex vPickMutex;
 
 	/**
-	 * \brief A std::vector of std::shared_ptr's to the picks mad at this this
+	 * \brief A std::vector of std::shared_ptr's to the picks made at this this
 	 * CSite
 	 */
 	std::vector<std::weak_ptr<CPick>> vPick;
-
-	/*
-	 * /brief A std::vector of shared node pointers that contain a list
-	 * of nodes that triggered for an input pick. It supports the concept
-	 * that each node can generate trigger event independently from other
-	 * webs. It is set by the method 'addTrigger'.
-	 */
-	std::vector<std::shared_ptr<CNode>> vTrigger;
-
-	/**
-	 * \brief A mutex to control threading access to vTrigger.
-	 */
-	mutable std::mutex vTriggerMutex;
 
 	/**
 	 * \brief A pointer to the main CGlass class used encode/decode time and

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -320,8 +320,9 @@ class CSite {
 	mutable std::mutex vPickMutex;
 
 	/**
-	 * \brief A std::vector of std::shared_ptr's to the picks made at this this
-	 * CSite
+	 * \brief A std::vector of std::weak_ptr's to the picks made at this this
+	 * CSite. A weak_ptr is used here instead of a shared_ptr to prevent a
+	 * cyclical reference between CPick and CSite.
 	 */
 	std::vector<std::weak_ptr<CPick>> vPick;
 

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -81,7 +81,7 @@ class CSite {
 	 * \param com - A pointer to a json::Object to construct the site from
 	 * \param glassPtr - A pointer to the CGlass class
 	 */
-	CSite(json::Object *com, CGlass *glassPtr);
+	CSite(std::shared_ptr<json::Object> site, CGlass *glassPtr);
 
 	/**
 	 * \brief CSite destructor

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -327,7 +327,7 @@ class CSite {
 	 * \brief A std::vector of std::shared_ptr's to the picks mad at this this
 	 * CSite
 	 */
-	std::vector<std::shared_ptr<CPick>> vPick;
+	std::vector<std::weak_ptr<CPick>> vPick;
 
 	/*
 	 * /brief A std::vector of shared node pointers that contain a list

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -213,7 +213,102 @@ class CSite {
 	 */
 	void addTrigger(std::shared_ptr<CNode> node);
 
+	/**
+	 * \brief Node link count getter
+	 * \return the node link count
+	 */
 	int getNodeLinksCount();
+
+	/**
+	 * \brief Use flag getter
+	 * \return the use flag
+	 */
+	bool getUse();
+
+	/**
+	 * \brief Use flag setter
+	 * \param use - the use flag
+	 */
+	void setUse(bool use);
+
+	/**
+	 * \brief Use for teleseismic flag getter
+	 * \return the use for teleseismic flag
+	 */
+	bool getUseForTele();
+
+	/**
+	 * \brief Use for teleseismic flag setter
+	 * \param useForTele - the use for teleseismic flag
+	 */
+	void setUseForTele(bool useForTele);
+
+	/**
+	 * \brief Quality getter
+	 * \return the quality
+	 */
+	double getQual();
+
+	/**
+	 * \brief Quality setter
+	 * \param qual - the quality
+	 */
+	void setQual(double qual);
+
+	/**
+	 * \brief CGeo getter
+	 * \return the CGeo
+	 */
+	glassutil::CGeo& getGeo();
+
+	/**
+	 * \brief Max picks for site getter
+	 * \return the max picks for site
+	 */
+	int getSitePickMax() const;
+
+	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	CGlass* getGlass() const;
+
+	/**
+	 * \brief SCNL getter
+	 * \return the SCNL
+	 */
+	const std::string& getScnl() const;
+
+	/**
+	 * \brief Site getter
+	 * \return the site
+	 */
+	const std::string& getSite() const;
+
+	/**
+	 * \brief Comp getter
+	 * \return the comp
+	 */
+	const std::string& getComp() const;
+
+	/**
+	 * \brief Net getter
+	 * \return the net
+	 */
+	const std::string& getNet() const;
+
+	/**
+	 * \brief Loc getter
+	 * \return the loc
+	 */
+	const std::string& getLoc() const;
+
+	// NOTE: Make these private in the future!!!!!!!
+
+	/**
+	 * \brief A mutex to control threading access to vPick.
+	 */
+	std::mutex vPickMutex;
 
 	/**
 	 * \brief A std::vector of std::shared_ptr's to the picks mad at this this
@@ -221,25 +316,20 @@ class CSite {
 	 */
 	std::vector<std::shared_ptr<CPick>> vPick;
 
-	/**
-	 * \brief A std::shared_ptr to the node with the best PDF the last time
-	 * nucleate() was called that exceeded web specific thresholds.
+	/*
+	 * /brief A std::vector of shared node pointers that contain a list
+	 * of nodes that triggered for an input pick. It supports the concept
+	 * that each node can generate trigger event independently from other
+	 * webs. It is set by the method 'addTrigger'.
 	 */
-	std::shared_ptr<CNode> pNode;
+	std::vector<std::shared_ptr<CNode>> vTrigger;
 
 	/**
-	 * \brief A std::shared_ptr to the node with the best PDF the last time
-	 * nucleate() was called with the largest value for the current pick.
+	 * \brief A mutex to control threading access to vTrigger.
 	 */
-	std::shared_ptr<CNode> qNode;
+	std::mutex vTriggerMutex;
 
-	/**
-	 * \brief A double value containing the P travel time
-	 * between the node with the best PDF the last time
-	 * nucleate() was called and the site in seconds
-	 */
-	double dTrav;
-
+ private:
 	/**
 	 * \brief A pointer to the main CGlass class used encode/decode time and
 	 * get debugging flags
@@ -305,25 +395,11 @@ class CSite {
 	 */
 	int nSitePickMax;
 
-	/*
-	 * /brief A std::vector of shared node pointers that contain a list
-	 * of nodes that triggered for an input pick. It supports the concept
-	 * that each node can generate trigger event independently from other
-	 * webs. It is set by the method 'addTrigger'.
-	 */
-	std::vector<std::shared_ptr<CNode>> vTrigger;
-
 	/**
-	 * \brief A mutex to control threading access to vPick.
+	 * \brief A mutex to control threading access to vNode.
 	 */
-	std::mutex vPickMutex;
+	std::mutex vNodeMutex;
 
-	/**
-	 * \brief A mutex to control threading access to vTrigger.
-	 */
-	std::mutex vTriggerMutex;
-
- private:
 	/**
 	 * \brief A std::vector of tuples linking site to node
 	 * {shared node pointer, travel-time 1, travel-time 2}
@@ -331,9 +407,13 @@ class CSite {
 	std::vector<NodeLink> vNode;
 
 	/**
-	 * \brief A mutex to control threading access to vNode.
+	 * \brief A recursive_mutex to control threading access to CSite.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
 	 */
-	std::mutex vNodeMutex;
+	std::recursive_mutex siteMutex;
 };
 }  // namespace glasscore
 #endif  // SITE_H

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -92,6 +92,8 @@ class CSite {
 	 */
 	void clear();
 
+	void clearVPick();
+
 	/**
 	 * \brief CSite update function
 	 *
@@ -303,12 +305,23 @@ class CSite {
 	 */
 	const std::string& getLoc() const;
 
-	// NOTE: Make these private in the future!!!!!!!
+	/**
+	 * \brief vPick getter
+	 * \return the vPick
+	 */
+	const std::vector<std::shared_ptr<CPick>> getVPick() const;
 
+	/**
+	 * \brief vTrigger getter
+	 * \return the vTrigger
+	 */
+	const std::vector<std::shared_ptr<CNode>> getVTrigger() const;
+
+ private:
 	/**
 	 * \brief A mutex to control threading access to vPick.
 	 */
-	std::mutex vPickMutex;
+	mutable std::mutex vPickMutex;
 
 	/**
 	 * \brief A std::vector of std::shared_ptr's to the picks mad at this this
@@ -327,9 +340,8 @@ class CSite {
 	/**
 	 * \brief A mutex to control threading access to vTrigger.
 	 */
-	std::mutex vTriggerMutex;
+	mutable std::mutex vTriggerMutex;
 
- private:
 	/**
 	 * \brief A pointer to the main CGlass class used encode/decode time and
 	 * get debugging flags

--- a/glasscore/glasslib/include/SiteList.h
+++ b/glasscore/glasslib/include/SiteList.h
@@ -78,7 +78,7 @@ class CSiteList {
 	 * \return Returns true if the communication was handled by CSiteList,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CSiteList add/update  site function
@@ -91,7 +91,7 @@ class CSiteList {
 	 * \return Returns true if the site was complete and added by CSiteList,
 	 * false otherwise
 	 */
-	bool addSite(json::Object *com);
+	bool addSite(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CSiteList add list of sites function
@@ -103,7 +103,7 @@ class CSiteList {
 	 * \return Returns true if the site was complete and added by CSiteList,
 	 * false otherwise
 	 */
-	bool addSiteList(json::Object *com);
+	bool addSiteList(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CSiteList  add/update  site function

--- a/glasscore/glasslib/include/SiteList.h
+++ b/glasscore/glasslib/include/SiteList.h
@@ -199,6 +199,24 @@ class CSiteList {
 	bool reqSiteList();
 
 	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass() const;
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief Get the current size of the site list
+	 */
+	int getVSiteSize() const;
+
+ private:
+	/**
 	 * \brief A pointer to the main CGlass class, used to pass this information
 	 * to sites added to CSiteList
 	 */
@@ -207,7 +225,7 @@ class CSiteList {
 	/**
 	 * \brief A mutex to control threading access to vSite.
 	 */
-	std::mutex vSiteMutex;
+	mutable std::mutex vSiteMutex;
 
 	/**
 	 * \brief A std::vector of all the sites in CSiteList.
@@ -219,6 +237,15 @@ class CSiteList {
 	 * in CSiteList indexed by the std::string scnl id.
 	 */
 	std::map<std::string, std::shared_ptr<CSite>> mSite;
+
+	/**
+	 * \brief A recursive_mutex to control threading access to CSiteList.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	mutable std::recursive_mutex m_SiteListMutex;
 };
 }  // namespace glasscore
 #endif  // SITELIST_H

--- a/glasscore/glasslib/include/Trigger.h
+++ b/glasscore/glasslib/include/Trigger.h
@@ -100,13 +100,53 @@ class CTrigger {
 	 * \brief CTrigger clear function
 	 */
 	void clear();
+
+	/**
+	 * \brief Latitude getter
+	 * \return the latitude
+	 */
 	double getLat() const;
+
+	/**
+	 * \brief Longitude getter
+	 * \return the longitude
+	 */
 	double getLon() const;
+
+	/**
+	 * \brief Depth getter
+	 * \return the depth
+	 */
 	double getZ() const;
+
+	/**
+	 * \brief Origin time getter
+	 * \return the origin time
+	 */
 	double getTOrg() const;
+
+	/**
+	 * \brief Resolution getter
+	 * \return the resolution
+	 */
 	double getResolution() const;
+
+	/**
+	 * \brief Sum getter
+	 * \return the sum
+	 */
 	double getSum() const;
+
+	/**
+	 * \brief Count getter
+	 * \return the count
+	 */
 	int getCount() const;
+
+	/**
+	 * \brief Web pointer getter
+	 * \return the CWeb pointer
+	 */
 	const CWeb* getWeb() const;
 
 	/**

--- a/glasscore/glasslib/include/Trigger.h
+++ b/glasscore/glasslib/include/Trigger.h
@@ -1,0 +1,174 @@
+/*****************************************
+ * This file is documented for Doxygen.
+ * If you modify this file please update
+ * the comments so that Doxygen will still
+ * be able to work.
+ ****************************************/
+#ifndef TRIGGER_H
+#define TRIGGER_H
+
+#include <vector>
+#include <memory>
+#include <string>
+#include <utility>
+#include <mutex>
+#include <tuple>
+#include "Geo.h"
+#include "Link.h"
+
+namespace glasscore {
+
+// forward declarations
+class CPick;
+class CWeb;
+
+/**
+ * \brief glasscore detection trigger class
+ *
+ * The CTrigger class represents a single detection trigger from the
+ * detection graph database.  A CTrigger consists of the location (latitude,
+ * longitude, and depth) of the triggering node, the spatial resolution of the
+ * triggering node, and a list of picks that made the trigger
+ *
+ * CTrigger uses smart pointers (std::shared_ptr).
+ */
+class CTrigger {
+ public:
+	/**
+	 * \brief CTrigger constructor
+	 */
+	CTrigger();
+
+	/**
+	 * \brief CTrigger advanced constructor
+	 *
+	 * Construct a trigger using the provided data
+	 *
+	 * \param lat - A double value containing the latitude to use
+	 * for this trigger in degrees
+	 * \param lon - A double value containing the longitude to use
+	 * for this trigger in degrees
+	 * \param z - A double value containing the depth to use
+	 * for this trigger in kilometers
+	 * \param ot - A double value containing the time to use
+	 * for this trigger in seconds
+	 * \param resolution - A double value containing the inter-node resolution
+	 * in kilometer
+	 * \param sum - A double value containing the bayesian sum for this trigger
+	 * \param count - An integer value containing the site count for this
+	 * trigger
+	 * \param picks - A std::vector<std::shared_ptr<CPick> containing the picks
+	 * for this trigger
+	 * \param web - A pointer to the creating node's CWeb
+	 */
+	CTrigger(double lat, double lon, double z, double ot, double resolution,
+				double sum, int count,
+				std::vector<std::shared_ptr<CPick>> picks, CWeb *web);
+
+	/**
+	 * \brief CTrigger destructor
+	 */
+	~CTrigger();
+
+	/**
+	 * \brief CTrigger initialization function
+	 *
+	 * Initialize a trigger using the provided data
+	 *
+	 * \param lat - A double value containing the latitude to use
+	 * for this trigger in degrees
+	 * \param lon - A double value containing the longitude to use
+	 * for this trigger in degrees
+	 * \param z - A double value containing the depth to use
+	 * for this trigger in kilometers
+	 * \param ot - A double value containing the time to use
+	 * for this trigger in seconds
+	 * \param resolution - A double value containing the inter-node resolution
+	 * in kilometer
+	 * \param sum - A double value containing the bayesian sum for this trigger
+	 * \param count - An integer value containing the site count for this
+	 * trigger
+	 * \param picks - A std::vector<std::shared_ptr<CPick> containing the picks
+	 * for this trigger
+	 * \param web - A pointer to the creating node's web
+	 */
+	bool initialize(double lat, double lon, double z, double ot,
+					double resolution, double sum, int count,
+					std::vector<std::shared_ptr<CPick>> picks, CWeb *web);
+
+	/**
+	 * \brief CTrigger clear function
+	 */
+	void clear();
+	double getLat() const;
+	double getLon() const;
+	double getZ() const;
+	double getTOrg() const;
+	double getResolution() const;
+	double getSum() const;
+	int getCount() const;
+	const CWeb* getWeb() const;
+
+	/**
+	 * \brief vPick getter
+	 * \return the vPick
+	 */
+	const std::vector<std::shared_ptr<CPick>> getVPick() const;
+
+ private:
+	/**
+	 * \brief A double value containing latitude of this triggerin degrees.
+	 */
+	double dLat;
+
+	/**
+	 * \brief A double value containing longitude of this triggerin degrees.
+	 */
+	double dLon;
+
+	/**
+	 * \brief A double value containing the depth of this trigger in kilometers.
+	 */
+	double dZ;
+
+	/**
+	 * \brief A double value with the origin time of this trigger in seconds
+	 */
+	double tOrg;
+
+	/**
+	 * \brief A double value containing the spatial resolution
+	 * (between nodes) in kilometers.
+	 */
+	double dResolution;
+
+	/**
+	 * \brief A double value that accumulates the Bayesian
+	 * sum of this trigger
+	 */
+	double dSum;
+
+	/**
+	 * \brief A integer value that tallies the number of sites
+	 * that are included in this trigger
+	 */
+	int nCount;
+
+	/**
+	 * \brief A std::vector of std::shared_ptr's to CPick objects
+	 * used in creating this trigger
+	 */
+	std::vector<std::shared_ptr<CPick>> vPick;
+
+	/**
+	 * \brief A pointer to the node CWeb class, used get travel times
+	 */
+	CWeb *pWeb;
+
+	/**
+	 * \brief A recursive mutex to control threading access to this trigger.
+	 */
+	mutable std::recursive_mutex triggerMutex;
+};
+}  // namespace glasscore
+#endif  // TRIGGER_H

--- a/glasscore/glasslib/include/Web.h
+++ b/glasscore/glasslib/include/Web.h
@@ -124,7 +124,7 @@ class CWeb {
 	 * \return Returns true if the communication was handled by CWeb,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief CWeb initialization function
@@ -168,7 +168,7 @@ class CWeb {
 	 * configuration
 	 * \return Returns true if successful, false if a grid was not created.
 	 */
-	bool grid(json::Object *com);
+	bool grid(std::shared_ptr<json::Object>  com);
 
 	/**
 	 * \brief Generate a detection grid with explicit nodes
@@ -179,7 +179,7 @@ class CWeb {
 	 * configuration
 	 * \return Returns true if successful, false if a grid was not created.
 	 */
-	bool grid_explicit(json::Object *com);
+	bool grid_explicit(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Generate a global detection grid
@@ -191,7 +191,7 @@ class CWeb {
 	 * configuration
 	 * \return Always returns true
 	 */
-	bool global(json::Object *com);
+	bool global(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Load the travel times for this web
@@ -212,7 +212,7 @@ class CWeb {
 	 * \param com - A pointer to a json::object containing the web configuration
 	 * \return Returns true if successful, false otherwise.
 	 */
-	bool genSiteFilters(json::Object *com);
+	bool genSiteFilters(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Generate node site list

--- a/glasscore/glasslib/include/Web.h
+++ b/glasscore/glasslib/include/Web.h
@@ -43,7 +43,7 @@ class CWeb {
 	 * The constructor for the CWeb class.
 	 * \param createBackgroundThread - A boolean flag indicating whether
 	 * to create a background thread for web updates. If set to false, glass will
-   * halt until the web update is completed. Default true.
+	 * halt until the web update is completed. Default true.
 	 * \param sleepTime - An integer containing the amount of
 	 * time to sleep in milliseconds between jobs.  Default 10
 	 * \param checkInterval - An integer containing the amount of time in
@@ -78,9 +78,9 @@ class CWeb {
 	 * use for travel time lookups.
 	 * \param secondTrav - A shared pointer to the second CTravelTime object to
 	 * use for travel time lookups.
-   * \param createBackgroundThread - A boolean flag indicating whether
-   * to create a background thread for web updates. If set to false, glass will
-   * halt until the web update is completed. Default true.
+	 * \param createBackgroundThread - A boolean flag indicating whether
+	 * to create a background thread for web updates. If set to false, glass will
+	 * halt until the web update is completed. Default true.
 	 * \param sleepTime - An integer containing the amount of
 	 * time to sleep in milliseconds between jobs.  Default 10
 	 * \param checkInterval - An integer containing the amount of time in
@@ -328,6 +328,55 @@ class CWeb {
 	bool statusCheck();
 
 	/**
+	 * \brief add a job
+	 *
+	 * Adds a job to the queue of jobs to be run by the background
+	 * thread
+	 * \param newjob - A std::function<void()> bound to the function
+	 * containing the job to run
+	 */
+	void addJob(std::function<void()> newjob);
+
+	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	CGlass* getGlass() const;
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief CSiteList getter
+	 * \return the CSiteList pointer
+	 */
+	const CSiteList* getSiteList() const;
+
+	/**
+	 * \brief CSiteList setter
+	 * \param siteList - the CSiteList pointer
+	 */
+	void setSiteList(CSiteList* siteList);
+	bool getUpdate() const;
+	double getResolution() const;
+	double getThresh() const;
+	int getCol() const;
+	int getDetect() const;
+	int getNucleate() const;
+	int getRow() const;
+	int getZ() const;
+	const std::string& getName() const;
+	const std::shared_ptr<traveltime::CTravelTime>& getTrv1() const;
+	const std::shared_ptr<traveltime::CTravelTime>& getTrv2() const;
+	int getVNetFilterSize() const;
+	int getVSitesFilterSize() const;
+	int getVNodeSize() const;
+
+ private:
+	/**
 	 * \brief the job sleep
 	 *
 	 * The function that performs the sleep between jobs
@@ -342,7 +391,6 @@ class CWeb {
 	 */
 	void setStatus(bool status);
 
-	// Local Attributes
 	/**
 	 * \brief A pointer to the main CGlass class, used to send output,
 	 * get default values, encode/decode time, and get debug flags
@@ -382,6 +430,11 @@ class CWeb {
 	 * node in the detection graph database
 	 */
 	std::vector<std::shared_ptr<CNode>> vNode;
+
+	/**
+	 * \brief the std::mutex for m_QueueMutex
+	 */
+	mutable std::mutex m_vNodeMutex;
 
 	/**
 	 * \brief String name of web used in tuning
@@ -454,7 +507,7 @@ class CWeb {
 	/**
 	 * \brief the std::mutex for traveltimes
 	 */
-	std::mutex m_TrvMutex;
+	mutable std::mutex m_TrvMutex;
 
 	/**
 	 * \brief A mutex to control threading access to vSite.
@@ -517,14 +570,13 @@ class CWeb {
 	bool m_bUseBackgroundThread;
 
 	/**
-	 * \brief add a job
-	 *
-	 * Adds a job to the queue of jobs to be run by the background
-	 * thread
-	 * \param newjob - A std::function<void()> bound to the function
-	 * containing the job to run
+	 * \brief A recursive_mutex to control threading access to CWeb.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
 	 */
-	void addJob(std::function<void()> newjob);
+	mutable std::recursive_mutex m_WebMutex;
 };
 }  // namespace glasscore
 #endif  // WEB_H

--- a/glasscore/glasslib/include/WebList.h
+++ b/glasscore/glasslib/include/WebList.h
@@ -66,7 +66,7 @@ class CWebList {
 	 * \return Returns true if the communication was handled by CWeb,
 	 * false otherwise
 	 */
-	bool dispatch(json::Object *com);
+	bool dispatch(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Add subnet web ('Grid', etc) from detection fabric
@@ -80,7 +80,7 @@ class CWebList {
 	 *
 	 * \return Always returns true
 	 */
-	bool addWeb(json::Object *com);
+	bool addWeb(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Remove subnet compoent ('Grid', etc) from detection fabric
@@ -95,7 +95,7 @@ class CWebList {
 	 *
 	 * \return Always returns true
 	 */
-	bool removeWeb(json::Object *com);
+	bool removeWeb(std::shared_ptr<json::Object> com);
 
 	/**
 	 * \brief Add a site to the webs

--- a/glasscore/glasslib/include/WebList.h
+++ b/glasscore/glasslib/include/WebList.h
@@ -10,6 +10,7 @@
 #include <json.h>
 #include <vector>
 #include <memory>
+#include <mutex>
 
 namespace glasscore {
 
@@ -131,6 +132,36 @@ class CWebList {
 	bool statusCheck();
 
 	/**
+	 * \brief CGlass getter
+	 * \return the CGlass pointer
+	 */
+	const CGlass* getGlass() const;
+
+	/**
+	 * \brief CGlass setter
+	 * \param glass - the CGlass pointer
+	 */
+	void setGlass(CGlass* glass);
+
+	/**
+	 * \brief CSiteList getter
+	 * \return the CSiteList pointer
+	 */
+	const CSiteList* getSiteList() const;
+
+	/**
+	 * \brief CSiteList setter
+	 * \param siteList - the CSiteList pointer
+	 */
+	void setSiteList(CSiteList* siteList);
+
+	/**
+	 * \brief Get the current size of the web list
+	 */
+	int getVWebSize() const;
+
+ private:
+	/**
 	 * \brief A pointer to the main CGlass class, used to send output,
 	 * get sites (stations), encode/decode time, and get debug flags
 	 */
@@ -152,6 +183,15 @@ class CWebList {
 	 * a background thread.
 	 */
 	bool m_bUseBackgroundThreads;
+
+	/**
+	 * \brief A recursive_mutex to control threading access to CCorrelationList.
+	 * NOTE: recursive mutexes are frowned upon, so maybe redesign around it
+	 * see: http://www.codingstandard.com/rule/18-3-3-do-not-use-stdrecursive_mutex/
+	 * However a recursive_mutex allows us to maintain the original class
+	 * design as delivered by the contractor.
+	 */
+	mutable std::recursive_mutex m_WebListMutex;
 };
 }  // namespace glasscore
 #endif  // WEBLIST_H

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -448,7 +448,7 @@ const std::shared_ptr<CSite>& CCorrelation::getSite() const {
 	return (pSite);
 }
 
-const std::string& CCorrelation::getAss() {
+const std::string& CCorrelation::getAss() const {
 	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 	return (sAss);
 }

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -461,17 +461,9 @@ const std::shared_ptr<json::Object>& CCorrelation::getJCorrelation() const {
 	return (jCorrelation);
 }
 
-const std::shared_ptr<CHypo>& CCorrelation::getHypo() const {
+const std::shared_ptr<CHypo> CCorrelation::getHypo() const {
 	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
-	std::shared_ptr<CHypo> spHypo;
-
-	if (wpHypo.expired() == true) {
-		return (spHypo);
-	} else {
-		spHypo = wpHypo.lock();
-	}
-
-	return (spHypo);
+	return (wpHypo.lock());
 }
 
 const std::shared_ptr<CSite>& CCorrelation::getSite() const {

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -164,7 +164,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 	}
 
 	// check to see if we're using this site
-	if (!site->bUse) {
+	if (!site->getUse()) {
 		return;
 	}
 
@@ -359,7 +359,7 @@ bool CCorrelation::initialize(std::shared_ptr<CSite> correlationSite,
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CCorrelation::initialize: pSite:" + pSite->sScnl
+			"CCorrelation::initialize: pSite:" + pSite->getScnl()
 					+ "; tCorrelation:" + std::to_string(tCorrelation)
 					+ "; idCorrelation:" + std::to_string(idCorrelation)
 					+ "; sPid:" + sPid + "; sPhs:" + sPhs + "; tOrg:"

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -406,7 +406,7 @@ void CCorrelation::remHypo(std::shared_ptr<CHypo> hyp) {
 	std::lock_guard<std::mutex> guard(correlationMutex);
 
 	// Remove hypo reference from this corrleation
-	if (pHypo->sPid == hyp->sPid) {
+	if (pHypo->getPid() == hyp->getPid()) {
 		pHypo = NULL;
 	}
 }

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -294,7 +294,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 		return;
 	}
 
-	std::lock_guard<std::mutex> guard(correlationMutex);
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 
 	// remember input json for hypo message generation
 	// note move to init?
@@ -309,7 +309,7 @@ CCorrelation::~CCorrelation() {
 
 // ---------------------------------------------------------clear
 void CCorrelation::clear() {
-	std::lock_guard<std::mutex> guard(correlationMutex);
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 
 	pSite = NULL;
 	pHypo = NULL;
@@ -341,7 +341,7 @@ bool CCorrelation::initialize(std::shared_ptr<CSite> correlationSite,
 		return (false);
 	}
 
-	std::lock_guard<std::mutex> guard(correlationMutex);
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 
 	pSite = correlationSite;
 	sPhs = phase;
@@ -382,7 +382,7 @@ void CCorrelation::addHypo(std::shared_ptr<CHypo> hyp, std::string ass,
 		return;
 	}
 
-	std::lock_guard<std::mutex> guard(correlationMutex);
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 
 	// Add hypo data reference to this correlation
 	if (force == true) {
@@ -403,7 +403,7 @@ void CCorrelation::remHypo(std::shared_ptr<CHypo> hyp) {
 		return;
 	}
 
-	std::lock_guard<std::mutex> guard(correlationMutex);
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 
 	// Remove hypo reference from this corrleation
 	if (pHypo->getPid() == hyp->getPid()) {
@@ -412,14 +412,70 @@ void CCorrelation::remHypo(std::shared_ptr<CHypo> hyp) {
 }
 
 void CCorrelation::clearHypo() {
-	std::lock_guard<std::mutex> guard(correlationMutex);
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 	pHypo = NULL;
 }
 
-void CCorrelation::setAss(std::string ass) {
-	std::lock_guard<std::mutex> guard(correlationMutex);
+double CCorrelation::getCorrelation() const {
+	return (dCorrelation);
+}
 
+double CCorrelation::getLat() const {
+	return (dLat);
+}
+
+double CCorrelation::getLon() const {
+	return (dLon);
+}
+
+double CCorrelation::getZ() const {
+	return (dZ);
+}
+
+int CCorrelation::getIdCorrelation() const {
+	return (idCorrelation);
+}
+
+const std::shared_ptr<json::Object>& CCorrelation::getJCorrelation() const {
+	return (jCorrelation);
+}
+
+const std::shared_ptr<CHypo>& CCorrelation::getHypo() const {
+	return (pHypo);
+}
+
+const std::shared_ptr<CSite>& CCorrelation::getSite() const {
+	return (pSite);
+}
+
+const std::string& CCorrelation::getAss() {
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
+	return (sAss);
+}
+
+void CCorrelation::setAss(std::string ass) {
+	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
 	sAss = ass;
+}
+
+const std::string& CCorrelation::getPhs() const {
+	return (sPhs);
+}
+
+const std::string& CCorrelation::getPid() const {
+	return (sPid);
+}
+
+double CCorrelation::getTCorrelation() const {
+	return (tCorrelation);
+}
+
+double CCorrelation::getTGlassCreate() const {
+	return (tGlassCreate);
+}
+
+double CCorrelation::getTOrg() const {
+	return (tOrg);
 }
 
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -463,7 +463,15 @@ const std::shared_ptr<json::Object>& CCorrelation::getJCorrelation() const {
 
 const std::shared_ptr<CHypo>& CCorrelation::getHypo() const {
 	std::lock_guard<std::recursive_mutex> guard(correlationMutex);
-	return (wpHypo.lock());
+	std::shared_ptr<CHypo> spHypo;
+
+	if (wpHypo.expired() == true) {
+		return (spHypo);
+	} else {
+		spHypo = wpHypo.lock();
+	}
+
+	return (spHypo);
 }
 
 const std::shared_ptr<CSite>& CCorrelation::getSite() const {

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -41,8 +41,8 @@ CCorrelation::CCorrelation(std::shared_ptr<CSite> correlationSite,
 }
 
 // ---------------------------------------------------------CCorrelation
-CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
-							CSiteList *pSiteList) {
+CCorrelation::CCorrelation(std::shared_ptr<json::Object> correlation,
+							int correlationId, CSiteList *pSiteList) {
 	clear();
 
 	// null check json
@@ -115,10 +115,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					glassutil::log_level::error,
 					"CCorrelation::CCorrelation: Missing required Station Key.");
 
-			// cleanup
-			delete (correlation);
-		correlation = NULL;
-
 			return;
 		}
 
@@ -139,10 +135,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					glassutil::log_level::error,
 					"CCorrelation::CCorrelation: Missing required Network Key.");
 
-			// cleanup
-			delete (correlation);
-		correlation = NULL;
-
 			return;
 		}
 
@@ -158,9 +150,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CCorrelation::CCorrelation: Missing required Site Key.");
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
 
 		return;
 	}
@@ -174,19 +163,12 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 	if (site == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::warn,
 								"CCorrelation::CCorrelation: site is null.");
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
 
 		return;
 	}
 
 	// check to see if we're using this site
 	if (!site->getUse()) {
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
-
 		return;
 	}
 
@@ -202,10 +184,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 				glassutil::log_level::error,
 				"CCorrelation::CCorrelation: Missing required Time Key.");
 
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
-
 		return;
 	}
 
@@ -219,10 +197,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 				glassutil::log_level::warn,
 				"CCorrelation::CCorrelation: Missing required ID Key.");
 
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
-
 		return;
 	}
 
@@ -234,10 +208,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CCorrelation::CCorrelation: Missing required Phase Key.");
-
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
 
 		return;
 	}
@@ -260,10 +230,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					"CCorrelation::CCorrelation: Missing required Hypocenter"
 					" Latitude Key.");
 
-			// cleanup
-			delete (correlation);
-		correlation = NULL;
-
 			return;
 		}
 
@@ -276,9 +242,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					glassutil::log_level::error,
 					"CCorrelation::CCorrelation: Missing required Hypocenter"
 					" Longitude Key.");
-			// cleanup
-			delete (correlation);
-		correlation = NULL;
 
 			return;
 		}
@@ -292,10 +255,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					glassutil::log_level::error,
 					"CCorrelation::CCorrelation: Missing required Hypocenter"
 					" Depth Key.");
-
-			// cleanup
-			delete (correlation);
-		correlation = NULL;
 
 			return;
 		}
@@ -314,10 +273,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					"CCorrelation::CCorrelation: Missing required Hypocenter"
 					" Time Key.");
 
-			// cleanup
-			delete (correlation);
-		correlation = NULL;
-
 			return;
 		}
 
@@ -326,10 +281,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CCorrelation::CCorrelation: Missing required Hypocenter Key.");
-
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
 
 		return;
 	}
@@ -344,10 +295,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 				glassutil::log_level::warn,
 				"CCorrelation::CCorrelation: Missing required Correlation Key.");
 
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
-
 		return;
 	}
 
@@ -358,10 +305,6 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 				glassutil::log_level::error,
 				"CCorrelation::CCorrelation: Failed to initialize correlation.");
 
-		// cleanup
-		delete (correlation);
-		correlation = NULL;
-
 		return;
 	}
 
@@ -370,11 +313,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 	// remember input json for hypo message generation
 	// note move to init?
 	// std::shared_ptr<json::Object> jcorr(new json::Object(*correlation));
-	jCorrelation = std::make_shared<json::Object>(json::Object(*correlation));
-
-	// cleanup
-	delete (correlation);
-		correlation = NULL;
+	jCorrelation = correlation;
 }
 
 // ---------------------------------------------------------~CCorrelation

--- a/glasscore/glasslib/src/Correlation.cpp
+++ b/glasscore/glasslib/src/Correlation.cpp
@@ -117,6 +117,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 			// cleanup
 			delete (correlation);
+		correlation = NULL;
 
 			return;
 		}
@@ -140,6 +141,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 			// cleanup
 			delete (correlation);
+		correlation = NULL;
 
 			return;
 		}
@@ -158,6 +160,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 				"CCorrelation::CCorrelation: Missing required Site Key.");
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -173,6 +176,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 								"CCorrelation::CCorrelation: site is null.");
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -181,6 +185,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 	if (!site->getUse()) {
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -199,6 +204,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -215,6 +221,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -230,6 +237,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -254,6 +262,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 			// cleanup
 			delete (correlation);
+		correlation = NULL;
 
 			return;
 		}
@@ -269,6 +278,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 					" Longitude Key.");
 			// cleanup
 			delete (correlation);
+		correlation = NULL;
 
 			return;
 		}
@@ -285,6 +295,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 			// cleanup
 			delete (correlation);
+		correlation = NULL;
 
 			return;
 		}
@@ -305,6 +316,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 			// cleanup
 			delete (correlation);
+		correlation = NULL;
 
 			return;
 		}
@@ -317,6 +329,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -333,6 +346,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -346,6 +360,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 		// cleanup
 		delete (correlation);
+		correlation = NULL;
 
 		return;
 	}
@@ -359,6 +374,7 @@ CCorrelation::CCorrelation(json::Object *correlation, int correlationId,
 
 	// cleanup
 	delete (correlation);
+		correlation = NULL;
 }
 
 // ---------------------------------------------------------~CCorrelation

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -246,12 +246,12 @@ bool CCorrelationList::addCorrelation(
 			// NOTE: maybe move below to CCorrelation function to match pick?
 
 			// correlations don't have a second travel time
-			traveltime::CTravelTime* nullTrav = NULL;
+			std::shared_ptr<traveltime::CTravelTime> nullTrav;
 
 			// create new hypo
 			// pGlass->m_TTTMutex.lock();
 			std::shared_ptr<CHypo> hypo = std::make_shared<CHypo>(
-					corr, pGlass->getTrvDefault().get(), nullTrav,
+					corr, pGlass->getTrvDefault(), nullTrav,
 					pGlass->getTTT());
 			// pGlass->m_TTTMutex.unlock();
 

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -32,7 +32,7 @@ CCorrelationList::~CCorrelationList() {
 
 // ---------------------------------------------------------clear
 void CCorrelationList::clear() {
-	std::lock_guard<std::recursive_mutex> listGuard(m_vCorrelationMutex);
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
 
 	pGlass = NULL;
 	pSiteList = NULL;
@@ -616,4 +616,50 @@ std::vector<std::shared_ptr<CCorrelation>> CCorrelationList::rogues(
 
 	return (vRogue);
 }
+
+const CSiteList* CCorrelationList::getSiteList() const {
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
+	return (pSiteList);
+}
+
+void CCorrelationList::setSiteList(CSiteList* siteList) {
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
+	pSiteList = siteList;
+}
+
+const CGlass* CCorrelationList::getGlass() const {
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
+	return (pGlass);
+}
+
+void CCorrelationList::setGlass(CGlass* glass) {
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
+	pGlass = glass;
+}
+
+int CCorrelationList::getNCorrelation() const {
+	std::lock_guard<std::recursive_mutex> vCorrelationGuard(m_vCorrelationMutex);
+	return (nCorrelation);
+}
+
+int CCorrelationList::getNCorrelationMax() const {
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
+	return (nCorrelationMax);
+}
+
+void CCorrelationList::setNCorrelationMax(int correlationMax) {
+	std::lock_guard<std::recursive_mutex> corrListGuard(m_CorrelationListMutex);
+	nCorrelationMax = correlationMax;
+}
+
+int CCorrelationList::getNCorrelationTotal() const {
+	std::lock_guard<std::recursive_mutex> vCorrelationGuard(m_vCorrelationMutex);
+	return (nCorrelationTotal);
+}
+
+int CCorrelationList::getVCorrelationSize() const {
+	std::lock_guard<std::recursive_mutex> vCorrelationGuard(m_vCorrelationMutex);
+	return (vCorrelation.size());
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -253,12 +253,12 @@ bool CCorrelationList::addCorrelation(json::Object *correlation) {
 			pGlass->m_TTTMutex.unlock();
 
 			// set hypo glass pointer and such
-			hypo->pGlass = pGlass;
-			hypo->dCutFactor = pGlass->dCutFactor;
-			hypo->dCutPercentage = pGlass->dCutPercentage;
-			hypo->dCutMin = pGlass->dCutMin;
-			hypo->nCut = pGlass->nNucleate;
-			hypo->dThresh = pGlass->dThresh;
+			hypo->setGlass(pGlass);
+			hypo->setCutFactor(pGlass->dCutFactor);
+			hypo->setCutPercentage(pGlass->dCutPercentage);
+			hypo->setCutMin(pGlass->dCutMin);
+			hypo->setCut(pGlass->nNucleate);
+			hypo->setThresh(pGlass->dThresh);
 
 			// add correlation to hypo
 			hypo->addCorrelation(corr);
@@ -468,15 +468,15 @@ bool CCorrelationList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 	}
 
 	glassutil::CLogit::log(glassutil::log_level::debug,
-							"CCorrelationList::scavenge. " + hyp->sPid);
+							"CCorrelationList::scavenge. " + hyp->getPid());
 
 	// get the index of the correlation to start with
 	// based on the hypo origin time
-	int it1 = indexCorrelation(hyp->tOrg - tDuration);
+	int it1 = indexCorrelation(hyp->getTOrg() - tDuration);
 
 	// get the index of the correlation to end with by using the hypo
 	// origin time plus the provided duration
-	int it2 = indexCorrelation(hyp->tOrg + tDuration);
+	int it2 = indexCorrelation(hyp->getTOrg() + tDuration);
 
 	// index can't be negative
 	// Primarily occurs if origin time is before first correlation
@@ -527,11 +527,11 @@ bool CCorrelationList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 						sLog,
 						sizeof(sLog),
 						"C-WAF %s %s %s (%d)\n",
-						hyp->sPid.substr(0, 4).c_str(),
+						hyp->getPid().substr(0, 4).c_str(),
 						glassutil::CDate::encodeDateTime(corr->tCorrelation)
 								.c_str(),
 						corr->pSite->sScnl.c_str(),
-						static_cast<int>(hyp->vCorr.size()));
+						static_cast<int>(hyp->getVCorrSize()));
 				glassutil::CLogit::Out(sLog);
 			}
 
@@ -603,7 +603,7 @@ std::vector<std::shared_ptr<CCorrelation>> CCorrelationList::rogues(
 		std::shared_ptr<CHypo> corrHyp = corr->pHypo;
 
 		// if the current pick is associated to this event
-		if ((corrHyp != NULL) && (corrHyp->sPid == pidHyp)) {
+		if ((corrHyp != NULL) && (corrHyp->getPid() == pidHyp)) {
 			// skip to next pick
 			continue;
 		}

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -142,8 +142,9 @@ bool CCorrelationList::addCorrelation(json::Object *correlation) {
 														pSiteList);
 
 	// check to see if we got a valid correlation
-	if ((newCorrelation->pSite == NULL) || (newCorrelation->tCorrelation == 0)
-			|| (newCorrelation->sPid == "")) {
+	if ((newCorrelation->getSite() == NULL)
+			|| (newCorrelation->getTCorrelation() == 0)
+			|| (newCorrelation->getPid() == "")) {
 		// cleanup
 		delete (newCorrelation);
 		return (false);
@@ -189,7 +190,7 @@ bool CCorrelationList::addCorrelation(json::Object *correlation) {
 	}
 
 	// create pair for insertion
-	std::pair<double, int> p(corr->tCorrelation, nCorrelation);
+	std::pair<double, int> p(corr->getTCorrelation(), nCorrelation);
 
 	// check to see if we're at the correlation limit
 	if (vCorrelation.size() == nCorrelationMax) {
@@ -207,7 +208,7 @@ bool CCorrelationList::addCorrelation(json::Object *correlation) {
 
 	// Insert new correlation in proper time sequence into correlation vector
 	// get the index of the new correlation
-	int iCorrelation = indexCorrelation(corr->tCorrelation);
+	int iCorrelation = indexCorrelation(corr->getTCorrelation());
 	switch (iCorrelation) {
 		case -2:
 			// Empty vector, just add it
@@ -384,10 +385,10 @@ bool CCorrelationList::checkDuplicate(CCorrelation * newCorrelation,
 	}
 
 	// get the index of the earliest possible match
-	int it1 = indexCorrelation(newCorrelation->tCorrelation - tWindow);
+	int it1 = indexCorrelation(newCorrelation->getTCorrelation() - tWindow);
 
 	// get index of the latest possible correlation
-	int it2 = indexCorrelation(newCorrelation->tCorrelation + tWindow);
+	int it2 = indexCorrelation(newCorrelation->getTCorrelation() + tWindow);
 
 	// index can't be negative, it1/2 negative if correlation before first in
 	// list
@@ -409,15 +410,16 @@ bool CCorrelationList::checkDuplicate(CCorrelation * newCorrelation,
 		std::shared_ptr<CCorrelation> cor = mCorrelation[q.second];
 
 		// check if time difference is within window
-		if (std::abs(newCorrelation->tCorrelation - cor->tCorrelation)
+		if (std::abs(newCorrelation->getTCorrelation() - cor->getTCorrelation())
 				< tWindow) {
 			// check if sites match
-			if (newCorrelation->pSite->sScnl == cor->pSite->sScnl) {
+			if (newCorrelation->getSite()->sScnl == cor->getSite()->sScnl) {
 				glassutil::CGeo geo1;
-				geo1.setGeographic(newCorrelation->dLat, newCorrelation->dLon,
-									newCorrelation->dZ);
+				geo1.setGeographic(newCorrelation->getLat(),
+									newCorrelation->getLon(),
+									newCorrelation->getZ());
 				glassutil::CGeo geo2;
-				geo2.setGeographic(cor->dLat, cor->dLon, cor->dZ);
+				geo2.setGeographic(cor->getLat(), cor->getLon(), cor->getZ());
 				double delta = RAD2DEG * geo1.delta(&geo2);
 
 				// check if distance difference is within window
@@ -428,12 +430,12 @@ bool CCorrelationList::checkDuplicate(CCorrelation * newCorrelation,
 							"CCorrelationList::checkDuplicate: Duplicate "
 									"(tWindow = " + std::to_string(tWindow)
 									+ ", xWindow = " + std::to_string(xWindow)
-									+ ") : old:" + cor->pSite->sScnl + " "
-									+ std::to_string(cor->tCorrelation)
+									+ ") : old:" + cor->getSite()->sScnl + " "
+									+ std::to_string(cor->getTCorrelation())
 									+ " new(del):"
-									+ newCorrelation->pSite->sScnl + " "
+									+ newCorrelation->getSite()->sScnl + " "
 									+ std::to_string(
-											newCorrelation->tCorrelation));
+											newCorrelation->getTCorrelation()));
 					return (true);
 				}
 			}
@@ -498,7 +500,7 @@ bool CCorrelationList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 		// get the correlation from the vector
 		auto q = vCorrelation[it];
 		std::shared_ptr<CCorrelation> corr = mCorrelation[q.second];
-		std::shared_ptr<CHypo> corrHyp = corr->pHypo;
+		std::shared_ptr<CHypo> corrHyp = corr->getHypo();
 
 		// check to see if this correlation is already in this hypo
 		if (hyp->hasCorrelation(corr)) {
@@ -528,9 +530,9 @@ bool CCorrelationList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 						sizeof(sLog),
 						"C-WAF %s %s %s (%d)\n",
 						hyp->getPid().substr(0, 4).c_str(),
-						glassutil::CDate::encodeDateTime(corr->tCorrelation)
-								.c_str(),
-						corr->pSite->sScnl.c_str(),
+						glassutil::CDate::encodeDateTime(
+								corr->getTCorrelation()).c_str(),
+						corr->getSite()->sScnl.c_str(),
 						static_cast<int>(hyp->getVCorrSize()));
 				glassutil::CLogit::Out(sLog);
 			}
@@ -600,7 +602,7 @@ std::vector<std::shared_ptr<CCorrelation>> CCorrelationList::rogues(
 		// get the current pick from the vector
 		auto q = vCorrelation[it];
 		std::shared_ptr<CCorrelation> corr = mCorrelation[q.second];
-		std::shared_ptr<CHypo> corrHyp = corr->pHypo;
+		std::shared_ptr<CHypo> corrHyp = corr->getHypo();
 
 		// if the current pick is associated to this event
 		if ((corrHyp != NULL) && (corrHyp->getPid() == pidHyp)) {

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -56,7 +56,7 @@ void CCorrelationList::clearCorrelations() {
 }
 
 // ---------------------------------------------------------dispatch
-bool CCorrelationList::dispatch(json::Object *com) {
+bool CCorrelationList::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -97,7 +97,8 @@ bool CCorrelationList::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------addCorrelation
-bool CCorrelationList::addCorrelation(json::Object *correlation) {
+bool CCorrelationList::addCorrelation(
+		std::shared_ptr<json::Object> correlation) {
 	std::lock_guard<std::recursive_mutex> listGuard(m_vCorrelationMutex);
 
 	// null check json

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -413,7 +413,7 @@ bool CCorrelationList::checkDuplicate(CCorrelation * newCorrelation,
 		if (std::abs(newCorrelation->getTCorrelation() - cor->getTCorrelation())
 				< tWindow) {
 			// check if sites match
-			if (newCorrelation->getSite()->sScnl == cor->getSite()->sScnl) {
+			if (newCorrelation->getSite()->getScnl() == cor->getSite()->getScnl()) {
 				glassutil::CGeo geo1;
 				geo1.setGeographic(newCorrelation->getLat(),
 									newCorrelation->getLon(),
@@ -430,10 +430,10 @@ bool CCorrelationList::checkDuplicate(CCorrelation * newCorrelation,
 							"CCorrelationList::checkDuplicate: Duplicate "
 									"(tWindow = " + std::to_string(tWindow)
 									+ ", xWindow = " + std::to_string(xWindow)
-									+ ") : old:" + cor->getSite()->sScnl + " "
+									+ ") : old:" + cor->getSite()->getScnl() + " "
 									+ std::to_string(cor->getTCorrelation())
 									+ " new(del):"
-									+ newCorrelation->getSite()->sScnl + " "
+									+ newCorrelation->getSite()->getScnl() + " "
 									+ std::to_string(
 											newCorrelation->getTCorrelation()));
 					return (true);
@@ -532,7 +532,7 @@ bool CCorrelationList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 						hyp->getPid().substr(0, 4).c_str(),
 						glassutil::CDate::encodeDateTime(
 								corr->getTCorrelation()).c_str(),
-						corr->getSite()->sScnl.c_str(),
+						corr->getSite()->getScnl().c_str(),
 						static_cast<int>(hyp->getVCorrSize()));
 				glassutil::CLogit::Out(sLog);
 			}

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -148,6 +148,7 @@ bool CCorrelationList::addCorrelation(
 			|| (newCorrelation->getPid() == "")) {
 		// cleanup
 		delete (newCorrelation);
+		// message was processed
 		return (true);
 	}
 
@@ -164,6 +165,7 @@ bool CCorrelationList::addCorrelation(
 					"CCorrelationList::addCorrelation: Duplicate correlation "
 					"not passed in.");
 			delete (newCorrelation);
+			// message was processed
 			return (true);
 		}
 	}
@@ -249,11 +251,9 @@ bool CCorrelationList::addCorrelation(
 			std::shared_ptr<traveltime::CTravelTime> nullTrav;
 
 			// create new hypo
-			// pGlass->m_TTTMutex.lock();
 			std::shared_ptr<CHypo> hypo = std::make_shared<CHypo>(
 					corr, pGlass->getTrvDefault(), nullTrav,
 					pGlass->getTTT());
-			// pGlass->m_TTTMutex.unlock();
 
 			// set hypo glass pointer and such
 			hypo->setGlass(pGlass);
@@ -292,7 +292,7 @@ bool CCorrelationList::addCorrelation(
 		}
 	}
 
-	// we're done
+	// we're done, message was processed
 	return (true);
 }
 

--- a/glasscore/glasslib/src/CorrelationList.cpp
+++ b/glasscore/glasslib/src/CorrelationList.cpp
@@ -147,7 +147,7 @@ bool CCorrelationList::addCorrelation(json::Object *correlation) {
 			|| (newCorrelation->getPid() == "")) {
 		// cleanup
 		delete (newCorrelation);
-		return (false);
+		return (true);
 	}
 
 	// check if correlation is duplicate, if pGlass exists
@@ -163,7 +163,7 @@ bool CCorrelationList::addCorrelation(json::Object *correlation) {
 					"CCorrelationList::addCorrelation: Duplicate correlation "
 					"not passed in.");
 			delete (newCorrelation);
-			return (false);
+			return (true);
 		}
 	}
 

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -28,6 +28,7 @@ CDetection::~CDetection() {
 
 // ---------------------------------------------------------clear
 void CDetection::clear() {
+	std::lock_guard<std::recursive_mutex> detectionGuard(detectionMutex);
 	pGlass = NULL;
 }
 
@@ -86,6 +87,8 @@ bool CDetection::process(json::Object *com) {
 								"CDetection::process: NULL pGlass.");
 		return (false);
 	}
+
+	std::lock_guard<std::recursive_mutex> detectionGuard(detectionMutex);
 
 	// detection definition variables
 	double torg = 0;
@@ -217,5 +220,15 @@ bool CDetection::process(json::Object *com) {
 
 	// done
 	return (true);
+}
+
+const CGlass* CDetection::getGlass() {
+	std::lock_guard<std::recursive_mutex> detectionGuard(detectionMutex);
+	return (pGlass);
+}
+
+void CDetection::setGlass(CGlass* glass) {
+	std::lock_guard<std::recursive_mutex> detectionGuard(detectionMutex);
+	pGlass = glass;
 }
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -179,7 +179,7 @@ bool CDetection::process(json::Object *com) {
 		glassutil::CGeo geo1;
 		geo1.setGeographic(lat, lon, z);
 		glassutil::CGeo geo2;
-		geo2.setGeographic(hypo->dLat, hypo->dLon, hypo->dZ);
+		geo2.setGeographic(hypo->getLat(), hypo->getLon(), hypo->getZ());
 		double delta = RAD2DEG * geo1.delta(&geo2);
 
 		// if the detection is more than 5 degrees away, it isn't a match
@@ -198,10 +198,10 @@ bool CDetection::process(json::Object *com) {
 			pGlass->m_TTTMutex.unlock();
 
 			// set hypo glass pointer and such
-			hypo->pGlass = pGlass;
-			hypo->dCutFactor = pGlass->dCutFactor;
-			hypo->dCutPercentage = pGlass->dCutPercentage;
-			hypo->dCutMin = pGlass->dCutMin;
+			hypo->setGlass(pGlass);
+			hypo->setCutFactor(pGlass->dCutFactor);
+			hypo->setCutPercentage(pGlass->dCutPercentage);
+			hypo->setCutMin(pGlass->dCutMin);
 
 			// process hypo using evolve
 			if (pGlass->pHypoList->evolve(hypo, 1)) {

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -196,13 +196,11 @@ bool CDetection::process(std::shared_ptr<json::Object> com) {
 			std::shared_ptr<traveltime::CTravelTime> nullTrav;
 
 			// create new hypo
-			// pGlass->m_TTTMutex.lock();
 			hypo = std::make_shared<CHypo>(lat, lon, z, torg,
 											glassutil::CPid::pid(), "Detection",
 											0.0, 0.0, 0,
 											pGlass->getTrvDefault(),
 											nullTrav, pGlass->getTTT());
-			// pGlass->m_TTTMutex.unlock();
 
 			// set hypo glass pointer and such
 			hypo->setGlass(pGlass);

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -222,7 +222,7 @@ bool CDetection::process(json::Object *com) {
 	return (true);
 }
 
-const CGlass* CDetection::getGlass() {
+const CGlass* CDetection::getGlass() const {
 	std::lock_guard<std::recursive_mutex> detectionGuard(detectionMutex);
 	return (pGlass);
 }

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -165,15 +165,13 @@ bool CDetection::process(json::Object *com) {
 	// Check to see if hypo already exists. We could also
 	// check location at this point, but it seems unlikely
 	// that would add much value
-	auto hypolist = pGlass->pHypoList;
-
 	// define a three minute search window
 	// NOTE: Hard coded.
 	double t1 = torg - 90.0;
 	double t2 = torg + 90.0;
 
 	// search for the first hypocenter in the window
-	std::shared_ptr<CHypo> hypo = hypolist->findHypo(t1, t2);
+	std::shared_ptr<CHypo> hypo = pGlass->getHypoList()->findHypo(t1, t2);
 
 	// check to see if we found a hypo
 	if (hypo != NULL) {
@@ -192,29 +190,29 @@ bool CDetection::process(json::Object *com) {
 			traveltime::CTravelTime* nullTrav = NULL;
 
 			// create new hypo
-			pGlass->m_TTTMutex.lock();
+			// pGlass->m_TTTMutex.lock();
 			hypo = std::make_shared<CHypo>(lat, lon, z, torg,
 											glassutil::CPid::pid(), "Detection",
 											0.0, 0.0, 0,
-											pGlass->pTrvDefault.get(), nullTrav,
-											pGlass->pTTT);
-			pGlass->m_TTTMutex.unlock();
+											pGlass->getTrvDefault().get(),
+											nullTrav, pGlass->getTTT());
+			// pGlass->m_TTTMutex.unlock();
 
 			// set hypo glass pointer and such
 			hypo->setGlass(pGlass);
-			hypo->setCutFactor(pGlass->dCutFactor);
-			hypo->setCutPercentage(pGlass->dCutPercentage);
-			hypo->setCutMin(pGlass->dCutMin);
+			hypo->setCutFactor(pGlass->getCutFactor());
+			hypo->setCutPercentage(pGlass->getCutPercentage());
+			hypo->setCutMin(pGlass->getCutMin());
 
 			// process hypo using evolve
-			if (pGlass->pHypoList->evolve(hypo, 1)) {
+			if (pGlass->getHypoList()->evolve(hypo, 1)) {
 				// add to hypo list
-				hypolist->addHypo(hypo);
+				pGlass->getHypoList()->addHypo(hypo);
 			}
 		} else {
 			// existing hypo, now hwat?
 			// schedule hypo for processing?
-			hypolist->pushFifo(hypo);
+			pGlass->getHypoList()->pushFifo(hypo);
 		}
 	}
 

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -85,6 +85,9 @@ bool CDetection::process(json::Object *com) {
 	if (pGlass == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CDetection::process: NULL pGlass.");
+
+		delete (com);
+
 		return (false);
 	}
 
@@ -114,6 +117,9 @@ bool CDetection::process(json::Object *com) {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
 					"CDetection::process: Missing required Hypocenter Time Key.");
+
+			delete (com);
+
 			return (false);
 		}
 
@@ -128,6 +134,9 @@ bool CDetection::process(json::Object *com) {
 					glassutil::log_level::error,
 					"CDetection::process: Missing required Hypocenter Latitude"
 					" Key.");
+
+			delete (com);
+
 			return (false);
 		}
 
@@ -141,6 +150,9 @@ bool CDetection::process(json::Object *com) {
 					glassutil::log_level::error,
 					"CDetection::process: Missing required Hypocenter Longitude"
 					" Key.");
+
+			delete (com);
+
 			return (false);
 		}
 
@@ -153,14 +165,22 @@ bool CDetection::process(json::Object *com) {
 					glassutil::log_level::error,
 					"CDetection::process: Missing required Hypocenter Depth"
 					" Key.");
+
+			delete (com);
+
 			return (false);
 		}
 	} else {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CDetection::process: Missing required Hypocenter Key.");
+
+		delete (com);
+
 		return (false);
 	}
+
+	delete (com);
 
 	// Check to see if hypo already exists. We could also
 	// check location at this point, but it seems unlikely

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -193,14 +193,14 @@ bool CDetection::process(std::shared_ptr<json::Object> com) {
 		// NOTE: Hard coded.
 		if (delta > 5.0) {
 			// detections don't have a second travel time
-			traveltime::CTravelTime* nullTrav = NULL;
+			std::shared_ptr<traveltime::CTravelTime> nullTrav;
 
 			// create new hypo
 			// pGlass->m_TTTMutex.lock();
 			hypo = std::make_shared<CHypo>(lat, lon, z, torg,
 											glassutil::CPid::pid(), "Detection",
 											0.0, 0.0, 0,
-											pGlass->getTrvDefault().get(),
+											pGlass->getTrvDefault(),
 											nullTrav, pGlass->getTTT());
 			// pGlass->m_TTTMutex.unlock();
 

--- a/glasscore/glasslib/src/Detection.cpp
+++ b/glasscore/glasslib/src/Detection.cpp
@@ -33,7 +33,7 @@ void CDetection::clear() {
 }
 
 // ---------------------------------------------------------Dispatch
-bool CDetection::dispatch(json::Object *com) {
+bool CDetection::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -74,7 +74,7 @@ bool CDetection::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------process
-bool CDetection::process(json::Object *com) {
+bool CDetection::process(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -85,8 +85,6 @@ bool CDetection::process(json::Object *com) {
 	if (pGlass == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CDetection::process: NULL pGlass.");
-
-		delete (com);
 
 		return (false);
 	}
@@ -118,8 +116,6 @@ bool CDetection::process(json::Object *com) {
 					glassutil::log_level::error,
 					"CDetection::process: Missing required Hypocenter Time Key.");
 
-			delete (com);
-
 			return (false);
 		}
 
@@ -135,8 +131,6 @@ bool CDetection::process(json::Object *com) {
 					"CDetection::process: Missing required Hypocenter Latitude"
 					" Key.");
 
-			delete (com);
-
 			return (false);
 		}
 
@@ -151,8 +145,6 @@ bool CDetection::process(json::Object *com) {
 					"CDetection::process: Missing required Hypocenter Longitude"
 					" Key.");
 
-			delete (com);
-
 			return (false);
 		}
 
@@ -166,8 +158,6 @@ bool CDetection::process(json::Object *com) {
 					"CDetection::process: Missing required Hypocenter Depth"
 					" Key.");
 
-			delete (com);
-
 			return (false);
 		}
 	} else {
@@ -175,12 +165,8 @@ bool CDetection::process(json::Object *com) {
 				glassutil::log_level::error,
 				"CDetection::process: Missing required Hypocenter Key.");
 
-		delete (com);
-
 		return (false);
 	}
-
-	delete (com);
 
 	// Check to see if hypo already exists. We could also
 	// check location at this point, but it seems unlikely

--- a/glasscore/glasslib/src/Glass.cpp
+++ b/glasscore/glasslib/src/Glass.cpp
@@ -313,7 +313,7 @@ bool CGlass::initialize(std::shared_ptr<json::Object> com) {
 		json::Array phases = (*com)["AssociationPhases"].ToArray();
 
 		// create and initialize travel time list
-		pTTT = new traveltime::CTTT();
+		pTTT = std::make_shared<traveltime::CTTT>();
 
 		// for each phase in the array
 		for (auto val : phases) {
@@ -1309,7 +1309,7 @@ std::shared_ptr<traveltime::CTravelTime>& CGlass::getTrvDefault() {
 	return (pTrvDefault);
 }
 
-traveltime::CTTT*& CGlass::getTTT() {
+std::shared_ptr<traveltime::CTTT>& CGlass::getTTT() {
 	std::lock_guard<std::mutex> ttGuard(m_TTTMutex);
 	return (pTTT);
 }

--- a/glasscore/glasslib/src/Glass.cpp
+++ b/glasscore/glasslib/src/Glass.cpp
@@ -77,7 +77,7 @@ bool CGlass::dispatch(json::Object *com) {
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CGlass::dispatch: NULL json communication.");
-		return(false);
+		return (false);
 	}
 
 	// check for a command
@@ -87,7 +87,8 @@ bool CGlass::dispatch(json::Object *com) {
 		json::Value v = (*com)["Cmd"].ToString();
 
 		// log cmd if it isn't one of the common ones
-		if ((v != "Site") && (v != "Ping") && (v != "Pick")) {
+		if ((v != "Site") && (v != "ReqHypo") && (v != "Correlation")
+				&& (v != "Pick")) {
 			glassutil::CLogit::log(glassutil::log_level::debug,
 									"CGlass::dispatch: Cmd:" + v.ToString());
 		}
@@ -107,7 +108,7 @@ bool CGlass::dispatch(json::Object *com) {
 
 		// Initialize glass
 		if (v == "Initialize") {
-			return(initialize(com));
+			return (initialize(com));
 		}
 
 		// clear glass configuration
@@ -124,27 +125,27 @@ bool CGlass::dispatch(json::Object *com) {
 
 			glassutil::CLogit::log(glassutil::log_level::debug,
 									"CGlass::dispatch: Cmd is:" + v.ToString());
-			return(false);
+			return (false);
 		}
 
 		// send any other commands to any of the configurable / input classes
 		if (pPickList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pSiteList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pHypoList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pCorrelationList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pDetection->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pWebList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 	}
 
@@ -153,21 +154,21 @@ bool CGlass::dispatch(json::Object *com) {
 			&& ((*com)["Type"].GetType() == json::ValueType::StringVal)) {
 		// send any input to any of the input processing classes
 		if (pPickList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pSiteList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pCorrelationList->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 		if (pDetection->dispatch(com)) {
-			return(true);
+			return (true);
 		}
 	}
 
 	// this communication was not handled
-	return(false);
+	return (false);
 }
 
 // ---------------------------------------------------------send
@@ -178,11 +179,11 @@ bool CGlass::send(json::Object *com) {
 		piSend->Send(com);
 
 		// done
-		return(true);
+		return (true);
 	}
 
 	// communication not sent
-	return(false);
+	return (false);
 }
 
 // ---------------------------------------------------------Clear
@@ -223,7 +224,7 @@ bool CGlass::initialize(json::Object *com) {
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CGlass::initialize: NULL json.");
-		return(false);
+		return (false);
 	}
 
 	// check cmd
@@ -235,14 +236,14 @@ bool CGlass::initialize(json::Object *com) {
 			glassutil::CLogit::log(
 					glassutil::log_level::warn,
 					"CGlass::initialize: Non-Initialize Cmd passed in.");
-			return(false);
+			return (false);
 		}
 	} else {
 		// no command or type
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CGlass::initialize: Missing required Cmd Key.");
-		return(false);
+		return (false);
 	}
 
 	// Reset parameters
@@ -435,7 +436,7 @@ bool CGlass::initialize(json::Object *com) {
 	} else {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"No association Phase array provided");
-		return(false);
+		return (false);
 	}
 
 	// setup if we are going to print phase travel times for debuging
@@ -1037,7 +1038,7 @@ bool CGlass::initialize(json::Object *com) {
 	pDetection = new CDetection();
 	pDetection->setGlass(this);
 
-	return(true);
+	return (true);
 }
 
 /* NOTE: Leave these in place as examples for Travel Time unit tests.
@@ -1135,7 +1136,7 @@ bool CGlass::initialize(json::Object *com) {
 // It is used for pruning and association, and is roughly
 // analogous to residual pruning in least squares approaches
 double CGlass::sig(double x, double sigma) {
-	return(exp(-0.5 * x * x / sigma / sigma));
+	return (exp(-0.5 * x * x / sigma / sigma));
 }
 // ---------------------------------------------------------Sig
 // Calculate the laplacian significance function, which is just
@@ -1143,9 +1144,9 @@ double CGlass::sig(double x, double sigma) {
 // analogous to residual pruning in L1 approach.
 double CGlass::sig_laplace_pdf(double x, double sigma) {
 	if (x > 0) {
-		return((1. / (2. * sigma)) * exp(-1. * x / sigma));
+		return ((1. / (2. * sigma)) * exp(-1. * x / sigma));
 	} else {
-		return((1. / (2. * sigma)) * exp(x / sigma));
+		return ((1. / (2. * sigma)) * exp(x / sigma));
 	}
 }
 
@@ -1153,184 +1154,184 @@ double CGlass::sig_laplace_pdf(double x, double sigma) {
 bool CGlass::statusCheck() {
 	// nullcheck
 	if (pPickList == NULL) {
-		return(false);
+		return (false);
 	}
 
 	// check pick list
 	if (pPickList->statusCheck() == false) {
-		return(false);
+		return (false);
 	}
 
 	// hypo list
 	if (pHypoList->statusCheck() == false) {
-		return(false);
+		return (false);
 	}
 
 	// webs
 	if (pWebList->statusCheck() == false) {
-		return(false);
+		return (false);
 	}
 
 	// all is well
-	return(true);
+	return (true);
 }
 
 double CGlass::getAvgDelta() const {
-	return(avgDelta);
+	return (avgDelta);
 }
 
 double CGlass::getAvgSigma() const {
-	return(avgSigma);
+	return (avgSigma);
 }
 
 double CGlass::getBeamMatchingAzimuthWindow() const {
-	return(beamMatchingAzimuthWindow);
+	return (beamMatchingAzimuthWindow);
 }
 
 double CGlass::getBeamMatchingDistanceWindow() const {
-	return(beamMatchingDistanceWindow);
+	return (beamMatchingDistanceWindow);
 }
 
 int CGlass::getCorrelationCancelAge() const {
-	return(correlationCancelAge);
+	return (correlationCancelAge);
 }
 
 double CGlass::getCorrelationMatchingTWindow() const {
-	return(correlationMatchingTWindow);
+	return (correlationMatchingTWindow);
 }
 
 double CGlass::getCorrelationMatchingXWindow() const {
-	return(correlationMatchingXWindow);
+	return (correlationMatchingXWindow);
 }
 
 double CGlass::getCutFactor() const {
-	return(dCutFactor);
+	return (dCutFactor);
 }
 
 double CGlass::getCutMin() const {
-	return(dCutMin);
+	return (dCutMin);
 }
 
 double CGlass::getCutPercentage() const {
-	return(dCutPercentage);
+	return (dCutPercentage);
 }
 
 double CGlass::getReportThresh() const {
-	return(dReportThresh);
+	return (dReportThresh);
 }
 
 double CGlass::getThresh() const {
-	return(dThresh);
+	return (dThresh);
 }
 
 double CGlass::getExpAffinity() const {
-	return(expAffinity);
+	return (expAffinity);
 }
 
 bool CGlass::getGraphicsOut() const {
-	return(graphicsOut);
+	return (graphicsOut);
 }
 
 const std::string& CGlass::getGraphicsOutFolder() const {
-	return(graphicsOutFolder);
+	return (graphicsOutFolder);
 }
 
 double CGlass::getGraphicsStepKm() const {
-	return(graphicsStepKM);
+	return (graphicsStepKM);
 }
 
 int CGlass::getGraphicsSteps() const {
-	return(graphicsSteps);
+	return (graphicsSteps);
 }
 
 int CGlass::getCycleLimit() const {
-	return(iCycleLimit);
+	return (iCycleLimit);
 }
 
 bool CGlass::getMinimizeTtLocator() const {
-	return(minimizeTTLocator);
+	return (minimizeTTLocator);
 }
 
 int CGlass::getCorrelationMax() const {
-	return(nCorrelationMax);
+	return (nCorrelationMax);
 }
 
 int CGlass::getDetect() const {
-	return(nDetect);
+	return (nDetect);
 }
 
 int CGlass::getHypoMax() const {
-	return(nHypoMax);
+	return (nHypoMax);
 }
 
 int CGlass::getNucleate() const {
-	return(nNucleate);
+	return (nNucleate);
 }
 
 int CGlass::getPickMax() const {
-	return(nPickMax);
+	return (nPickMax);
 }
 
 double CGlass::getReportCut() const {
-	return(nReportCut);
+	return (nReportCut);
 }
 
 int CGlass::getSitePickMax() const {
-	return(nSitePickMax);
+	return (nSitePickMax);
 }
 
 CCorrelationList*& CGlass::getCorrelationList() {
-	return(pCorrelationList);
+	return (pCorrelationList);
 }
 
 CDetection*& CGlass::getDetection() {
-	return(pDetection);
+	return (pDetection);
 }
 
 CHypoList*& CGlass::getHypoList() {
-	return(pHypoList);
+	return (pHypoList);
 }
 
 double CGlass::getPickDuplicateWindow() const {
-	return(pickDuplicateWindow);
+	return (pickDuplicateWindow);
 }
 
 CPickList*& CGlass::getPickList() {
-	return(pPickList);
+	return (pPickList);
 }
 
 CSiteList*& CGlass::getSiteList() {
-	return(pSiteList);
+	return (pSiteList);
 }
 
 std::shared_ptr<traveltime::CTravelTime>& CGlass::getTrvDefault() {
 	std::lock_guard<std::mutex> ttGuard(m_TTTMutex);
-	return(pTrvDefault);
+	return (pTrvDefault);
 }
 
 traveltime::CTTT*& CGlass::getTTT() {
 	std::lock_guard<std::mutex> ttGuard(m_TTTMutex);
-	return(pTTT);
+	return (pTTT);
 }
 
 CWebList*& CGlass::getWebList() {
-	return(pWebList);
+	return (pWebList);
 }
 
 double CGlass::getSdAssociate() const {
-	return(sdAssociate);
+	return (sdAssociate);
 }
 
 double CGlass::getSdPrune() const {
-	return(sdPrune);
+	return (sdPrune);
 }
 
 bool CGlass::getTestLocator() const {
-	return(testLocator);
+	return (testLocator);
 }
 
 bool CGlass::getTestTimes() const {
-	return(testTimes);
+	return (testTimes);
 }
 
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Glass.cpp
+++ b/glasscore/glasslib/src/Glass.cpp
@@ -96,10 +96,6 @@ bool CGlass::dispatch(json::Object *com) {
 									"CGlass::dispatch: Cmd:" + v.ToString());
 		}
 
-		if (v == "Ping") {
-			return (ping(com));
-		}
-
 		// reset debugging values
 		nIterate = 0;
 		nLocate = 0;
@@ -1018,7 +1014,7 @@ bool CGlass::initialize(json::Object *com) {
 
 	// create site list
 	pSiteList = new CSiteList();
-	pSiteList->pGlass = this;
+	pSiteList->setGlass(this);
 
 	// clean out old web list if any
 	if (pWebList) {
@@ -1027,8 +1023,8 @@ bool CGlass::initialize(json::Object *com) {
 
 	// create detection web list
 	pWebList = new CWebList(webBackgroundUpdate);
-	pWebList->pGlass = this;
-	pWebList->pSiteList = pSiteList;
+	pWebList->setGlass(this);
+	pWebList->setSiteList(pSiteList);
 
 	// clean out old pick list if any
 	if (pPickList) {
@@ -1037,8 +1033,8 @@ bool CGlass::initialize(json::Object *com) {
 
 	// create pick list
 	pPickList = new CPickList(numNucleationThreads);
-	pPickList->pGlass = this;
-	pPickList->pSiteList = pSiteList;
+	pPickList->setGlass(this);
+	pPickList->setSiteList(pSiteList);
 
 	// clean out old correlation list if any
 	if (pCorrelationList) {
@@ -1047,8 +1043,8 @@ bool CGlass::initialize(json::Object *com) {
 
 	// create correlation list
 	pCorrelationList = new CCorrelationList();
-	pCorrelationList->pGlass = this;
-	pCorrelationList->pSiteList = pSiteList;
+	pCorrelationList->setGlass(this);
+	pCorrelationList->setSiteList(pSiteList);
 
 	// clean out old hypo list if any
 	if (pHypoList) {
@@ -1057,36 +1053,7 @@ bool CGlass::initialize(json::Object *com) {
 
 	// create hypo list
 	pHypoList = new CHypoList(numHypoThreads);
-	pHypoList->pGlass = this;
-
-	// configure output format
-	if ((com->HasKey("OutputFormat"))
-			&& ((*com)["OutputFormat"].GetType() == json::ValueType::StringVal)) {
-		// get the output format
-		std::string outputformat = (*com)["OutputFormat"].ToString();
-
-		// set up based on output format
-		if (outputformat == "Event") {
-			pHypoList->bSendEvent = true;
-
-			glassutil::CLogit::log(
-					glassutil::log_level::info,
-					"CGlass::initialize: Using output format Event");
-		} else {
-			pHypoList->bSendEvent = false;
-
-			glassutil::CLogit::log(
-					glassutil::log_level::info,
-					"CGlass::initialize: Using default output format Event");
-		}
-	} else {
-		// default to sending quake messages
-		pHypoList->bSendEvent = false;
-
-		glassutil::CLogit::log(
-				glassutil::log_level::info,
-				"CGlass::initialize: Using default output format Quake");
-	}
+	pHypoList->setGlass(this);
 
 	// create detection processor
 	pDetection = new CDetection();
@@ -1095,29 +1062,6 @@ bool CGlass::initialize(json::Object *com) {
 	return (true);
 }
 
-// ---------------------------------------------------------Ping
-bool CGlass::ping(json::Object *com) {
-	// NOTE: This function only had relevance for Caryl, consider removing
-	json::Object pong;
-	pong["Cmd"] = "Pong";
-	int npicks = 0;
-	int nquakes = 0;
-	if (pPickList) {
-		npicks = pPickList->vPick.size();
-	}
-	if (pHypoList) {
-		nquakes = pHypoList->vHypo.size();
-	}
-	pong["nPicks"] = npicks;
-	pong["nQuakes"] = nquakes;
-	pong["nLoc"] = nLocate;
-	pong["nIter"] = nIterate;
-	pong["Web"] = sWeb;
-	pong["Sum"] = dSum;
-	pong["Count"] = nCount;
-	send(&pong);
-	return true;
-}
 /* NOTE: Leave these in place as examples for Travel Time unit tests.
  *
  // ---------------------------------------------------------Test

--- a/glasscore/glasslib/src/Glass.cpp
+++ b/glasscore/glasslib/src/Glass.cpp
@@ -1090,7 +1090,7 @@ bool CGlass::initialize(json::Object *com) {
 
 	// create detection processor
 	pDetection = new CDetection();
-	pDetection->pGlass = this;
+	pDetection->setGlass(this);
 
 	return (true);
 }

--- a/glasscore/glasslib/src/Glass.cpp
+++ b/glasscore/glasslib/src/Glass.cpp
@@ -72,7 +72,7 @@ CGlass::~CGlass() {
 }
 
 // ---------------------------------------------------------dispatch
-bool CGlass::dispatch(json::Object *com) {
+bool CGlass::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -172,7 +172,7 @@ bool CGlass::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------send
-bool CGlass::send(json::Object *com) {
+bool CGlass::send(std::shared_ptr<json::Object> com) {
 	// make sure we have something to send to
 	if (piSend) {
 		// send the communication
@@ -219,7 +219,7 @@ void CGlass::clear() {
 }
 
 // ---------------------------------------------------------Initialize
-bool CGlass::initialize(json::Object *com) {
+bool CGlass::initialize(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,

--- a/glasscore/glasslib/src/Glass.cpp
+++ b/glasscore/glasslib/src/Glass.cpp
@@ -38,10 +38,6 @@ CGlass::CGlass() {
 	nCorrelationMax = 1000;
 	nSitePickMax = 200;
 	nHypoMax = 100;
-	bTrack = false;
-	sWeb = "Nada";
-	nCount = 0;
-	dSum = 0.0;
 	graphicsOut = false;
 	graphicsOutFolder = "./";
 	graphicsStepKM = 1.;
@@ -81,7 +77,7 @@ bool CGlass::dispatch(json::Object *com) {
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CGlass::dispatch: NULL json communication.");
-		return (false);
+		return(false);
 	}
 
 	// check for a command
@@ -96,26 +92,22 @@ bool CGlass::dispatch(json::Object *com) {
 									"CGlass::dispatch: Cmd:" + v.ToString());
 		}
 
-		// reset debugging values
-		nIterate = 0;
-		nLocate = 0;
-
 		// generate travel time file
 		// NOTE: Move to stand alone program
 		// if (v == "GenTrv") {
-		// return (genTrv(com));
+		// return((genTrv(com));
 		// }
 
 		// test travel time classes
 		// NOTE: Move to unit tests.
 		// if (v == "TestTTT") {
 		// testTTT(com);
-		// return (true);
+		// return(true);
 		// }
 
 		// Initialize glass
 		if (v == "Initialize") {
-			return (initialize(com));
+			return(initialize(com));
 		}
 
 		// clear glass configuration
@@ -132,27 +124,27 @@ bool CGlass::dispatch(json::Object *com) {
 
 			glassutil::CLogit::log(glassutil::log_level::debug,
 									"CGlass::dispatch: Cmd is:" + v.ToString());
-			return (false);
+			return(false);
 		}
 
 		// send any other commands to any of the configurable / input classes
 		if (pPickList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pSiteList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pHypoList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pCorrelationList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pDetection->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pWebList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 	}
 
@@ -161,21 +153,21 @@ bool CGlass::dispatch(json::Object *com) {
 			&& ((*com)["Type"].GetType() == json::ValueType::StringVal)) {
 		// send any input to any of the input processing classes
 		if (pPickList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pSiteList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pCorrelationList->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 		if (pDetection->dispatch(com)) {
-			return (true);
+			return(true);
 		}
 	}
 
 	// this communication was not handled
-	return (false);
+	return(false);
 }
 
 // ---------------------------------------------------------send
@@ -186,11 +178,11 @@ bool CGlass::send(json::Object *com) {
 		piSend->Send(com);
 
 		// done
-		return (true);
+		return(true);
 	}
 
 	// communication not sent
-	return (false);
+	return(false);
 }
 
 // ---------------------------------------------------------Clear
@@ -231,7 +223,7 @@ bool CGlass::initialize(json::Object *com) {
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CGlass::initialize: NULL json.");
-		return (false);
+		return(false);
 	}
 
 	// check cmd
@@ -243,14 +235,14 @@ bool CGlass::initialize(json::Object *com) {
 			glassutil::CLogit::log(
 					glassutil::log_level::warn,
 					"CGlass::initialize: Non-Initialize Cmd passed in.");
-			return (false);
+			return(false);
 		}
 	} else {
 		// no command or type
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CGlass::initialize: Missing required Cmd Key.");
-		return (false);
+		return(false);
 	}
 
 	// Reset parameters
@@ -443,7 +435,7 @@ bool CGlass::initialize(json::Object *com) {
 	} else {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"No association Phase array provided");
-		return (false);
+		return(false);
 	}
 
 	// setup if we are going to print phase travel times for debuging
@@ -834,20 +826,6 @@ bool CGlass::initialize(json::Object *com) {
 				"parameters");
 	}
 
-	// bTrack
-	if ((com->HasKey("Track"))
-			&& ((*com)["Track"].GetType() == json::ValueType::BoolVal)) {
-		bTrack = (*com)["Track"].ToBool();
-
-		if (bTrack) {
-			glassutil::CLogit::log(glassutil::log_level::info,
-									"CGlass::initialize: Track set to true");
-		} else {
-			glassutil::CLogit::log(glassutil::log_level::info,
-									"CGlass::initialize: Track set to false");
-		}
-	}
-
 	// Test Locator
 	if ((com->HasKey("TestLocator"))
 			&& ((*com)["TestLocator"].GetType() == json::ValueType::BoolVal)) {
@@ -1059,7 +1037,7 @@ bool CGlass::initialize(json::Object *com) {
 	pDetection = new CDetection();
 	pDetection->setGlass(this);
 
-	return (true);
+	return(true);
 }
 
 /* NOTE: Leave these in place as examples for Travel Time unit tests.
@@ -1077,7 +1055,7 @@ bool CGlass::initialize(json::Object *com) {
 
  bool bload = terra->load(mdl.c_str());
  if (!bload)
- return false;
+ return(false;
  printf("Terra nLayer:%ld dRadius:%.2f\n", terra->nLayer, terra->dRadius);
  double r = terra->dRadius;
 
@@ -1096,7 +1074,7 @@ bool CGlass::initialize(json::Object *com) {
  printf("T %6.2f %6.2f %6.2f %6.2f\n", deg, t1, t2, t2 - t1);
  }
 
- return true;
+ return(true;
  }
 
  // ---------------------------------------------------------GenTrv
@@ -1107,7 +1085,7 @@ bool CGlass::initialize(json::Object *com) {
  gentrv = new CGenTrv();
  bool bres = gentrv->Generate(com);
  delete gentrv;
- return bres;
+ return(bres;
  }
 
  // ---------------------------------------------------------TestTTT
@@ -1157,7 +1135,7 @@ bool CGlass::initialize(json::Object *com) {
 // It is used for pruning and association, and is roughly
 // analogous to residual pruning in least squares approaches
 double CGlass::sig(double x, double sigma) {
-	return exp(-0.5 * x * x / sigma / sigma);
+	return(exp(-0.5 * x * x / sigma / sigma));
 }
 // ---------------------------------------------------------Sig
 // Calculate the laplacian significance function, which is just
@@ -1165,9 +1143,9 @@ double CGlass::sig(double x, double sigma) {
 // analogous to residual pruning in L1 approach.
 double CGlass::sig_laplace_pdf(double x, double sigma) {
 	if (x > 0) {
-		return (1. / (2. * sigma)) * exp(-1. * x / sigma);
+		return((1. / (2. * sigma)) * exp(-1. * x / sigma));
 	} else {
-		return (1. / (2. * sigma)) * exp(x / sigma);
+		return((1. / (2. * sigma)) * exp(x / sigma));
 	}
 }
 
@@ -1175,25 +1153,184 @@ double CGlass::sig_laplace_pdf(double x, double sigma) {
 bool CGlass::statusCheck() {
 	// nullcheck
 	if (pPickList == NULL) {
-		return (false);
+		return(false);
 	}
 
 	// check pick list
 	if (pPickList->statusCheck() == false) {
-		return (false);
+		return(false);
 	}
 
 	// hypo list
 	if (pHypoList->statusCheck() == false) {
-		return (false);
+		return(false);
 	}
 
 	// webs
 	if (pWebList->statusCheck() == false) {
-		return (false);
+		return(false);
 	}
 
 	// all is well
-	return (true);
+	return(true);
 }
+
+double CGlass::getAvgDelta() const {
+	return(avgDelta);
+}
+
+double CGlass::getAvgSigma() const {
+	return(avgSigma);
+}
+
+double CGlass::getBeamMatchingAzimuthWindow() const {
+	return(beamMatchingAzimuthWindow);
+}
+
+double CGlass::getBeamMatchingDistanceWindow() const {
+	return(beamMatchingDistanceWindow);
+}
+
+int CGlass::getCorrelationCancelAge() const {
+	return(correlationCancelAge);
+}
+
+double CGlass::getCorrelationMatchingTWindow() const {
+	return(correlationMatchingTWindow);
+}
+
+double CGlass::getCorrelationMatchingXWindow() const {
+	return(correlationMatchingXWindow);
+}
+
+double CGlass::getCutFactor() const {
+	return(dCutFactor);
+}
+
+double CGlass::getCutMin() const {
+	return(dCutMin);
+}
+
+double CGlass::getCutPercentage() const {
+	return(dCutPercentage);
+}
+
+double CGlass::getReportThresh() const {
+	return(dReportThresh);
+}
+
+double CGlass::getThresh() const {
+	return(dThresh);
+}
+
+double CGlass::getExpAffinity() const {
+	return(expAffinity);
+}
+
+bool CGlass::getGraphicsOut() const {
+	return(graphicsOut);
+}
+
+const std::string& CGlass::getGraphicsOutFolder() const {
+	return(graphicsOutFolder);
+}
+
+double CGlass::getGraphicsStepKm() const {
+	return(graphicsStepKM);
+}
+
+int CGlass::getGraphicsSteps() const {
+	return(graphicsSteps);
+}
+
+int CGlass::getCycleLimit() const {
+	return(iCycleLimit);
+}
+
+bool CGlass::getMinimizeTtLocator() const {
+	return(minimizeTTLocator);
+}
+
+int CGlass::getCorrelationMax() const {
+	return(nCorrelationMax);
+}
+
+int CGlass::getDetect() const {
+	return(nDetect);
+}
+
+int CGlass::getHypoMax() const {
+	return(nHypoMax);
+}
+
+int CGlass::getNucleate() const {
+	return(nNucleate);
+}
+
+int CGlass::getPickMax() const {
+	return(nPickMax);
+}
+
+double CGlass::getReportCut() const {
+	return(nReportCut);
+}
+
+int CGlass::getSitePickMax() const {
+	return(nSitePickMax);
+}
+
+CCorrelationList*& CGlass::getCorrelationList() {
+	return(pCorrelationList);
+}
+
+CDetection*& CGlass::getDetection() {
+	return(pDetection);
+}
+
+CHypoList*& CGlass::getHypoList() {
+	return(pHypoList);
+}
+
+double CGlass::getPickDuplicateWindow() const {
+	return(pickDuplicateWindow);
+}
+
+CPickList*& CGlass::getPickList() {
+	return(pPickList);
+}
+
+CSiteList*& CGlass::getSiteList() {
+	return(pSiteList);
+}
+
+std::shared_ptr<traveltime::CTravelTime>& CGlass::getTrvDefault() {
+	std::lock_guard<std::mutex> ttGuard(m_TTTMutex);
+	return(pTrvDefault);
+}
+
+traveltime::CTTT*& CGlass::getTTT() {
+	std::lock_guard<std::mutex> ttGuard(m_TTTMutex);
+	return(pTTT);
+}
+
+CWebList*& CGlass::getWebList() {
+	return(pWebList);
+}
+
+double CGlass::getSdAssociate() const {
+	return(sdAssociate);
+}
+
+double CGlass::getSdPrune() const {
+	return(sdPrune);
+}
+
+bool CGlass::getTestLocator() const {
+	return(testLocator);
+}
+
+bool CGlass::getTestTimes() const {
+	return(testTimes);
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -2753,4 +2753,21 @@ int CHypo::getReportCount() const {
 	return (reportCount);
 }
 
+bool CHypo::isLockedForProcessing() {
+	if (processingMutex.try_lock() == false) {
+		return (true);
+	}
+
+	processingMutex.unlock();
+	return (false);
+}
+
+void CHypo::lockForProcessing() {
+	processingMutex.lock();
+}
+
+void CHypo::unlockAfterProcessing() {
+	processingMutex.unlock();
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -93,7 +93,7 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 	}
 
 	// lock for trv copying
-	std::lock_guard < std::mutex > ttGuard(node->pWeb->m_TrvMutex);
+	std::lock_guard<std::mutex> ttGuard(node->pWeb->m_TrvMutex);
 
 	if (!initialize(node->dLat, node->dLon, node->dZ, node->tOrg,
 					glassutil::CPid::pid(), node->pWeb->sName, 0.0,
@@ -139,7 +139,7 @@ CHypo::~CHypo() {
 // ---------------------------------------------------------clear
 void CHypo::clear() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	dLat = 0.0;
 	dLon = 0.0;
@@ -152,7 +152,7 @@ void CHypo::clear() {
 	dBayesInitial = 0.0;
 	iCycle = 0;
 	nWts = 0;
-	sWeb = "";
+	sWebName = "";
 	dMed = 0;
 	dMin = 0;
 	dGap = 0;
@@ -165,8 +165,6 @@ void CHypo::clear() {
 	dCutMin = 30.0;
 
 	bFixed = false;
-	bRefine = false;
-	bQuake = false;
 	bEvent = false;
 
 	pGlass = NULL;
@@ -204,7 +202,7 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 						traveltime::CTravelTime* secondTrav,
 						traveltime::CTTT *ttt, double resolution) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	clear();
 
@@ -213,7 +211,7 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 	dZ = z;
 	tOrg = time;
 	sPid = pid;
-	sWeb = web;
+	sWebName = web;
 	dBayes = bayes;
 	dBayesInitial = bayes;
 
@@ -229,7 +227,7 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 			"CHypo::initialize: lat:" + std::to_string(dLat) + "; lon:"
 					+ std::to_string(dLon) + "; z:" + std::to_string(dZ)
 					+ "; t:" + std::to_string(tOrg) + "; sPid:" + sPid
-					+ "; web:" + sWeb + "; bayes:" + std::to_string(dBayes)
+					+ "; web:" + sWebName + "; bayes:" + std::to_string(dBayes)
 					+ "; thresh:" + std::to_string(dThresh) + "; cut:"
 					+ std::to_string(nCut) + "; resolution:"
 					+ std::to_string(dRes));
@@ -254,7 +252,7 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 // ---------------------------------------------------------addPick
 void CHypo::addPick(std::shared_ptr<CPick> pck) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (pck == NULL) {
@@ -282,17 +280,10 @@ void CHypo::addPick(std::shared_ptr<CPick> pck) {
 	vPick.push_back(pck);
 }
 
-void CHypo::incrementProcessCount() {
-	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
-
-	processCount++;
-}
-
 // ---------------------------------------------------------remPick
 void CHypo::remPick(std::shared_ptr<CPick> pck) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (pck == NULL) {
@@ -321,7 +312,7 @@ void CHypo::remPick(std::shared_ptr<CPick> pck) {
 
 bool CHypo::hasPick(std::shared_ptr<CPick> pck) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (pck == NULL) {
@@ -343,7 +334,7 @@ bool CHypo::hasPick(std::shared_ptr<CPick> pck) {
 
 void CHypo::clearPicks() {
 	// lock the hypo since we're iterating through it's lists
-	std::lock_guard < std::recursive_mutex > hypoGuard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 
 	// go through all the picks linked to this hypo
 	for (auto pck : vPick) {
@@ -365,7 +356,7 @@ void CHypo::clearPicks() {
 // ---------------------------------------------------------addPick
 void CHypo::addCorrelation(std::shared_ptr<CCorrelation> corr) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (corr == NULL) {
@@ -398,7 +389,7 @@ void CHypo::addCorrelation(std::shared_ptr<CCorrelation> corr) {
 // ---------------------------------------------------------remPick
 void CHypo::remCorrelation(std::shared_ptr<CCorrelation> corr) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (corr == NULL) {
@@ -426,7 +417,7 @@ void CHypo::remCorrelation(std::shared_ptr<CCorrelation> corr) {
 
 bool CHypo::hasCorrelation(std::shared_ptr<CCorrelation> corr) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (corr == NULL) {
@@ -448,7 +439,7 @@ bool CHypo::hasCorrelation(std::shared_ptr<CCorrelation> corr) {
 
 void CHypo::clearCorrelations() {
 	// lock the hypo since we're iterating through it's lists
-	std::lock_guard < std::recursive_mutex > hypoGuard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 
 	// go through all the picks linked to this hypo
 	for (auto corr : vCorr) {
@@ -501,7 +492,7 @@ double CHypo::Rand(double x, double y) {
 // ---------------------------------------------------------Hypo
 json::Object CHypo::hypo() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	json::Object hypo;
 	// null check
@@ -526,8 +517,8 @@ json::Object CHypo::hypo() {
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CHypo::Hypo: generating hypo message for sPid:" + sPid + " sWeb:"
-					+ sWeb);
+			"CHypo::Hypo: generating hypo message for sPid:" + sPid + " sWebName:"
+					+ sWebName);
 
 	// NOTE: Need to think about this format, currently it *almost*
 	// creates a detection formats json, but doesn't use the library
@@ -561,7 +552,7 @@ json::Object CHypo::hypo() {
 	hypo["Gap"] = dGap;
 	hypo["Bayes"] = dBayes;
 	hypo["InitialBayes"] = dBayesInitial;
-	hypo["Web"] = sWeb;
+	hypo["Web"] = sWebName;
 
 	// generate data array for this hypo
 	// set up traveltime object
@@ -605,7 +596,8 @@ json::Object CHypo::hypo() {
 			pickObj["Site"] = site->sScnl;
 			pickObj["Pid"] = pick->getPid();
 			pickObj["T"] = glassutil::CDate::encodeDateTime(pick->getTPick());
-			pickObj["Time"] = glassutil::CDate::encodeISO8601Time(pick->getTPick());
+			pickObj["Time"] = glassutil::CDate::encodeISO8601Time(
+					pick->getTPick());
 			pickObj["Distance"] = geo.delta(&site->geo) / DEG2RAD;
 			pickObj["Azimuth"] = geo.azimuth(&site->geo) / DEG2RAD;
 			pickObj["Residual"] = tres;
@@ -673,7 +665,7 @@ json::Object CHypo::hypo() {
 // ---------------------------------------------------------Event
 void CHypo::event() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	bEvent = true;
 	reportCount++;
@@ -706,7 +698,7 @@ void CHypo::event() {
 bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 						double sdassoc) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null check
 	if (pick == NULL) {
@@ -837,7 +829,7 @@ bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 						double xWindow) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// NOTE: this is a simple time/distance check for association
 	// wiser heads than mine may come up with a more robust approach JMP
@@ -912,7 +904,7 @@ bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 // ---------------------------------------------------------affinity
 double CHypo::affinity(std::shared_ptr<CPick> pck) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// null checks
 	if (pck == NULL) {
@@ -963,7 +955,7 @@ double CHypo::affinity(std::shared_ptr<CPick> pck) {
 // ---------------------------------------------------------affinity
 double CHypo::affinity(std::shared_ptr<CCorrelation> corr) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// NOTE: I'm just combining time/distance into a made up affinity
 	// wiser heads than mine may come up with a more robust approach JMP
@@ -1013,7 +1005,7 @@ double CHypo::affinity(std::shared_ptr<CCorrelation> corr) {
 // ---------------------------------------------------------prune
 bool CHypo::prune() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// nullcheck
 	if (pGlass == NULL) {
@@ -1028,7 +1020,7 @@ bool CHypo::prune() {
 							"CHypo::prune. " + sPid);
 
 	// set up local vector to track picks to remove
-	std::vector < std::shared_ptr < CPick >> vremove;
+	std::vector<std::shared_ptr<CPick>> vremove;
 
 	// set up a geographic object for this hypo
 	glassutil::CGeo geo;
@@ -1044,9 +1036,10 @@ bool CHypo::prune() {
 			// pick no longer associates, add to remove list
 			vremove.push_back(pck);
 			// if (pGlass->bTrack) {
-			snprintf(sLog, sizeof(sLog), "CHypo::prune: CUL %s %s (%.2f)",
-						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-						pck->getSite()->sScnl.c_str(), sdprune);
+			snprintf(
+					sLog, sizeof(sLog), "CHypo::prune: CUL %s %s (%.2f)",
+					glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
+					pck->getSite()->sScnl.c_str(), sdprune);
 			glassutil::CLogit::log(sLog);
 			// }
 
@@ -1060,10 +1053,10 @@ bool CHypo::prune() {
 
 		// check if delta is beyond distance limit
 		if (delta > dCut) {
-			snprintf(sLog, sizeof(sLog),
-						"CHypo::prune: CUL %s %s (%.2f > %.2f)",
-						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-						pck->getSite()->sScnl.c_str(), delta, dCut);
+			snprintf(
+					sLog, sizeof(sLog), "CHypo::prune: CUL %s %s (%.2f > %.2f)",
+					glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
+					pck->getSite()->sScnl.c_str(), delta, dCut);
 			glassutil::CLogit::log(sLog);
 
 			// add pick to remove list
@@ -1086,7 +1079,7 @@ bool CHypo::prune() {
 			"CHypo::prune pick pruneCount:" + std::to_string(pruneCount));
 
 	// set up local vector to track correlations to remove
-	std::vector < std::shared_ptr < CCorrelation >> vcremove;
+	std::vector<std::shared_ptr<CCorrelation>> vcremove;
 
 	// get the correlation windows
 	double tWindow = pGlass->correlationMatchingTWindow;
@@ -1129,7 +1122,7 @@ bool CHypo::prune() {
 // ---------------------------------------------------------cancel
 bool CHypo::cancel() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// nullcheck
 	if (pGlass == NULL) {
@@ -1253,7 +1246,7 @@ bool CHypo::cancel() {
 // ---------------------------------------------------------cancel
 bool CHypo::reportCheck() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// nullcheck
 	if (pGlass == NULL) {
@@ -1310,7 +1303,7 @@ bool CHypo::reportCheck() {
 // ---------------------------------------------------------stats
 void CHypo::stats() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// Calculate the statistical distribution of distance
 	// histogram for culling purposes. The actual values are
@@ -1424,14 +1417,14 @@ void CHypo::summary() {
 	snprintf(sLog, sizeof(sLog),
 				"CHypo::summary: %s%7.2f%8.2f%6.1f%6.1f%6.1f%5d (%5.1f) %s",
 				sorg.c_str(), dLat, dLon, dZ, dMin, dGap,
-				static_cast<int>(vPick.size()), dBayes, sWeb.c_str());
+				static_cast<int>(vPick.size()), dBayes, sWebName.c_str());
 	glassutil::CLogit::log(sLog);
 }
 
 // ---------------------------------------------------------list
 void CHypo::list(std::string src) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	if (pGlass == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -1469,7 +1462,7 @@ void CHypo::list(std::string src) {
 			"CHypo::list: ** %s **\\nPid:%s\nGap:%.1f Dmin:%.1f Dmedian:%.1f"
 			"\nSigma:%.2f Kurtosis:%.2f\nWeb:%s",
 			sorg.c_str(), sPid.c_str(), dGap, dMin, dMed, dSig, dKrt,
-			sWeb.c_str());
+			sWebName.c_str());
 	glassutil::CLogit::log(sLog);
 
 	// setup traveltime interface for this hypo
@@ -1480,7 +1473,7 @@ void CHypo::list(std::string src) {
 	geo.setGeographic(dLat, dLon, 6371.0 - dZ);
 
 	// create local pick vector
-	std::vector < std::shared_ptr < CPick >> vpick;
+	std::vector<std::shared_ptr<CPick>> vpick;
 
 	// copy picks to the local pick vector
 	for (auto pick : vPick) {
@@ -1488,8 +1481,8 @@ void CHypo::list(std::string src) {
 	}
 
 	// generate list of rogue picks
-	std::vector < std::shared_ptr < CPick >> pickRogues = pGlass->pPickList
-			->rogues(sPid, tOrg);
+	std::vector<std::shared_ptr<CPick>> pickRogues = pGlass->pPickList->rogues(
+			sPid, tOrg);
 
 	// add rogue picks to the local pick vector
 	for (auto pick : pickRogues) {
@@ -1565,7 +1558,7 @@ void CHypo::list(std::string src) {
 double CHypo::anneal(int nIter, double dStart, double dStop, double tStart,
 						double tStop) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// This is essentially a faster algorithmic implementation of iterate
 	// nullcheck
@@ -1592,7 +1585,7 @@ double CHypo::anneal(int nIter, double dStart, double dStop, double tStart,
 	stats();
 
 	// create pick delete vector
-	std::vector < std::shared_ptr < CPick >> vkill;
+	std::vector<std::shared_ptr<CPick>> vkill;
 
 	// set the traveltime for the current hypo
 	if (pTrv1 != NULL) {
@@ -1667,7 +1660,7 @@ double CHypo::anneal(int nIter, double dStart, double dStop, double tStart,
 // ---------------------------------------------------------localize
 double CHypo::localize() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// Localize this hypo
 	// nullcheck
@@ -1762,7 +1755,7 @@ double CHypo::localize() {
 void CHypo::annealingLocate(int nIter, double dStart, double dStop,
 							double tStart, double tStop, int nucleate) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// don't locate if the location is fixed
 	if (bFixed) {
@@ -1910,7 +1903,7 @@ void CHypo::annealingLocate(int nIter, double dStart, double dStop,
 double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 						int nucleate) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	if (pTTT == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -1993,7 +1986,7 @@ double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 void CHypo::annealingLocateResidual(int nIter, double dStart, double dStop,
 									double tStart, double tStop, int nucleate) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	if (pTTT == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -2121,7 +2114,7 @@ void CHypo::annealingLocateResidual(int nIter, double dStart, double dStop,
 double CHypo::getSumAbsResidual(double xlat, double xlon, double xZ, double oT,
 								int nucleate) {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	if (pTTT == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -2185,7 +2178,7 @@ double CHypo::getSumAbsResidual(double xlat, double xlon, double xZ, double oT,
 // ---------------------------------------------------graphicsOutput
 void CHypo::graphicsOutput() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	if (pTTT == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -2242,7 +2235,7 @@ void CHypo::graphicsOutput() {
 // ---------------------------------------------------------trap
 void CHypo::trap() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	char sLog[1024];
 
@@ -2281,7 +2274,7 @@ void CHypo::trap() {
 // ---------------------------------------------------------weights
 bool CHypo::weights() {
 	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
 	// Calculate station weight from distance and nearby stations
 	// to reduce biases induced by network density
@@ -2361,21 +2354,9 @@ bool CHypo::weights() {
 	return (true);
 }
 
-void CHypo::setCycle(int newCycle) {
-	// lock mutex for this scope
-	std::lock_guard < std::recursive_mutex > guard(hypoMutex);
-
-	iCycle = newCycle;
-
-	glassutil::CLogit::log(
-			glassutil::log_level::debug,
-			"CHypo::setCycle sPid:" + sPid + " cycle: "
-					+ std::to_string(iCycle));
-}
-
 bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 	// lock the hypo since we're iterating through it's lists
-	std::lock_guard < std::recursive_mutex > hypoGuard(hypoMutex);
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 
 	// nullchecks
 	if (pGlass == NULL) {
@@ -2444,8 +2425,10 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 			// this pick has a higher affinity with the provided hypo
 			if (pGlass->bTrack) {
 				snprintf(
-						sLog, sizeof(sLog),
-						"CHypo::resolve: SCV %s %s %s %s (%.2f)", sPid.c_str(),
+						sLog,
+						sizeof(sLog),
+						"CHypo::resolve: SCV %s %s %s %s (%.2f)",
+						sPid.c_str(),
 						sOtherPid.c_str(),
 						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
 						pck->getSite()->sScnl.c_str(), aff1);
@@ -2572,4 +2555,204 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 
 	return (bAss);
 }
+
+double CHypo::getLat() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dLat);
+}
+
+double CHypo::getLon() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dLon);
+}
+
+double CHypo::getZ() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dZ);
+}
+
+double CHypo::getTOrg() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (tOrg);
+}
+
+double CHypo::getBayes() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dBayes);
+}
+
+bool CHypo::getCorrAdded() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (bCorrAdded);
+}
+
+void CHypo::setCorrAdded(bool corrAdded) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	bCorrAdded = corrAdded;
+}
+
+bool CHypo::getEvent() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (bEvent);
+}
+
+bool CHypo::getFixed() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (bFixed);
+}
+
+void CHypo::setFixed(bool fixed) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	bFixed = fixed;
+}
+
+double CHypo::getBayesInitial() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dBayesInitial);
+}
+
+double CHypo::getCutFactor()  {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dCutFactor);
+}
+
+void CHypo::setCutFactor(double cutFactor) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	dCutFactor = cutFactor;
+}
+
+double CHypo::getCutMin() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dCutMin);
+}
+
+void CHypo::setCutMin(double cutMin) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	dCutMin = cutMin;
+}
+
+double CHypo::getCutPercentage() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dCutPercentage);
+}
+
+void CHypo::setCutPercentage(double cutPercentage) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	dCutPercentage = cutPercentage;
+}
+
+double CHypo::getGap() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dGap);
+}
+
+double CHypo::getKrt() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dKrt);
+}
+
+double CHypo::getMed() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dMed);
+}
+
+double CHypo::getMin() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dMin);
+}
+
+double CHypo::getRes() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dRes);
+}
+
+double CHypo::getSig() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dSig);
+}
+
+double CHypo::getThresh() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (dThresh);
+}
+
+void CHypo::setThresh(double thresh) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	dThresh = thresh;
+}
+
+int CHypo::getCycle() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (iCycle);
+}
+
+int CHypo::setCycle(int newCycle) {
+	// lock mutex for this scope
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
+
+	iCycle = newCycle;
+
+	return (iCycle);
+}
+
+int CHypo::getCut() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (nCut);
+}
+
+void CHypo::setCut(double cut) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	nCut = cut;
+}
+
+const CGlass* CHypo::getGlass() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (pGlass);
+}
+
+void CHypo::setGlass(CGlass* glass) {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	pGlass = glass;
+}
+
+int CHypo::getProcessCount() {
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
+	return (processCount);
+}
+
+int CHypo::incrementProcessCount() {
+	// lock mutex for this scope
+	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
+
+	processCount++;
+
+	return (processCount);
+}
+
+const std::string& CHypo::getPid() const {
+	return (sPid);
+}
+
+const std::string& CHypo::getWebName() const {
+	return (sWebName);
+}
+
+int CHypo::getVPickSize() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (vPick.size());
+}
+int CHypo::getVCorrSize() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (vCorr.size());
+}
+
+double CHypo::getTCreate() const {
+	return (tCreate);
+}
+
+int CHypo::getReportCount() {
+	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
+	return (reportCount);
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -1894,7 +1894,7 @@ double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 		return (0);
 	}
 
-	if (pTTT == NULL) {
+	if (!pTTT) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CHypo::getBayes: NULL pTTT.");
 		return (0);
@@ -1940,7 +1940,7 @@ double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 
 		// only use nucleation phases if on nucleation branch
 		if (nucleate == 1) {
-			if ((pTrv1) && (pTrv1)) {
+			if ((pTrv1) && (pTrv2)) {
 				// we have both nucleation phases
 				// first nucleation phase
 				// calculate the residual using the phase name

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -94,8 +94,8 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 
 	if (!initialize(node->getLat(), node->getLon(), node->getZ(),
 					node->getTOrg(), glassutil::CPid::pid(),
-					node->getWeb()->getName(), 0.0, node->getWeb()->getThresh(),
-					node->getWeb()->getNucleate(),
+					node->getWeb()->getName(), node->getSum(),
+					node->getWeb()->getThresh(), node->getWeb()->getNucleate(),
 					node->getWeb()->getTrv1().get(),
 					node->getWeb()->getTrv2().get(), ttt,
 					node->getResolution())) {
@@ -1780,11 +1780,6 @@ void CHypo::annealingLocate(int nIter, double dStart, double dStop,
 				<< std::to_string(valStart) << " 0 0 0 \n";
 	}
 
-	snprintf(sLog, sizeof(sLog), "CHypo::annealingLocate: old bayes value "
-				"%.4f sPid:%s",
-				valStart, sPid.c_str());
-	glassutil::CLogit::log(sLog);
-
 	// set the starting location as the current best stack value
 	valBest = valStart;
 
@@ -1875,15 +1870,14 @@ void CHypo::annealingLocate(int nIter, double dStart, double dStop,
 	if (nucleate == 1) {
 		dBayesInitial = valBest;
 	}
-	snprintf(sLog, sizeof(sLog),
-				"CHypo::annealingLocate: total movement (%.4f,%.4f,%.4f,%.4f)"
-				" (%.4f,%.4f,%.4f,%.4f) sPid:%s",
-				dLat, dLon, dZ, tOrg, ddx, ddy, ddz, ddt, sPid.c_str());
-	glassutil::CLogit::log(sLog);
 
-	snprintf(sLog, sizeof(sLog), "CHypo::annealingLocate: new bayes value "
-				"%.4f sPid:%s",
-				valBest, sPid.c_str());
+	snprintf(
+			sLog, sizeof(sLog),
+			"CHypo::annealingLocate: total movement (%.4f,%.4f,%.4f,%.4f)"
+			" (%.4f,%.4f,%.4f,%.4f) sPid:%s; new bayes value:%.4f; old bayes"
+			" value:%.4f",
+			dLat, dLon, dZ, tOrg, ddx, ddy, ddz, ddt, sPid.c_str(), valBest,
+			valStart);
 	glassutil::CLogit::log(sLog);
 
 	if (pGlass->getGraphicsOut() == true) {

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -84,22 +84,22 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 		return;
 	}
 
-	if (node->pWeb == NULL) {
+	if (node->getWeb() == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
-								"CHypo::CHypo: NULL node->pWeb.");
+								"CHypo::CHypo: NULL node->getWeb().");
 
 		clear();
 		return;
 	}
 
 	// lock for trv copying
-	std::lock_guard<std::mutex> ttGuard(node->pWeb->m_TrvMutex);
+	std::lock_guard<std::mutex> ttGuard(node->getWeb()->m_TrvMutex);
 
-	if (!initialize(node->dLat, node->dLon, node->dZ, node->tOrg,
-					glassutil::CPid::pid(), node->pWeb->sName, 0.0,
-					node->pWeb->dThresh, node->pWeb->nNucleate,
-					node->pWeb->pTrv1.get(), node->pWeb->pTrv2.get(), ttt,
-					node->dResolution)) {
+	if (!initialize(node->getLat(), node->getLon(), node->getZ(), node->getTOrg(),
+					glassutil::CPid::pid(), node->getWeb()->sName, 0.0,
+					node->getWeb()->dThresh, node->getWeb()->nNucleate,
+					node->getWeb()->pTrv1.get(), node->getWeb()->pTrv2.get(), ttt,
+					node->getResolution())) {
 		clear();
 	}
 }

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -15,7 +15,7 @@
 #include "HypoList.h"
 #include "Pick.h"
 #include "Correlation.h"
-#include "Node.h"
+#include "Trigger.h"
 #include "Web.h"
 #include "Glass.h"
 #include "Logit.h"
@@ -67,7 +67,7 @@ CHypo::CHypo(double lat, double lon, double z, double time, std::string pid,
 }
 
 // ---------------------------------------------------------CHypo
-CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
+CHypo::CHypo(std::shared_ptr<CTrigger> trigger, traveltime::CTTT *ttt) {
 	// seed the random number generator
 	std::random_device randomDevice;
 	m_RandomGenerator.seed(randomDevice());
@@ -76,7 +76,7 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 	pTrv2 = NULL;
 
 	// null checks
-	if (node == NULL) {
+	if (trigger == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CHypo::CHypo: NULL node.");
 
@@ -84,7 +84,7 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 		return;
 	}
 
-	if (node->getWeb() == NULL) {
+	if (trigger->getWeb() == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CHypo::CHypo: NULL node->getWeb().");
 
@@ -92,13 +92,14 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 		return;
 	}
 
-	if (!initialize(node->getLat(), node->getLon(), node->getZ(),
-					node->getTOrg(), glassutil::CPid::pid(),
-					node->getWeb()->getName(), node->getSum(),
-					node->getWeb()->getThresh(), node->getWeb()->getNucleate(),
-					node->getWeb()->getTrv1().get(),
-					node->getWeb()->getTrv2().get(), ttt,
-					node->getResolution())) {
+	if (!initialize(trigger->getLat(), trigger->getLon(), trigger->getZ(),
+					trigger->getTOrg(), glassutil::CPid::pid(),
+					trigger->getWeb()->getName(), trigger->getSum(),
+					trigger->getWeb()->getThresh(),
+					trigger->getWeb()->getNucleate(),
+					trigger->getWeb()->getTrv1().get(),
+					trigger->getWeb()->getTrv2().get(), ttt,
+					trigger->getResolution())) {
 		clear();
 	}
 }

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -95,11 +95,11 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 	// lock for trv copying
 	std::lock_guard<std::mutex> ttGuard(node->getWeb()->m_TrvMutex);
 
-	if (!initialize(node->getLat(), node->getLon(), node->getZ(), node->getTOrg(),
-					glassutil::CPid::pid(), node->getWeb()->sName, 0.0,
-					node->getWeb()->dThresh, node->getWeb()->nNucleate,
-					node->getWeb()->pTrv1.get(), node->getWeb()->pTrv2.get(), ttt,
-					node->getResolution())) {
+	if (!initialize(node->getLat(), node->getLon(), node->getZ(),
+					node->getTOrg(), glassutil::CPid::pid(),
+					node->getWeb()->sName, 0.0, node->getWeb()->dThresh,
+					node->getWeb()->nNucleate, node->getWeb()->pTrv1.get(),
+					node->getWeb()->pTrv2.get(), ttt, node->getResolution())) {
 		clear();
 	}
 }
@@ -871,7 +871,8 @@ bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 					" Corr:%s tDist:%.2f<tWindow:%.2f"
 					" xDist:%.2f>xWindow:%.2f)",
 					sPid.c_str(),
-					glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
+					glassutil::CDate::encodeDateTime(corr->getTCorrelation())
+							.c_str(),
 					corr->getSite()->getScnl().c_str(), corr->getPid().c_str(),
 					tDist, tWindow, xDist, xWindow);
 			glassutil::CLogit::log(sLog);
@@ -882,22 +883,24 @@ bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 
 	if (xDist == 0) {
 		snprintf(
-				sLog, sizeof(sLog),
+				sLog,
+				sizeof(sLog),
 				"CHypo::associate: C-NOASSOC Hypo:%s Time:%s Station:%s Corr:%s"
 				" tDist:%.2f>tWindow:%.2f",
 				sPid.c_str(),
 				glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-				corr->getSite()->getScnl().c_str(), corr->getPid().c_str(), tDist,
-				tWindow);
+				corr->getSite()->getScnl().c_str(), corr->getPid().c_str(),
+				tDist, tWindow);
 	} else {
 		snprintf(
-				sLog, sizeof(sLog),
+				sLog,
+				sizeof(sLog),
 				"CHypo::associate: C-NOASSOC Hypo:%s Time:%s Station:%s Corr:%s"
 				" tDist:%.2f<tWindow:%.2f xDist:%.2f>xWindow:%.2f)",
 				sPid.c_str(),
 				glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-				corr->getSite()->getScnl().c_str(), corr->getPid().c_str(), tDist,
-				tWindow, xDist, xWindow);
+				corr->getSite()->getScnl().c_str(), corr->getPid().c_str(),
+				tDist, tWindow, xDist, xWindow);
 	}
 	glassutil::CLogit::log(sLog);
 
@@ -1097,8 +1100,11 @@ bool CHypo::prune() {
 			vcremove.push_back(cor);
 			// if (pGlass->bTrack) {
 			snprintf(
-					sLog, sizeof(sLog), "CHypo::prune: C-CUL %s %s",
-					glassutil::CDate::encodeDateTime(cor->getTCorrelation()).c_str(),
+					sLog,
+					sizeof(sLog),
+					"CHypo::prune: C-CUL %s %s",
+					glassutil::CDate::encodeDateTime(cor->getTCorrelation())
+							.c_str(),
 					cor->getSite()->getScnl().c_str());
 			glassutil::CLogit::log(sLog);
 			// }
@@ -1542,8 +1548,8 @@ void CHypo::list(std::string src) {
 						"CHypo::list: ** %s **\nPid:%s\n%s  %s %s %.2f Dis:%.1f"
 						" Azm:%.1f Wt:NA",
 						sorg.c_str(), sPid.c_str(), sass.c_str(),
-						site->getScnl().c_str(), pTTT->sPhase.c_str(), tres, dis,
-						azm);
+						site->getScnl().c_str(), pTTT->sPhase.c_str(), tres,
+						dis, azm);
 			glassutil::CLogit::log(sLog);
 
 		} else {
@@ -1551,8 +1557,8 @@ void CHypo::list(std::string src) {
 						"CHypo::list: ** %s **\nPid:%s\n%s  %s %s %.2f Dis:%.1f"
 						" Azm:%.1f Wt:%.2f",
 						sorg.c_str(), sPid.c_str(), sass.c_str(),
-						site->getScnl().c_str(), pTTT->sPhase.c_str(), tres, dis,
-						azm, vWts[ipk]);
+						site->getScnl().c_str(), pTTT->sPhase.c_str(), tres,
+						dis, azm, vWts[ipk]);
 			glassutil::CLogit::log(sLog);
 		}
 	}
@@ -2562,32 +2568,32 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 	return (bAss);
 }
 
-double CHypo::getLat() {
+double CHypo::getLat() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dLat);
 }
 
-double CHypo::getLon() {
+double CHypo::getLon() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dLon);
 }
 
-double CHypo::getZ() {
+double CHypo::getZ() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dZ);
 }
 
-double CHypo::getTOrg() {
+double CHypo::getTOrg() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (tOrg);
 }
 
-double CHypo::getBayes() {
+double CHypo::getBayes() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dBayes);
 }
 
-bool CHypo::getCorrAdded() {
+bool CHypo::getCorrAdded() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (bCorrAdded);
 }
@@ -2597,12 +2603,12 @@ void CHypo::setCorrAdded(bool corrAdded) {
 	bCorrAdded = corrAdded;
 }
 
-bool CHypo::getEvent() {
+bool CHypo::getEvent() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (bEvent);
 }
 
-bool CHypo::getFixed() {
+bool CHypo::getFixed() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (bFixed);
 }
@@ -2612,12 +2618,12 @@ void CHypo::setFixed(bool fixed) {
 	bFixed = fixed;
 }
 
-double CHypo::getBayesInitial() {
+double CHypo::getBayesInitial() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dBayesInitial);
 }
 
-double CHypo::getCutFactor() {
+double CHypo::getCutFactor() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dCutFactor);
 }
@@ -2627,7 +2633,7 @@ void CHypo::setCutFactor(double cutFactor) {
 	dCutFactor = cutFactor;
 }
 
-double CHypo::getCutMin() {
+double CHypo::getCutMin() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dCutMin);
 }
@@ -2637,7 +2643,7 @@ void CHypo::setCutMin(double cutMin) {
 	dCutMin = cutMin;
 }
 
-double CHypo::getCutPercentage() {
+double CHypo::getCutPercentage() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dCutPercentage);
 }
@@ -2647,37 +2653,37 @@ void CHypo::setCutPercentage(double cutPercentage) {
 	dCutPercentage = cutPercentage;
 }
 
-double CHypo::getGap() {
+double CHypo::getGap() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dGap);
 }
 
-double CHypo::getKrt() {
+double CHypo::getKrt() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dKrt);
 }
 
-double CHypo::getMed() {
+double CHypo::getMed() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dMed);
 }
 
-double CHypo::getMin() {
+double CHypo::getMin() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dMin);
 }
 
-double CHypo::getRes() {
+double CHypo::getRes() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dRes);
 }
 
-double CHypo::getSig() {
+double CHypo::getSig() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dSig);
 }
 
-double CHypo::getThresh() {
+double CHypo::getThresh() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (dThresh);
 }
@@ -2687,7 +2693,7 @@ void CHypo::setThresh(double thresh) {
 	dThresh = thresh;
 }
 
-int CHypo::getCycle() {
+int CHypo::getCycle() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (iCycle);
 }
@@ -2701,7 +2707,7 @@ int CHypo::setCycle(int newCycle) {
 	return (iCycle);
 }
 
-int CHypo::getCut() {
+int CHypo::getCut() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (nCut);
 }
@@ -2711,7 +2717,7 @@ void CHypo::setCut(double cut) {
 	nCut = cut;
 }
 
-const CGlass* CHypo::getGlass() {
+const CGlass* CHypo::getGlass() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (pGlass);
 }
@@ -2721,7 +2727,7 @@ void CHypo::setGlass(CGlass* glass) {
 	pGlass = glass;
 }
 
-int CHypo::getProcessCount() {
+int CHypo::getProcessCount() const {
 	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 	return (processCount);
 }
@@ -2743,11 +2749,11 @@ const std::string& CHypo::getWebName() const {
 	return (sWebName);
 }
 
-int CHypo::getVPickSize() {
+int CHypo::getVPickSize() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (vPick.size());
 }
-int CHypo::getVCorrSize() {
+int CHypo::getVCorrSize() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (vCorr.size());
 }
@@ -2756,7 +2762,7 @@ double CHypo::getTCreate() const {
 	return (tCreate);
 }
 
-int CHypo::getReportCount() {
+int CHypo::getReportCount() const {
 	std::lock_guard<std::recursive_mutex> hypoGuard(hypoMutex);
 	return (reportCount);
 }

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -47,9 +47,9 @@ CHypo::CHypo() {
 // ---------------------------------------------------------CHypo
 CHypo::CHypo(double lat, double lon, double z, double time, std::string pid,
 				std::string web, double bayes, double thresh, int cut,
-				traveltime::CTravelTime* firstTrav,
-				traveltime::CTravelTime* secondTrav, traveltime::CTTT *ttt,
-				double resolution) {
+				std::shared_ptr<traveltime::CTravelTime> firstTrav,
+				std::shared_ptr<traveltime::CTravelTime> secondTrav,
+				std::shared_ptr<traveltime::CTTT> ttt, double resolution) {
 	// seed the random number generator
 	std::random_device randomDevice;
 	m_RandomGenerator.seed(randomDevice());
@@ -61,7 +61,8 @@ CHypo::CHypo(double lat, double lon, double z, double time, std::string pid,
 }
 
 // ---------------------------------------------------------CHypo
-CHypo::CHypo(std::shared_ptr<CTrigger> trigger, traveltime::CTTT *ttt) {
+CHypo::CHypo(std::shared_ptr<CTrigger> trigger,
+				std::shared_ptr<traveltime::CTTT> ttt) {
 	// seed the random number generator
 	std::random_device randomDevice;
 	m_RandomGenerator.seed(randomDevice());
@@ -88,17 +89,17 @@ CHypo::CHypo(std::shared_ptr<CTrigger> trigger, traveltime::CTTT *ttt) {
 					trigger->getWeb()->getName(), trigger->getSum(),
 					trigger->getWeb()->getThresh(),
 					trigger->getWeb()->getNucleate(),
-					trigger->getWeb()->getTrv1().get(),
-					trigger->getWeb()->getTrv2().get(), ttt,
-					trigger->getResolution())) {
+					trigger->getWeb()->getTrv1(), trigger->getWeb()->getTrv2(),
+					ttt, trigger->getResolution())) {
 		clear();
 	}
 }
 
 // ---------------------------------------------------------CHypo
 CHypo::CHypo(std::shared_ptr<CCorrelation> corr,
-				traveltime::CTravelTime* firstTrav,
-				traveltime::CTravelTime* secondTrav, traveltime::CTTT *ttt) {
+				std::shared_ptr<traveltime::CTravelTime> firstTrav,
+				std::shared_ptr<traveltime::CTravelTime> secondTrav,
+				std::shared_ptr<traveltime::CTTT> ttt) {
 	// seed the random number generator
 	std::random_device randomDevice;
 	m_RandomGenerator.seed(randomDevice());
@@ -178,9 +179,10 @@ void CHypo::clear() {
 bool CHypo::initialize(double lat, double lon, double z, double time,
 						std::string pid, std::string web, double bayes,
 						double thresh, int cut,
-						traveltime::CTravelTime* firstTrav,
-						traveltime::CTravelTime* secondTrav,
-						traveltime::CTTT *ttt, double resolution) {
+						std::shared_ptr<traveltime::CTravelTime> firstTrav,
+						std::shared_ptr<traveltime::CTravelTime> secondTrav,
+						std::shared_ptr<traveltime::CTTT> ttt,
+						double resolution) {
 	// lock mutex for this scope
 	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -78,7 +78,7 @@ CHypo::CHypo(std::shared_ptr<CTrigger> trigger,
 
 	if (trigger->getWeb() == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
-								"CHypo::CHypo: NULL node->getWeb().");
+								"CHypo::CHypo: NULL trigger->getWeb().");
 
 		clear();
 		return;
@@ -2450,18 +2450,6 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 		// check which affinity is better
 		if (aff1 > aff2) {
 			// this pick has a higher affinity with the provided hypo
-			/*
-			 snprintf(
-			 sLog,
-			 sizeof(sLog),
-			 "CHypo::resolve: SCV %s %s %s %s (%.2f)",
-			 sPid.c_str(),
-			 sOtherPid.c_str(),
-			 glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-			 pck->getSite()->getScnl().c_str(), aff1);
-			 glassutil::CLogit::log(sLog);
-			 */
-
 			// remove the pick from it's original hypo
 			pickHyp->remPick(pck);
 
@@ -2541,20 +2529,7 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 
 		// check which affinity is better
 		if (aff1 > aff2) {
-			// this pick has a higher affinity with the provided hypo
-			/*
-			 snprintf(
-			 sLog,
-			 sizeof(sLog),
-			 "CHypo::resolve: C SCV %s %s %s %s (%.2f)\n",
-			 sPid.c_str(),
-			 sOtherPid.c_str(),
-			 glassutil::CDate::encodeDateTime(
-			 corr->getTCorrelation()).c_str(),
-			 corr->getSite()->getScnl().c_str(), aff1);
-			 glassutil::CLogit::log(sLog);
-			 */
-
+			// this correlation has a higher affinity with the provided hypo
 			// remove the correlation from it's original hypo
 			corrHyp->remCorrelation(corr);
 

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -1149,9 +1149,10 @@ bool CHypo::cancel() {
 	char sHypo[1024];
 
 	glassutil::CDate dt = glassutil::CDate(tOrg);
-	snprintf(sHypo, sizeof(sHypo), "%s %s%9.4f%10.4f%6.1f %d", sPid.c_str(),
-				dt.dateTime().c_str(), dLat, dLon, dZ,
-				static_cast<int>(vPick.size()));
+	snprintf(sHypo, sizeof(sHypo), "CHypo::cancel: %s tOrg:%s; dLat:%9.4f; "
+				"dLon:%10.4f; dZ:%6.1f; bayes:%.2f; nPick:%d; nCorr:%d",
+				sPid.c_str(), dt.dateTime().c_str(), dLat, dLon, dZ, dBayes,
+				static_cast<int>(vPick.size()), static_cast<int>(vCorr.size()));
 
 	// check to see if there is enough supporting data for this hypocenter
 	// NOTE, in Node, ncut is used as a threshold for the number of

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -92,14 +92,13 @@ CHypo::CHypo(std::shared_ptr<CNode> node, traveltime::CTTT *ttt) {
 		return;
 	}
 
-	// lock for trv copying
-	std::lock_guard<std::mutex> ttGuard(node->getWeb()->m_TrvMutex);
-
 	if (!initialize(node->getLat(), node->getLon(), node->getZ(),
 					node->getTOrg(), glassutil::CPid::pid(),
-					node->getWeb()->sName, 0.0, node->getWeb()->dThresh,
-					node->getWeb()->nNucleate, node->getWeb()->pTrv1.get(),
-					node->getWeb()->pTrv2.get(), ttt, node->getResolution())) {
+					node->getWeb()->getName(), 0.0, node->getWeb()->getThresh(),
+					node->getWeb()->getNucleate(),
+					node->getWeb()->getTrv1().get(),
+					node->getWeb()->getTrv2().get(), ttt,
+					node->getResolution())) {
 		clear();
 	}
 }

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -269,7 +269,7 @@ void CHypo::addPick(std::shared_ptr<CPick> pck) {
 		if (q->getPid() == pck->getPid()) {
 			char sLog[1024];
 			snprintf(sLog, sizeof(sLog), "CHypo::addPick: ** Duplicate pick %s",
-						pck->getSite()->sScnl.c_str());
+						pck->getSite()->getScnl().c_str());
 			glassutil::CLogit::log(sLog);
 
 			// NOTE: shouldn't we not add this duplicate pick?
@@ -374,7 +374,7 @@ void CHypo::addCorrelation(std::shared_ptr<CCorrelation> corr) {
 			char sLog[1024];
 			snprintf(sLog, sizeof(sLog),
 						"CHypo::addCorrelation: ** Duplicate correlation %s",
-						corr->getSite()->sScnl.c_str());
+						corr->getSite()->getScnl().c_str());
 			glassutil::CLogit::log(sLog);
 
 			return;
@@ -570,7 +570,7 @@ json::Object CHypo::hypo() {
 		// get basic pick values
 		std::shared_ptr<CSite> site = pick->getSite();
 		double tobs = pick->getTPick() - tOrg;
-		double tcal = pTTT->T(&site->geo, tobs);
+		double tcal = pTTT->T(&site->getGeo(), tobs);
 		double tres = tobs - tcal;
 		// should this be changed?
 		double sig = pGlass->sig(tres, 1.0);
@@ -586,20 +586,20 @@ json::Object CHypo::hypo() {
 			// add the association info
 			json::Object assocobj;
 			assocobj["Phase"] = pTTT->sPhase;
-			assocobj["Distance"] = geo.delta(&site->geo) / DEG2RAD;
-			assocobj["Azimuth"] = geo.azimuth(&site->geo) / DEG2RAD;
+			assocobj["Distance"] = geo.delta(&site->getGeo()) / DEG2RAD;
+			assocobj["Azimuth"] = geo.azimuth(&site->getGeo()) / DEG2RAD;
 			assocobj["Residual"] = tres;
 			assocobj["Sigma"] = sig;
 			pickObj["AssociationInfo"] = assocobj;
 		} else {
 			// we don't have a jpick, so fill in what we know
-			pickObj["Site"] = site->sScnl;
+			pickObj["Site"] = site->getScnl();
 			pickObj["Pid"] = pick->getPid();
 			pickObj["T"] = glassutil::CDate::encodeDateTime(pick->getTPick());
 			pickObj["Time"] = glassutil::CDate::encodeISO8601Time(
 					pick->getTPick());
-			pickObj["Distance"] = geo.delta(&site->geo) / DEG2RAD;
-			pickObj["Azimuth"] = geo.azimuth(&site->geo) / DEG2RAD;
+			pickObj["Distance"] = geo.delta(&site->getGeo()) / DEG2RAD;
+			pickObj["Azimuth"] = geo.azimuth(&site->getGeo()) / DEG2RAD;
 			pickObj["Residual"] = tres;
 		}
 
@@ -612,7 +612,7 @@ json::Object CHypo::hypo() {
 		// get basic pick values
 		std::shared_ptr<CSite> site = correlation->getSite();
 		double tobs = correlation->getTCorrelation() - tOrg;
-		double tcal = pTTT->T(&site->geo, tobs);
+		double tcal = pTTT->T(&site->getGeo(), tobs);
 		double tres = tobs - tcal;
 		// should this be changed?
 		double sig = pGlass->sig(tres, 1.0);
@@ -629,22 +629,22 @@ json::Object CHypo::hypo() {
 			// add the association info
 			json::Object assocobj;
 			assocobj["Phase"] = pTTT->sPhase;
-			assocobj["Distance"] = geo.delta(&site->geo) / DEG2RAD;
-			assocobj["Azimuth"] = geo.azimuth(&site->geo) / DEG2RAD;
+			assocobj["Distance"] = geo.delta(&site->getGeo()) / DEG2RAD;
+			assocobj["Azimuth"] = geo.azimuth(&site->getGeo()) / DEG2RAD;
 			assocobj["Residual"] = tres;
 			assocobj["Sigma"] = sig;
 			correlationObj["AssociationInfo"] = assocobj;
 		} else {
 			// we don't have a jCorrelation, so fill in what we know
-			correlationObj["Site"] = site->sScnl;
+			correlationObj["Site"] = site->getScnl();
 			correlationObj["Pid"] = correlation->getPid();
 			correlationObj["Time"] = glassutil::CDate::encodeISO8601Time(
 					correlation->getTCorrelation());
 			correlationObj["Latitude"] = correlation->getLat();
 			correlationObj["Longitude"] = correlation->getLon();
 			correlationObj["Depth"] = correlation->getZ();
-			correlationObj["Distance"] = geo.delta(&site->geo) / DEG2RAD;
-			correlationObj["Azimuth"] = geo.azimuth(&site->geo) / DEG2RAD;
+			correlationObj["Distance"] = geo.delta(&site->getGeo()) / DEG2RAD;
+			correlationObj["Azimuth"] = geo.azimuth(&site->getGeo()) / DEG2RAD;
 			correlationObj["Residual"] = tres;
 			correlationObj["Correlation"] = correlation->getCorrelation();
 		}
@@ -733,7 +733,7 @@ bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 	std::shared_ptr<CSite> site = pick->getSite();
 
 	// compute distance
-	double siteDistance = hypoGeo.delta(&site->geo) / DEG2RAD;
+	double siteDistance = hypoGeo.delta(&site->getGeo()) / DEG2RAD;
 
 	// check if distance is beyond cutoff
 	if (siteDistance > dCut) {
@@ -745,7 +745,7 @@ bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 	double tObs = pick->getTPick() - tOrg;
 
 	// get expected travel time
-	double tCal = pTTT->T(&site->geo, tObs);
+	double tCal = pTTT->T(&site->getGeo(), tObs);
 
 	// Check if pick has an invalid travel time,
 	if (tCal < 0.0) {
@@ -756,7 +756,7 @@ bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 	// check backazimuth if present
 	if (pick->getBackAzimuth() > 0) {
 		// compute azimith from the site to the node
-		double siteAzimuth = site->geo.azimuth(&hypoGeo);
+		double siteAzimuth = site->getGeo().azimuth(&hypoGeo);
 
 		// check to see if pick's backazimuth is within the
 		// valid range
@@ -806,7 +806,7 @@ bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 		 " stdev:%.2f>sdassoc:%.2f)",
 		 sPid.c_str(),
 		 glassutil::CDate::encodeDateTime(pick->getTPick()).c_str(),
-		 pick->getSite()->sScnl.c_str(), pick->getPid().c_str(), stdev, sdassoc);
+		 pick->getSite()->getScnl().c_str(), pick->getPid().c_str(), stdev, sdassoc);
 		 glassutil::CLogit::log(sLog);
 		 */
 
@@ -819,7 +819,7 @@ bool CHypo::associate(std::shared_ptr<CPick> pick, double sigma,
 	 " stdev:%.2f>sdassoc:%.2f)",
 	 sPid.c_str(),
 	 glassutil::CDate::encodeDateTime(pick->getTPick()).c_str(),
-	 pick->getSite()->sScnl.c_str(), pick->getPid().c_str(), stdev, sdassoc);
+	 pick->getSite()->getScnl().c_str(), pick->getPid().c_str(), stdev, sdassoc);
 	 glassutil::CLogit::log(sLog);
 	 */
 
@@ -872,7 +872,7 @@ bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 					" xDist:%.2f>xWindow:%.2f)",
 					sPid.c_str(),
 					glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-					corr->getSite()->sScnl.c_str(), corr->getPid().c_str(),
+					corr->getSite()->getScnl().c_str(), corr->getPid().c_str(),
 					tDist, tWindow, xDist, xWindow);
 			glassutil::CLogit::log(sLog);
 
@@ -887,7 +887,7 @@ bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 				" tDist:%.2f>tWindow:%.2f",
 				sPid.c_str(),
 				glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-				corr->getSite()->sScnl.c_str(), corr->getPid().c_str(), tDist,
+				corr->getSite()->getScnl().c_str(), corr->getPid().c_str(), tDist,
 				tWindow);
 	} else {
 		snprintf(
@@ -896,7 +896,7 @@ bool CHypo::associate(std::shared_ptr<CCorrelation> corr, double tWindow,
 				" tDist:%.2f<tWindow:%.2f xDist:%.2f>xWindow:%.2f)",
 				sPid.c_str(),
 				glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-				corr->getSite()->sScnl.c_str(), corr->getPid().c_str(), tDist,
+				corr->getSite()->getScnl().c_str(), corr->getPid().c_str(), tDist,
 				tWindow, xDist, xWindow);
 	}
 	glassutil::CLogit::log(sLog);
@@ -1043,7 +1043,7 @@ bool CHypo::prune() {
 			snprintf(
 					sLog, sizeof(sLog), "CHypo::prune: CUL %s %s (%.2f)",
 					glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-					pck->getSite()->sScnl.c_str(), sdprune);
+					pck->getSite()->getScnl().c_str(), sdprune);
 			glassutil::CLogit::log(sLog);
 			// }
 
@@ -1053,14 +1053,14 @@ bool CHypo::prune() {
 
 		// Trim whiskers
 		// compute delta between site and hypo
-		double delta = geo.delta(&pck->getSite()->geo);
+		double delta = geo.delta(&pck->getSite()->getGeo());
 
 		// check if delta is beyond distance limit
 		if (delta > dCut) {
 			snprintf(
 					sLog, sizeof(sLog), "CHypo::prune: CUL %s %s (%.2f > %.2f)",
 					glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-					pck->getSite()->sScnl.c_str(), delta, dCut);
+					pck->getSite()->getScnl().c_str(), delta, dCut);
 			glassutil::CLogit::log(sLog);
 
 			// add pick to remove list
@@ -1099,7 +1099,7 @@ bool CHypo::prune() {
 			snprintf(
 					sLog, sizeof(sLog), "CHypo::prune: C-CUL %s %s",
 					glassutil::CDate::encodeDateTime(cor->getTCorrelation()).c_str(),
-					cor->getSite()->sScnl.c_str());
+					cor->getSite()->getScnl().c_str());
 			glassutil::CLogit::log(sLog);
 			// }
 
@@ -1338,13 +1338,13 @@ void CHypo::stats() {
 		std::shared_ptr<CSite> site = pick->getSite();
 
 		// compute the distance delta
-		double delta = geo.delta(&site->geo) / DEG2RAD;
+		double delta = geo.delta(&site->getGeo()) / DEG2RAD;
 
 		// add to distance vactor
 		dis.push_back(delta);
 
 		// compute the azimuth
-		double azimuth = geo.azimuth(&site->geo) / DEG2RAD;
+		double azimuth = geo.azimuth(&site->getGeo()) / DEG2RAD;
 
 		// add to azimuth vector
 		azm.push_back(azimuth);
@@ -1508,7 +1508,7 @@ void CHypo::list(std::string src) {
 		double tobs = pick->getTPick() - tOrg;
 
 		// get expected travel time
-		double tcal = pTTT->T(&site->geo, tobs);
+		double tcal = pTTT->T(&site->getGeo(), tobs);
 
 		// compute residual
 		double tres = tobs - tcal;
@@ -1520,10 +1520,10 @@ void CHypo::list(std::string src) {
 		}
 
 		// compute distance
-		double dis = geo.delta(&site->geo) / DEG2RAD;
+		double dis = geo.delta(&site->getGeo()) / DEG2RAD;
 
 		// compute azimuth
-		double azm = geo.azimuth(&site->geo) / DEG2RAD;
+		double azm = geo.azimuth(&site->getGeo()) / DEG2RAD;
 
 		// get the association string
 		std::string sass = pick->getAss();
@@ -1542,7 +1542,7 @@ void CHypo::list(std::string src) {
 						"CHypo::list: ** %s **\nPid:%s\n%s  %s %s %.2f Dis:%.1f"
 						" Azm:%.1f Wt:NA",
 						sorg.c_str(), sPid.c_str(), sass.c_str(),
-						site->sScnl.c_str(), pTTT->sPhase.c_str(), tres, dis,
+						site->getScnl().c_str(), pTTT->sPhase.c_str(), tres, dis,
 						azm);
 			glassutil::CLogit::log(sLog);
 
@@ -1551,7 +1551,7 @@ void CHypo::list(std::string src) {
 						"CHypo::list: ** %s **\nPid:%s\n%s  %s %s %.2f Dis:%.1f"
 						" Azm:%.1f Wt:%.2f",
 						sorg.c_str(), sPid.c_str(), sass.c_str(),
-						site->sScnl.c_str(), pTTT->sPhase.c_str(), tres, dis,
+						site->getScnl().c_str(), pTTT->sPhase.c_str(), tres, dis,
 						azm, vWts[ipk]);
 			glassutil::CLogit::log(sLog);
 		}
@@ -1610,11 +1610,11 @@ double CHypo::anneal(int nIter, double dStart, double dStop, double tStart,
 		// calculate the travel times
 		double tCal1 = -1;
 		if (pTrv1 != NULL) {
-			tCal1 = pTrv1->T(&pick->getSite()->geo);
+			tCal1 = pTrv1->T(&pick->getSite()->getGeo());
 		}
 		double tCal2 = -1;
 		if (pTrv2 != NULL) {
-			tCal2 = pTrv2->T(&pick->getSite()->geo);
+			tCal2 = pTrv2->T(&pick->getSite()->getGeo());
 		}
 
 		// calculate absolute residuals
@@ -1954,14 +1954,14 @@ double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 
 		// only use nucleation phase if on nucleation branch
 		if (nucleate == 1 && pTrv2 == NULL) {
-			tcal = pTrv1->T(&site->geo);
+			tcal = pTrv1->T(&site->getGeo());
 			resi = tobs - tcal;
 		} else if (nucleate == 1 && pTrv1 == NULL) {
-			tcal = pTrv2->T(&site->geo);
+			tcal = pTrv2->T(&site->getGeo());
 			resi = tobs - tcal;
 		} else {
 			// take whichever has the smallest residual, P or S
-			tcal = pTTT->T(&site->geo, tobs);
+			tcal = pTTT->T(&site->getGeo(), tobs);
 			if (pTTT->sPhase == "P") {
 				resi = tobs - tcal;
 			} else if (pTTT->sPhase == "S") {
@@ -1977,7 +1977,7 @@ double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 		}
 
 		// calculate distance to station to get sigma
-		double delta = RAD2DEG * geo.delta(&site->geo);
+		double delta = RAD2DEG * geo.delta(&site->getGeo());
 		double sigma = (tap.Val(delta) * 2.25) + 0.75;
 
 		// calculate and add to the stack
@@ -2158,14 +2158,14 @@ double CHypo::getSumAbsResidual(double xlat, double xlon, double xZ, double oT,
 
 		// only use nucleation phase if on nucleation branch
 		if (nucleate == 1 && pTrv2 == NULL) {
-			tcal = pTrv1->T(&site->geo);
+			tcal = pTrv1->T(&site->getGeo());
 			resi = tobs - tcal;
 		} else if (nucleate == 1 && pTrv1 == NULL) {
-			tcal = pTrv2->T(&site->geo);
+			tcal = pTrv2->T(&site->getGeo());
 			resi = tobs - tcal;
 		} else {
 			// take whichever has the smallest residual, P or S
-			tcal = pTTT->T(&site->geo, tobs);
+			tcal = pTTT->T(&site->getGeo(), tobs);
 			if (pTTT->sPhase == "P" || pTTT->sPhase == "S") {
 				resi = tobs - tcal;
 			}
@@ -2215,8 +2215,8 @@ void CHypo::graphicsOutput() {
 				auto pick = vPick[ipick];
 				double tobs = pick->getTPick() - tOrg;
 				std::shared_ptr<CSite> site = pick->getSite();
-				tcal = pTTT->T(&site->geo, tobs);
-				delta = RAD2DEG * geo.delta(&site->geo);
+				tcal = pTTT->T(&site->getGeo(), tobs);
+				delta = RAD2DEG * geo.delta(&site->getGeo());
 
 				// This should be a function.
 				if (delta < 1.5) {
@@ -2322,7 +2322,7 @@ bool CHypo::weights() {
 		geo.setGeographic(dLat, dLon, 6371.0 - dZ);
 
 		// get distance between this pick and the hypo
-		double del = RAD2DEG * geo.delta(&site->geo);
+		double del = RAD2DEG * geo.delta(&site->getGeo());
 
 		// compute sigma for this pick-hypo distance from the average sigma and
 		// the distance to this site using the taper
@@ -2339,7 +2339,7 @@ bool CHypo::weights() {
 			std::shared_ptr<CSite> sitej = pickj->getSite();
 
 			// get the distance between this pick and the pick being weighted
-			double delj = RAD2DEG * site->getDelta(&sitej->geo);
+			double delj = RAD2DEG * site->getDelta(&sitej->getGeo());
 
 			// if the distance is within 6 sig
 			if (delj < (6.0 * sig)) {
@@ -2421,7 +2421,7 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 					"CHypo::resolve: SCV COMPARE %s %s %s %s (%.2f, %.2f)",
 					sPid.c_str(), sOtherPid.c_str(),
 					glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-					pck->getSite()->sScnl.c_str(), aff1, aff2);
+					pck->getSite()->getScnl().c_str(), aff1, aff2);
 		glassutil::CLogit::log(sLog);
 
 		// check which affinity is better
@@ -2435,7 +2435,7 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 						sPid.c_str(),
 						sOtherPid.c_str(),
 						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-						pck->getSite()->sScnl.c_str(), aff1);
+						pck->getSite()->getScnl().c_str(), aff1);
 				glassutil::CLogit::log(sLog);
 			}
 
@@ -2513,7 +2513,7 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 				sPid.c_str(),
 				sOtherPid.c_str(),
 				glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-				corr->getSite()->sScnl.c_str(), aff1, aff2);
+				corr->getSite()->getScnl().c_str(), aff1, aff2);
 		glassutil::CLogit::log(sLog);
 
 		// check which affinity is better
@@ -2528,7 +2528,7 @@ bool CHypo::resolve(std::shared_ptr<CHypo> hyp) {
 						sOtherPid.c_str(),
 						glassutil::CDate::encodeDateTime(
 								corr->getTCorrelation()).c_str(),
-						corr->getSite()->sScnl.c_str(), aff1);
+						corr->getSite()->getScnl().c_str(), aff1);
 				glassutil::CLogit::log(sLog);
 			}
 

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -490,11 +490,13 @@ double CHypo::Rand(double x, double y) {
 }
 
 // ---------------------------------------------------------Hypo
-json::Object CHypo::hypo() {
+std::shared_ptr<json::Object> CHypo::hypo() {
 	// lock mutex for this scope
 	std::lock_guard<std::recursive_mutex> guard(hypoMutex);
 
-	json::Object hypo;
+	std::shared_ptr<json::Object> hypo = std::make_shared<json::Object>(
+			json::Object());
+
 	// null check
 	if (pGlass == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::warn,
@@ -526,9 +528,9 @@ json::Object CHypo::hypo() {
 	// the quake format?
 
 	// basic info
-	hypo["Cmd"] = "Hypo";
-	hypo["Type"] = "Hypo";
-	hypo["ID"] = sPid;
+	(*hypo)["Cmd"] = "Hypo";
+	(*hypo)["Type"] = "Hypo";
+	(*hypo)["ID"] = sPid;
 
 	// source
 	// NOTE: THIS NEEDS TO BE NOT HARDCODED EVENTUALLY
@@ -536,23 +538,23 @@ json::Object CHypo::hypo() {
 	json::Object src;
 	src["AgencyID"] = "US";
 	src["Author"] = "glass";
-	hypo["Source"] = src;
+	(*hypo)["Source"] = src;
 
 	// time
-	hypo["T"] = glassutil::CDate::encodeDateTime(tOrg);
-	hypo["Time"] = glassutil::CDate::encodeISO8601Time(tOrg);
+	(*hypo)["T"] = glassutil::CDate::encodeDateTime(tOrg);
+	(*hypo)["Time"] = glassutil::CDate::encodeISO8601Time(tOrg);
 
 	// location
-	hypo["Latitude"] = dLat;
-	hypo["Longitude"] = dLon;
-	hypo["Depth"] = dZ;
+	(*hypo)["Latitude"] = dLat;
+	(*hypo)["Longitude"] = dLon;
+	(*hypo)["Depth"] = dZ;
 
 	// supplementary info
-	hypo["MinimumDistance"] = dMin;
-	hypo["Gap"] = dGap;
-	hypo["Bayes"] = dBayes;
-	hypo["InitialBayes"] = dBayesInitial;
-	hypo["Web"] = sWebName;
+	(*hypo)["MinimumDistance"] = dMin;
+	(*hypo)["Gap"] = dGap;
+	(*hypo)["Bayes"] = dBayes;
+	(*hypo)["InitialBayes"] = dBayesInitial;
+	(*hypo)["Web"] = sWebName;
 
 	// generate data array for this hypo
 	// set up traveltime object
@@ -654,10 +656,10 @@ json::Object CHypo::hypo() {
 	}
 
 	// add data array to object
-	hypo["Data"] = data;
+	(*hypo)["Data"] = data;
 
 	if (pGlass) {
-		pGlass->send(&hypo);
+		pGlass->send(hypo);
 	}
 
 	// done
@@ -671,28 +673,29 @@ void CHypo::event() {
 
 	bEvent = true;
 	reportCount++;
-	json::Object evt;
+	std::shared_ptr<json::Object> event = std::make_shared<json::Object>(
+				json::Object());
 
 	// fill in Event command from current hypocenter
-	evt["Cmd"] = "Event";
-	evt["Pid"] = sPid;
-	evt["CreateTime"] = glassutil::CDate::encodeISO8601Time(tCreate);
-	evt["ReportTime"] = glassutil::CDate::encodeISO8601Time(
+	(*event)["Cmd"] = "Event";
+	(*event)["Pid"] = sPid;
+	(*event)["CreateTime"] = glassutil::CDate::encodeISO8601Time(tCreate);
+	(*event)["ReportTime"] = glassutil::CDate::encodeISO8601Time(
 			glassutil::CDate::now());
-	evt["Version"] = reportCount;
+	(*event)["Version"] = reportCount;
 
 	// basic hypo information
-	evt["Latitude"] = dLat;
-	evt["Longitude"] = dLon;
-	evt["Depth"] = dZ;
-	evt["Time"] = glassutil::CDate::encodeISO8601Time(tOrg);
-	evt["Bayes"] = dBayes;
-	evt["Ndata"] = static_cast<int>(vPick.size())
+	(*event)["Latitude"] = dLat;
+	(*event)["Longitude"] = dLon;
+	(*event)["Depth"] = dZ;
+	(*event)["Time"] = glassutil::CDate::encodeISO8601Time(tOrg);
+	(*event)["Bayes"] = dBayes;
+	(*event)["Ndata"] = static_cast<int>(vPick.size())
 			+ static_cast<int>(vCorr.size());
 
 	// send it
 	if (pGlass) {
-		pGlass->send(&evt);
+		pGlass->send(event);
 	}
 }
 

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -1320,11 +1320,19 @@ bool CHypoList::reqHypo(json::Object *com) {
 
 	// check the hypo
 	if (!hyp) {
-		return (false);
+		// cleanup
+		delete (com);
+		com = NULL;
+
+		return (true);
 	}
 
 	// generate the hypo message
 	hyp->hypo();
+
+	// cleanup
+	delete (com);
+	com = NULL;
 
 	// done
 	return (true);

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -99,7 +99,7 @@ void CHypoList::clearHypos() {
 }
 
 // ---------------------------------------------------------Dispatch
-bool CHypoList::dispatch(json::Object *com) {
+bool CHypoList::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -331,13 +331,14 @@ bool CHypoList::addHypo(std::shared_ptr<CHypo> hypo, bool scheduleProcessing) {
 						+ " Removing Hypo: " + pdx.second);
 
 		// create expiration message
-		json::Object expire;
-		expire["Cmd"] = "Expire";
-		expire["Pid"] = pdx.second;
+		std::shared_ptr<json::Object> expire = std::make_shared<json::Object>(
+				json::Object());
+		(*expire)["Cmd"] = "Expire";
+		(*expire)["Pid"] = pdx.second;
 
 		// send message
 		if (pGlass) {
-			pGlass->send(&expire);
+			pGlass->send(expire);
 		}
 	}
 
@@ -428,13 +429,14 @@ void CHypoList::remHypo(std::shared_ptr<CHypo> hypo, bool reportCancel) {
 	if (reportCancel == true) {
 		if (hypo->getEvent()) {
 			// create cancellation message
-			json::Object can;
-			can["Cmd"] = "Cancel";
-			can["Pid"] = pid;
+			std::shared_ptr<json::Object> cancel =
+					std::make_shared<json::Object>(json::Object());
+			(*cancel)["Cmd"] = "Cancel";
+			(*cancel)["Pid"] = pid;
 
 			// send message
 			if (pGlass) {
-				pGlass->send(&can);
+				pGlass->send(cancel);
 			}
 		}
 	}
@@ -1266,7 +1268,7 @@ bool CHypoList::evolve(std::shared_ptr<CHypo> hyp, int announce) {
  }
  */
 // ---------------------------------------------------------ReqHypo
-bool CHypoList::reqHypo(json::Object *com) {
+bool CHypoList::reqHypo(std::shared_ptr<json::Object> com) {
 	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 	// null check json
@@ -1320,19 +1322,11 @@ bool CHypoList::reqHypo(json::Object *com) {
 
 	// check the hypo
 	if (!hyp) {
-		// cleanup
-		delete (com);
-		com = NULL;
-
 		return (true);
 	}
 
 	// generate the hypo message
 	hyp->hypo();
-
-	// cleanup
-	delete (com);
-	com = NULL;
 
 	// done
 	return (true);

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -828,6 +828,9 @@ void CHypoList::darwin() {
 		return;
 	}
 
+	// only allow one thread to process a hypo at at time
+	hyp->lockForProcessing();
+
 	// log the hypo we're working on
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
@@ -844,6 +847,8 @@ void CHypoList::darwin() {
 				"CHypoList::darwin canceling sPid:" + hyp->getPid()
 						+ " processCount:"
 						+ std::to_string(hyp->getProcessCount()));
+
+		hyp->unlockAfterProcessing();
 
 		// remove hypo from the hypo list
 		remHypo(hyp);
@@ -864,11 +869,16 @@ void CHypoList::darwin() {
 						+ " at cycle limit:" + std::to_string(hyp->getCycle())
 						+ +" processCount:"
 						+ std::to_string(hyp->getProcessCount()));
+
+		hyp->unlockAfterProcessing();
+
 		return;
 	}
 
 	// process this hypocenter
 	evolve(hyp);
+
+	hyp->unlockAfterProcessing();
 
 	// resort the hypocenter list to maintain
 	// time order

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -507,13 +507,13 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 
 	// are there any hypos to associate with?
 	if (vHypo.size() < 1) {
+		glassutil::CLogit::log(
+				glassutil::log_level::debug,
+				"CHypoList::associate NOASSOC idPick:"
+						+ std::to_string(pk->getIdPick()) + "; No Hypos");
 		// nope
 		return (false);
 	}
-
-	glassutil::CLogit::log(
-			glassutil::log_level::debug,
-			"CHypoList::associate idPick:" + std::to_string(pk->getIdPick()));
 
 	std::string pid;
 	std::vector<std::shared_ptr<CHypo>> viper;
@@ -561,6 +561,11 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 
 	// there were no hypos that the pick associated with
 	if (viper.size() < 1) {
+		glassutil::CLogit::log(
+				glassutil::log_level::debug,
+				"CHypoList::associate NOASSOC idPick:"
+						+ std::to_string(pk->getIdPick()));
+
 		return (false);
 	}
 
@@ -598,6 +603,11 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 		// add to the processing queue
 		pushFifo(hyp);
 
+		glassutil::CLogit::log(
+				glassutil::log_level::debug,
+				"CHypoList::associate ASSOC idPick:"
+						+ std::to_string(pk->getIdPick()) + "; numHypos:1");
+
 		// the pick was associated
 		return (true);
 	}
@@ -616,6 +626,12 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 		// note that we didn't link the pick to any hypos
 		pushFifo(q);
 	}
+
+	glassutil::CLogit::log(
+			glassutil::log_level::debug,
+			"CHypoList::associate ASSOC idPick:"
+					+ std::to_string(pk->getIdPick()) + "; numHypos:"
+					+ std::to_string(viper.size()));
 
 	// the pick was associated
 	return (true);

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -513,7 +513,7 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CHypoList::associate idPick:" + std::to_string(pk->idPick));
+			"CHypoList::associate idPick:" + std::to_string(pk->getIdPick()));
 
 	std::string pid;
 	std::vector<std::shared_ptr<CHypo>> viper;
@@ -522,7 +522,7 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 	// (a potential hypo must be before the pick we're associating)
 	// use the pick time minus 2400 seconds to compute the starting index
 	// NOTE: Hard coded time delta
-	int it1 = indexHypo(pk->tPick - 2400.0);
+	int it1 = indexHypo(pk->getTPick() - 2400.0);
 
 	// check to see the index indicates that the time is before the
 	// start of the hypo list
@@ -533,7 +533,7 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 
 	// get the ending index based on the pick time (a potential hypo can't
 	// be after the pick we're associating)
-	int it2 = indexHypo(pk->tPick);
+	int it2 = indexHypo(pk->getTPick());
 
 	std::string pidmax;
 	double sdassoc = pGlass->sdAssociate;
@@ -572,11 +572,12 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 		// log
 		if (pGlass->bTrack) {
 			char sLog[1024];
-			snprintf(sLog, sizeof(sLog), "ASS %s %s %s (%d)\n",
-						hyp->sPid.c_str(),
-						glassutil::CDate::encodeDateTime(pk->tPick).c_str(),
-						pk->pSite->sScnl.c_str(),
-						static_cast<int>(hyp->vPick.size()));
+			snprintf(
+					sLog, sizeof(sLog), "ASS %s %s %s (%d)\n",
+					hyp->sPid.c_str(),
+					glassutil::CDate::encodeDateTime(pk->getTPick()).c_str(),
+					pk->getSite()->sScnl.c_str(),
+					static_cast<int>(hyp->vPick.size()));
 			glassutil::CLogit::Out(sLog);
 		}
 
@@ -1142,13 +1143,13 @@ bool CHypoList::merge(std::shared_ptr<CHypo> hypo) {
 				// add all picks for other two events
 				for (auto pick : hypo->vPick) {
 					// they're not associated yet, just potentially
-					pick->sAss = "N";
+					pick->setAss("N");
 					hypo3->addPick(pick);
 				}
 
 				for (auto pick : hypo2->vPick) {
 					// they're not associated yet, just potentially
-					pick->sAss = "N";
+					pick->setAss("N");
 					hypo3->addPick(pick);
 				}
 

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -662,7 +662,7 @@ bool CHypoList::associate(std::shared_ptr<CCorrelation> corr) {
 	// *could* be issues here, but has no idea how significant they are.
 	// Could affect association to splits with similar origin times.
 	int it1 = indexHypo(
-			corr->tCorrelation - pGlass->correlationMatchingTWindow);
+			corr->getTCorrelation() - pGlass->correlationMatchingTWindow);
 
 	// check to see the index indicates that the time is before the
 	// start of the hypo list
@@ -674,7 +674,7 @@ bool CHypoList::associate(std::shared_ptr<CCorrelation> corr) {
 	// get the ending index based on the correlation time plus
 	// correlationMatchingTWindow
 	int it2 = indexHypo(
-			corr->tCorrelation + pGlass->correlationMatchingTWindow);
+			corr->getTCorrelation() + pGlass->correlationMatchingTWindow);
 
 	std::string pidmax;
 
@@ -717,8 +717,8 @@ bool CHypoList::associate(std::shared_ptr<CCorrelation> corr) {
 					sizeof(sLog),
 					"C-ASS %s %s %s (%d)\n",
 					hyp->getPid().substr(0, 4).c_str(),
-					glassutil::CDate::encodeDateTime(corr->tCorrelation).c_str(),
-					corr->pSite->sScnl.c_str(),
+					glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
+					corr->getSite()->sScnl.c_str(),
 					static_cast<int>(hyp->getVCorrSize()));
 			glassutil::CLogit::Out(sLog);
 		}

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -576,7 +576,7 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 					sLog, sizeof(sLog), "ASS %s %s %s (%d)\n",
 					hyp->getPid().c_str(),
 					glassutil::CDate::encodeDateTime(pk->getTPick()).c_str(),
-					pk->getSite()->sScnl.c_str(),
+					pk->getSite()->getScnl().c_str(),
 					static_cast<int>(hyp->getVPickSize()));
 			glassutil::CLogit::Out(sLog);
 		}
@@ -718,7 +718,7 @@ bool CHypoList::associate(std::shared_ptr<CCorrelation> corr) {
 					"C-ASS %s %s %s (%d)\n",
 					hyp->getPid().substr(0, 4).c_str(),
 					glassutil::CDate::encodeDateTime(corr->getTCorrelation()).c_str(),
-					corr->getSite()->sScnl.c_str(),
+					corr->getSite()->getScnl().c_str(),
 					static_cast<int>(hyp->getVCorrSize()));
 			glassutil::CLogit::Out(sLog);
 		}

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -886,13 +886,13 @@ void CHypoList::darwin() {
 		// resort the hypocenter list to maintain
 		// time order
 		sort();
-	} catch (const std::exception &e) {
+	} catch (...) {
 		// ensure the hypo is unlocked
 		if (hyp->isLockedForProcessing()) {
 			hyp->unlockAfterProcessing();
 		}
 
-		throw e;
+		throw;
 	}
 }
 

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -1305,11 +1305,6 @@ bool CHypoList::reqHypo(json::Object *com) {
 		return (false);
 	}
 
-	// log
-	char sLog[1024];
-	snprintf(sLog, sizeof(sLog), "ReqHypo %s\n", sPid.c_str());
-	glassutil::CLogit::Out(sLog);
-
 	// get the hypo
 	std::shared_ptr<CHypo> hyp = mHypo[sPid];
 

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -253,7 +253,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 	// parent web
 	int nCut = pWeb->getNucleate();
 	double dThresh = pWeb->getThresh();
-	double dAzimuthRange = pWeb->getGlass()-> getBeamMatchingAzimuthWindow();
+	double dAzimuthRange = pWeb->getGlass()->getBeamMatchingAzimuthWindow();
 	// commented out because slowness matching of beams is not yet implemented
 	// but is scheduled to be soon
 	// double dDistanceRange = pWeb->pGlass->getBeamMatchingDistanceWindow();
@@ -411,10 +411,11 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		glassutil::CDate dt = glassutil::CDate(tOrigin);
 		std::string sOrg = dt.dateTime();
 		char sLog[1024];
-		snprintf(sLog, sizeof(sLog),
-					"**Nucleate %s Web:%s Cut:%d Thresh:%.2f nPick:%d\n",
-					sOrg.c_str(), pWeb->getName().c_str(), nCut, dSum,
-					static_cast<int>(vPick.size()));
+		snprintf(
+				sLog, sizeof(sLog),
+				"**Nucleate %s Web:%s Cut:%d Thresh:%.2f nPick:%d dSum: %.2f",
+				sOrg.c_str(), pWeb->getName().c_str(), nCut, dThresh,
+				static_cast<int>(vPick.size()), dSum);
 		glassutil::CLogit::Out(sLog);
 	}
 

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -253,10 +253,10 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 	// parent web
 	int nCut = pWeb->getNucleate();
 	double dThresh = pWeb->getThresh();
-	double dAzimuthRange = pWeb->getGlass()->beamMatchingAzimuthWindow;
+	double dAzimuthRange = pWeb->getGlass()-> getBeamMatchingAzimuthWindow();
 	// commented out because slowness matching of beams is not yet implemented
 	// but is scheduled to be soon
-	// double dDistanceRange = pWeb->pGlass->beamMatchingDistanceWindow;
+	// double dDistanceRange = pWeb->pGlass->getBeamMatchingDistanceWindow();
 
 	// init overall significance sum and node site count
 	// to 0
@@ -414,7 +414,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		snprintf(sLog, sizeof(sLog),
 					"**Nucleate %s Web:%s Cut:%d Thresh:%.2f nPick:%d\n",
 					sOrg.c_str(), pWeb->getName().c_str(), nCut, dSum,
-					vPick.size());
+					static_cast<int>(vPick.size()));
 		glassutil::CLogit::Out(sLog);
 	}
 

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -284,10 +284,10 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		// search through each pick at this site
 		for (const auto &pick : site->vPick) {
 			// get the pick's arrival time
-			double tPick = pick->tPick;
+			double tPick = pick->getTPick();
 
 			// get the picks back azimuth
-			double backAzimuth = pick->dBackAzimuth;
+			double backAzimuth = pick->getBackAzimuth();
 
 			// compute observed travel time from the pick time and
 			// the provided origin time
@@ -307,7 +307,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 				nodeGeo.setGeographic(dLat, dLon, 6371.0 - dZ);
 
 				// compute azimith from the site to the node
-				double siteAzimuth = pick->pSite->geo.azimuth(&nodeGeo);
+				double siteAzimuth = pick->getSite()->geo.azimuth(&nodeGeo);
 
 				// check to see if pick's backazimuth is within the
 				// valid range

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -536,15 +536,13 @@ std::string CNode::getSitesString() {
 	return (siteString);
 }
 
-int CNode::getSiteLinksCount() {
+int CNode::getSiteLinksCount() const {
 	// lock mutex for this scope
 	std::lock_guard<std::mutex> guard(vSiteMutex);
-	int size = vSite.size();
-
-	return (size);
+	return (vSite.size());
 }
 
-bool CNode::getEnabled() {
+bool CNode::getEnabled() const {
 	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
 	return (bEnabled);
 }
@@ -570,7 +568,7 @@ double CNode::getZ() const {
 	return (dZ);
 }
 
-CWeb* CNode::getWeb() {
+CWeb* CNode::getWeb() const {
 	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
 	return (pWeb);
 }
@@ -588,17 +586,17 @@ const std::string& CNode::getPid() const {
 	return (sPid);
 }
 
-double CNode::getTOrg() {
+double CNode::getTOrg() const {
 	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
 	return (tOrg);
 }
 
-double CNode::getSum() {
+double CNode::getSum() const {
 	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
 	return (dSum);
 }
 
-int CNode::getCount() {
+int CNode::getCount() const {
 	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
 	return (nCount);
 }

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -235,7 +235,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		return (false);
 	}
 	// check web pGlass
-	if (pWeb->pGlass == NULL) {
+	if (pWeb->getGlass() == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CNode::nucleate: NULL web glass pointer.");
 		return (false);
@@ -251,9 +251,9 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 
 	// get the cut and threshold from our
 	// parent web
-	int nCut = pWeb->nNucleate;
-	double dThresh = pWeb->dThresh;
-	double dAzimuthRange = pWeb->pGlass->beamMatchingAzimuthWindow;
+	int nCut = pWeb->getNucleate();
+	double dThresh = pWeb->getThresh();
+	double dAzimuthRange = pWeb->getGlass()->beamMatchingAzimuthWindow;
 	// commented out because slowness matching of beams is not yet implemented
 	// but is scheduled to be soon
 	// double dDistanceRange = pWeb->pGlass->beamMatchingDistanceWindow;
@@ -288,10 +288,10 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		}
 
 		// site->vPickMutex.lock();
-		std::vector<std::shared_ptr<CPick>> vPick = site->getVPick();
+		std::vector<std::shared_ptr<CPick>> vSitePicks = site->getVPick();
 
 		// search through each pick at this site
-		for (const auto &pick : vPick) {
+		for (const auto &pick : vSitePicks) {
 			// get the pick's arrival time
 			double tPick = pick->getTPick();
 
@@ -412,8 +412,9 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		std::string sOrg = dt.dateTime();
 		char sLog[1024];
 		snprintf(sLog, sizeof(sLog),
-					"**Nucleate %s Web:%s Cut:%d Thresh:%.2f\n", sOrg.c_str(),
-					pWeb->sName.c_str(), nCut, dSum);
+					"**Nucleate %s Web:%s Cut:%d Thresh:%.2f nPick:%d\n",
+					sOrg.c_str(), pWeb->getName().c_str(), nCut, dSum,
+					vPick.size());
 		glassutil::CLogit::Out(sLog);
 	}
 
@@ -457,11 +458,11 @@ double CNode::getBestSig(double tObservedTT, SiteLink link) {
 	// and detection grid resolution
 	double dSig1 = 0;
 	if (dRes1 > 0) {
-		dSig1 = pWeb->pGlass->sig(dRes1, dResolution);
+		dSig1 = pWeb->getGlass()->sig(dRes1, dResolution);
 	}
 	double dSig2 = 0;
 	if (dRes2 > 0) {
-		dSig2 = pWeb->pGlass->sig(dRes2, dResolution);
+		dSig2 = pWeb->getGlass()->sig(dRes2, dResolution);
 	}
 
 	// return the higher of the two significances

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <mutex>
 #include <algorithm>
+#include <vector>
 #include "Node.h"
 #include "Glass.h"
 #include "Web.h"
@@ -286,9 +287,11 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 			continue;
 		}
 
-		site->vPickMutex.lock();
+		// site->vPickMutex.lock();
+		std::vector<std::shared_ptr<CPick>> vPick = site->getVPick();
+
 		// search through each pick at this site
-		for (const auto &pick : site->vPick) {
+		for (const auto &pick : vPick) {
 			// get the pick's arrival time
 			double tPick = pick->getTPick();
 
@@ -361,7 +364,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 			}
 		}
 
-		site->vPickMutex.unlock();
+		// site->vPickMutex.unlock();
 
 		// check to see if the pick with the highest significance at this site
 		// should be added to the overall sum from this site
@@ -599,6 +602,11 @@ double CNode::getSum() const {
 int CNode::getCount() const {
 	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
 	return (nCount);
+}
+
+const std::vector<std::shared_ptr<CPick> > CNode::getVPick() const {
+	std::lock_guard<std::recursive_mutex> nodeGuard(nodeMutex);
+	return (vPick);
 }
 
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -279,7 +279,6 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 			continue;
 		}
 
-		// site->vPickMutex.lock();
 		std::vector<std::shared_ptr<CPick>> vSitePicks = site->getVPick();
 
 		// search through each pick at this site
@@ -355,8 +354,6 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 				pickBest = pick;
 			}
 		}
-
-		// site->vPickMutex.unlock();
 
 		// check to see if the pick with the highest significance at this site
 		// should be added to the overall sum from this site

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -161,7 +161,7 @@ bool CNode::unlinkSite(std::shared_ptr<CSite> site) {
 
 		// if the new station would be before
 		// the current station
-		if (currentSite->sScnl == site->sScnl) {
+		if (currentSite->getScnl() == site->getScnl()) {
 			found = true;
 			foundLink = link;
 			foundSite = currentSite;
@@ -276,7 +276,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 		std::shared_ptr<CSite> site = std::get < LINK_PTR > (link);
 
 		// Ignore if station out of service
-		if (!site->bUse) {
+		if (!site->getUse()) {
 			continue;
 		}
 
@@ -307,7 +307,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 				nodeGeo.setGeographic(dLat, dLon, 6371.0 - dZ);
 
 				// compute azimith from the site to the node
-				double siteAzimuth = pick->getSite()->geo.azimuth(&nodeGeo);
+				double siteAzimuth = pick->getSite()->getGeo().azimuth(&nodeGeo);
 
 				// check to see if pick's backazimuth is within the
 				// valid range
@@ -324,7 +324,7 @@ bool CNode::nucleate(double tOrigin, bool bList) {
 			// azimuth check
 			/*if (pick->dSlowness > 0) {
 			 // compute distance from the site to the node
-			 double siteDistance = pick->pSite->geo.delta(&nodeGeo);
+			 double siteDistance = pick->pSite->getGeo().delta(&nodeGeo);
 
 			 // compute observed distance from slowness (1/velocity)
 			 // and tObs (distance = velocity * time)
@@ -477,7 +477,7 @@ std::shared_ptr<CSite> CNode::getSite(std::string sScnl) {
 		// get the site
 		auto aSite = std::get < LINK_PTR > (link);
 
-		if (aSite->sScnl == sScnl) {
+		if (aSite->getScnl() == sScnl) {
 			// found
 			return (aSite);
 		}
@@ -520,10 +520,10 @@ std::string CNode::getSitesString() {
 		// get the site
 		std::shared_ptr<CSite> currentSite = std::get < LINK_PTR > (link);
 
-		siteString += sPid + "," + currentSite->sScnl + ","
-				+ std::to_string(currentSite->geo.dLat) + ";"
-				+ std::to_string(currentSite->geo.dLon) + ";"
-				+ std::to_string(currentSite->geo.dRad) + "\n";
+		siteString += sPid + "," + currentSite->getScnl() + ","
+				+ std::to_string(currentSite->getGeo().dLat) + ";"
+				+ std::to_string(currentSite->getGeo().dLon) + ";"
+				+ std::to_string(currentSite->getGeo().dRad) + "\n";
 	}
 
 	return (siteString);

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -275,11 +275,12 @@ bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 	dBackAzimuth = backAzimuth;
 	dSlowness = slowness;
 
-	glassutil::CLogit::log(
-			glassutil::log_level::debug,
-			"CPick::initialize: site:" + pSite->getScnl() + "; tPick:"
-					+ std::to_string(tPick) + "; idPick:"
-					+ std::to_string(idPick) + "; sPid:" + sPid);
+	/* glassutil::CLogit::log(
+	 glassutil::log_level::debug,
+	 "CPick::initialize: site:" + pSite->getScnl() + "; tPick:"
+	 + std::to_string(tPick) + "; idPick:"
+	 + std::to_string(idPick) + "; sPid:" + sPid);
+	 */
 
 	return (true);
 }
@@ -469,18 +470,18 @@ bool CPick::nucleate() {
 		if (pGlass->getHypoList()->evolve(hypo, 1)) {
 			// the hypo survived evolve,
 			// log the hypo
+			std::string pt = glassutil::CDate::encodeDateTime(tPick);
 			std::string st = glassutil::CDate::encodeDateTime(hypo->getTOrg());
-			snprintf(sLog, sizeof(sLog),
-						"CPick::nucleate: TRG hypo:%s %s %9.4f %10.4f %6.1f %d",
-						hypo->getPid().c_str(), st.c_str(), hypo->getLat(),
-						hypo->getLon(), hypo->getZ(),
-						static_cast<int>(hypo->getVPickSize()));
-			glassutil::CLogit::log(sLog);
 
-			// log the triggering web
-			snprintf(sLog, sizeof(sLog), "CPick::nucleate: WEB %s\n",
-						node->getName().c_str());
-			glassutil::CLogit::log(sLog);
+			glassutil::CLogit::log(
+					glassutil::log_level::debug,
+					"CPick::nucleate: TRG site:" + pSite->getScnl() + "; tPick:"
+							+ pt + "; idPick:" + std::to_string(idPick)
+							+ "; sPid:" + sPid + " => web:" + node->getName()
+							+ "; hyp: " + hypo->getPid() + "; lat:"
+							+ std::to_string(hypo->getLat()) + "; lon:"
+							+ std::to_string(hypo->getLon()) + "; z:"
+							+ std::to_string(hypo->getZ()) + "; tOrg:" + st);
 
 			// add a link to the hypo for each pick
 			// NOTE: Why is this done? Shouldn't evolve have already
@@ -506,9 +507,11 @@ bool CPick::nucleate() {
 		return (true);
 	}
 
-	snprintf(sLog, sizeof(sLog), "CPick::nucleate: NOTRG idPick:%d sPid:%s",
-				idPick, sPid.c_str());
-	glassutil::CLogit::log(sLog);
+	std::string pt = glassutil::CDate::encodeDateTime(tPick);
+	glassutil::CLogit::log(
+			glassutil::log_level::debug,
+			"CPick::nucleate: NOTRG site:" + pSite->getScnl() + "; tPick:" + pt
+					+ "; idPick:" + std::to_string(idPick) + "; sPid:" + sPid);
 
 	// done
 	return (false);

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -515,7 +515,7 @@ const std::shared_ptr<json::Object>& CPick::getJPick() const {
 	return (jPick);
 }
 
-const std::shared_ptr<CHypo>& CPick::getHypo() {
+const std::shared_ptr<CHypo>& CPick::getHypo() const {
 	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
 	return (pHypo);
 }
@@ -524,7 +524,7 @@ const std::shared_ptr<CSite>& CPick::getSite() const {
 	return (pSite);
 }
 
-const std::string& CPick::getAss() {
+const std::string& CPick::getAss() const {
 	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
 	return (sAss);
 }

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -358,10 +358,6 @@ bool CPick::nucleate() {
 	std::vector<std::shared_ptr<CNode>> vTrigger = pSite->getVTrigger();
 
 	for (auto node : vTrigger) {
-		snprintf(sLog, sizeof(sLog), "CPick::nucleate: %s %d %.2f",
-					pGlass->sWeb.c_str(), pGlass->nCount, pGlass->dSum);
-		glassutil::CLogit::log(sLog);
-
 		// nucleate at the node to build the
 		// list of picks that support this node
 		// tOrg was set during nucleation pass
@@ -374,16 +370,16 @@ bool CPick::nucleate() {
 		}
 
 		// create the hypo using the node
-		pGlass->m_TTTMutex.lock();
-		std::shared_ptr<CHypo> hypo = std::make_shared<CHypo>(node,
-																pGlass->pTTT);
-		pGlass->m_TTTMutex.unlock();
+		// pGlass->m_TTTMutex.lock();
+		std::shared_ptr<CHypo> hypo = std::make_shared<CHypo>(
+				node, pGlass->getTTT());
+		// pGlass->m_TTTMutex.unlock();
 
 		// set hypo glass pointer and such
 		hypo->setGlass(pGlass);
-		hypo->setCutFactor(pGlass->dCutFactor);
-		hypo->setCutPercentage(pGlass->dCutPercentage);
-		hypo->setCutMin(pGlass->dCutMin);
+		hypo->setCutFactor(pGlass->getCutFactor());
+		hypo->setCutPercentage(pGlass->getCutPercentage());
+		hypo->setCutMin(pGlass->getCutMin());
 
 		// add links to all the picks that support the hypo
 		std::vector<std::shared_ptr<CPick>> vNodePicks = node->getVPick();
@@ -464,7 +460,7 @@ bool CPick::nucleate() {
 
 		// if we got this far, the hypo has enough supporting data to
 		// merit looking at it closer.  Process it using evolve
-		if (pGlass->pHypoList->evolve(hypo, 1)) {
+		if (pGlass->getHypoList()->evolve(hypo, 1)) {
 			// the hypo survived evolve,
 			// log the hypo
 			std::string st = glassutil::CDate::encodeDateTime(hypo->getTOrg());
@@ -493,7 +489,7 @@ bool CPick::nucleate() {
 			 }*/
 
 			// add new hypo to hypo list
-			pGlass->pHypoList->addHypo(hypo);
+			pGlass->getHypoList()->addHypo(hypo);
 		}
 	}
 

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -352,20 +352,10 @@ bool CPick::nucleate() {
 	// is exceeded, the node is added to the site's trigger list
 	pSite->nucleate(tPick);
 
-	// Set glass values for debugging
-	pGlass->sWeb = "";
-	pGlass->nCount = 0;
-	pGlass->dSum = 0.0;
-
 	// for each node that triggered linked to this
 	// pick's site
 	pSite->vTriggerMutex.lock();
 	for (auto node : pSite->vTrigger) {
-		// Set glass values for debugging
-		pGlass->sWeb = node->pWeb->sName;
-		pGlass->nCount = node->nCount;
-		pGlass->dSum = node->dSum;
-
 		snprintf(sLog, sizeof(sLog), "CPick::nucleate: %s %d %.2f",
 					pGlass->sWeb.c_str(), pGlass->nCount, pGlass->dSum);
 		glassutil::CLogit::log(sLog);
@@ -376,7 +366,7 @@ bool CPick::nucleate() {
 		// NOTE: this did not used to check the nucleate return here
 		// it seems that this should improve computational performance
 		// but MIGHT have unintended consequences.
-		if (!node->nucleate(node->tOrg, true)) {
+		if (!node->nucleate(node->getTOrg(), true)) {
 			// didn't nucleate anything
 			continue;
 		}
@@ -423,8 +413,9 @@ bool CPick::nucleate() {
 			// this all assumes that the closest grid triggers
 			// values derived from testing global event association
 
-			hypo->anneal(10000, node->dResolution / 2., node->dResolution / 10.,
-							node->dResolution / 10.0, .1);
+			hypo->anneal(10000, node->getResolution() / 2.,
+							node->getResolution() / 10.,
+							node->getResolution() / 10.0, .1);
 
 			// get the number of picks we have now
 			int npick = hypo->getVPickSize();
@@ -472,7 +463,7 @@ bool CPick::nucleate() {
 
 			// log the triggering web
 			snprintf(sLog, sizeof(sLog), "CPick::nucleate: WEB %s\n",
-						node->sName.c_str());
+						node->getName().c_str());
 			glassutil::CLogit::log(sLog);
 
 			// add a link to the hypo for each pick

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -149,7 +149,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 	}
 
 	// check to see if we're using this site
-	if (!site->bUse) {
+	if (!site->getUse()) {
 		return;
 	}
 
@@ -276,7 +276,7 @@ bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CPick::initialize: site:" + pSite->sScnl + "; tPick:"
+			"CPick::initialize: site:" + pSite->getScnl() + "; tPick:"
 					+ std::to_string(tPick) + "; idPick:"
 					+ std::to_string(idPick) + "; sPid:" + sPid);
 
@@ -335,7 +335,7 @@ void CPick::setAss(std::string ass) {
 // ---------------------------------------------------------Nucleate
 bool CPick::nucleate() {
 	// get CGlass pointer from site
-	CGlass *pGlass = pSite->pGlass;
+	CGlass *pGlass = pSite->getGlass();
 
 	// nullcheck
 	if (pGlass == NULL) {
@@ -403,7 +403,7 @@ bool CPick::nucleate() {
 			if (pGlass->bTrack) {
 				snprintf(sLog, sizeof(sLog),
 							"CPick::nucleate: Adding to hyp %s\n",
-							pick->pSite->sScnl.c_str());
+							pick->pSite->getScnl().c_str());
 				glassutil::CLogit::log(sLog);
 			}
 		}

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -225,7 +225,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		return;
 	}
 
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	// remember input json for hypo message generation
 	// note, move to init?
@@ -240,7 +240,7 @@ CPick::~CPick() {
 
 // ---------------------------------------------------------~clear
 void CPick::clear() {
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	pSite = NULL;
 	pHypo = NULL;
@@ -258,9 +258,9 @@ void CPick::clear() {
 bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 						int pickId, std::string pickIdString,
 						double backAzimuth, double slowness) {
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+
 	clear();
-	// lock after clear to avoid deadlock
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	// nullcheck
 	if (pickSite == NULL) {
@@ -285,7 +285,7 @@ bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 
 // ---------------------------------------------------------addHypo
 void CPick::addHypo(std::shared_ptr<CHypo> hyp, std::string ass, bool force) {
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	// nullcheck
 	if (hyp == NULL) {
@@ -306,7 +306,7 @@ void CPick::addHypo(std::shared_ptr<CHypo> hyp, std::string ass, bool force) {
 
 // ---------------------------------------------------------remHypo
 void CPick::remHypo(std::shared_ptr<CHypo> hyp) {
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	// nullcheck
 	if (hyp == NULL) {
@@ -322,12 +322,12 @@ void CPick::remHypo(std::shared_ptr<CHypo> hyp) {
 }
 
 void CPick::clearHypo() {
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 	pHypo = NULL;
 }
 
 void CPick::setAss(std::string ass) {
-	std::lock_guard < std::recursive_mutex > guard(pickMutex);
+	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	sAss = ass;
 }
@@ -383,8 +383,8 @@ bool CPick::nucleate() {
 
 		// create the hypo using the node
 		pGlass->m_TTTMutex.lock();
-		std::shared_ptr<CHypo> hypo = std::make_shared < CHypo
-				> (node, pGlass->pTTT);
+		std::shared_ptr<CHypo> hypo = std::make_shared<CHypo>(node,
+																pGlass->pTTT);
 		pGlass->m_TTTMutex.unlock();
 
 		// set hypo glass pointer and such
@@ -506,4 +506,47 @@ bool CPick::nucleate() {
 	// done
 	return (false);
 }
+
+double CPick::getBackAzimuth() const {
+	return (dBackAzimuth);
+}
+
+double CPick::getSlowness() const {
+	return (dSlowness);
+}
+
+int CPick::getIdPick() const {
+	return (idPick);
+}
+
+const std::shared_ptr<json::Object>& CPick::getJPick() const {
+	return (jPick);
+}
+
+const std::shared_ptr<CHypo>& CPick::getHypo() {
+	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
+	return (pHypo);
+}
+
+const std::shared_ptr<CSite>& CPick::getSite() const {
+	return (pSite);
+}
+
+const std::string& CPick::getAss() {
+	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
+	return (sAss);
+}
+
+const std::string& CPick::getPhs() const {
+	return (sPhs);
+}
+
+const std::string& CPick::getPid() const {
+	return (sPid);
+}
+
+double CPick::getTPick() const {
+	return (tPick);
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -102,6 +102,10 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
 					"CPick::CPick: Missing required Station Key.");
+
+			// cleanup
+			delete (pick);
+
 			return;
 		}
 
@@ -121,6 +125,10 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
 					"CPick::CPick: Missing required Network Key.");
+
+			// cleanup
+			delete (pick);
+
 			return;
 		}
 
@@ -135,6 +143,10 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		// no site key
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CPick::CPick: Missing required Site Key.");
+
+		// cleanup
+		delete (pick);
+
 		return;
 	}
 
@@ -147,11 +159,18 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 	if (site == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::warn,
 								"CPick::CPick: site is null.");
+
+		// cleanup
+		delete (pick);
+
 		return;
 	}
 
 	// check to see if we're using this site
 	if (!site->getUse()) {
+		// cleanup
+		delete (pick);
+
 		return;
 	}
 
@@ -173,6 +192,10 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CPick::CPick: Missing required Time or T Key.");
+
+		// cleanup
+		delete (pick);
+
 		return;
 	}
 
@@ -188,6 +211,10 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		glassutil::CLogit::log(
 				glassutil::log_level::warn,
 				"CPick::CPick: Missing required ID or Pid Key.");
+
+		// cleanup
+		delete (pick);
+
 		return;
 	}
 
@@ -224,6 +251,10 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 	if (!initialize(site, tpick, pickId, pid, backAzimuth, slowness)) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CPick::CPick: Failed to initialize pick.");
+
+		// cleanup
+		delete (pick);
+
 		return;
 	}
 
@@ -231,8 +262,11 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 	// remember input json for hypo message generation
 	// note, move to init?
-	std::shared_ptr<json::Object> jpck(new json::Object(*pick));
-	jPick = jpck;
+	// std::shared_ptr<json::Object> jpck(new json::Object(*pick));
+	jPick = std::make_shared<json::Object>(json::Object(*pick));
+
+	// cleanup
+	delete (pick);
 }
 
 // ---------------------------------------------------------~CPick
@@ -385,8 +419,8 @@ bool CPick::nucleate() {
 		// it seems that this should improve computational performance
 		// but MIGHT have unintended consequences.
 		// if (!node->nucleate(node->getTOrg(), true)) {
-			// didn't nucleate anything
-			// continue;
+		// didn't nucleate anything
+		// continue;
 		// }
 
 		// create the hypo using the node

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -105,6 +105,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 			// cleanup
 			delete (pick);
+			pick = NULL;
 
 			return;
 		}
@@ -128,6 +129,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 			// cleanup
 			delete (pick);
+			pick = NULL;
 
 			return;
 		}
@@ -146,6 +148,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 		// cleanup
 		delete (pick);
+		pick = NULL;
 
 		return;
 	}
@@ -162,6 +165,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 		// cleanup
 		delete (pick);
+		pick = NULL;
 
 		return;
 	}
@@ -170,7 +174,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 	if (!site->getUse()) {
 		// cleanup
 		delete (pick);
-
+		pick = NULL;
 		return;
 	}
 
@@ -195,6 +199,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 		// cleanup
 		delete (pick);
+		pick = NULL;
 
 		return;
 	}
@@ -214,6 +219,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 		// cleanup
 		delete (pick);
+		pick = NULL;
 
 		return;
 	}
@@ -254,6 +260,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 		// cleanup
 		delete (pick);
+		pick = NULL;
 
 		return;
 	}
@@ -267,6 +274,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 	// cleanup
 	delete (pick);
+	pick = NULL;
 }
 
 // ---------------------------------------------------------~CPick

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -316,7 +316,7 @@ void CPick::remHypo(std::shared_ptr<CHypo> hyp) {
 	}
 
 	// Remove hypo reference from this pick
-	if (pHypo->sPid == hyp->sPid) {
+	if (pHypo->getPid() == hyp->getPid()) {
 		pHypo = NULL;
 	}
 }
@@ -388,10 +388,10 @@ bool CPick::nucleate() {
 		pGlass->m_TTTMutex.unlock();
 
 		// set hypo glass pointer and such
-		hypo->pGlass = pGlass;
-		hypo->dCutFactor = pGlass->dCutFactor;
-		hypo->dCutPercentage = pGlass->dCutPercentage;
-		hypo->dCutMin = pGlass->dCutMin;
+		hypo->setGlass(pGlass);
+		hypo->setCutFactor(pGlass->dCutFactor);
+		hypo->setCutPercentage(pGlass->dCutPercentage);
+		hypo->setCutMin(pGlass->dCutMin);
 
 		// add links to all the picks that support the hypo
 		for (auto pick : node->vPick) {
@@ -410,7 +410,7 @@ bool CPick::nucleate() {
 
 		// use the hypo's nucleation threshold, which is really the
 		// web's nucleation threshold
-		int ncut = hypo->nCut;
+		int ncut = hypo->getCut();
 		bool bad = false;
 
 		// First localization attempt after nucleation
@@ -427,10 +427,10 @@ bool CPick::nucleate() {
 							node->dResolution / 10.0, .1);
 
 			// get the number of picks we have now
-			int npick = hypo->vPick.size();
+			int npick = hypo->getVPickSize();
 
 			snprintf(sLog, sizeof(sLog), "CPick::nucleate: -- Pass %d %d/%d %s",
-						ipass, npick, ncut, hypo->sPid.c_str());
+						ipass, npick, ncut, hypo->getPid().c_str());
 			glassutil::CLogit::log(sLog);
 
 			// check to see if we still have enough picks for this hypo to
@@ -442,7 +442,7 @@ bool CPick::nucleate() {
 				// we don't
 				snprintf(sLog, sizeof(sLog),
 							"CPick::nucleate: -- Abandoning this solution %s",
-							hypo->sPid.c_str());
+							hypo->getPid().c_str());
 				glassutil::CLogit::log(sLog);
 
 				// don't bother making additional passes
@@ -462,11 +462,12 @@ bool CPick::nucleate() {
 		if (pGlass->pHypoList->evolve(hypo, 1)) {
 			// the hypo survived evolve,
 			// log the hypo
-			std::string st = glassutil::CDate::encodeDateTime(hypo->tOrg);
+			std::string st = glassutil::CDate::encodeDateTime(hypo->getTOrg());
 			snprintf(sLog, sizeof(sLog),
 						"CPick::nucleate: TRG hypo:%s %s %9.4f %10.4f %6.1f %d",
-						hypo->sPid.c_str(), st.c_str(), hypo->dLat, hypo->dLon,
-						hypo->dZ, static_cast<int>(hypo->vPick.size()));
+						hypo->getPid().c_str(), st.c_str(), hypo->getLat(),
+						hypo->getLon(), hypo->getZ(),
+						static_cast<int>(hypo->getVPickSize()));
 			glassutil::CLogit::log(sLog);
 
 			// log the triggering web

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -1,6 +1,7 @@
 #include <json.h>
 #include <memory>
 #include <string>
+#include <vector>
 #include "Pid.h"
 #include "Web.h"
 #include "Node.h"
@@ -354,8 +355,9 @@ bool CPick::nucleate() {
 
 	// for each node that triggered linked to this
 	// pick's site
-	pSite->vTriggerMutex.lock();
-	for (auto node : pSite->vTrigger) {
+	std::vector<std::shared_ptr<CNode>> vTrigger = pSite->getVTrigger();
+
+	for (auto node : vTrigger) {
 		snprintf(sLog, sizeof(sLog), "CPick::nucleate: %s %d %.2f",
 					pGlass->sWeb.c_str(), pGlass->nCount, pGlass->dSum);
 		glassutil::CLogit::log(sLog);
@@ -384,7 +386,8 @@ bool CPick::nucleate() {
 		hypo->setCutMin(pGlass->dCutMin);
 
 		// add links to all the picks that support the hypo
-		for (auto pick : node->vPick) {
+		std::vector<std::shared_ptr<CPick>> vPick = node->getVPick();
+		for (auto pick : vPick) {
 			// they're not associated yet, just potentially
 			pick->setAss("N");
 			hypo->addPick(pick);
@@ -483,8 +486,7 @@ bool CPick::nucleate() {
 		}
 	}
 
-	int triggerCount = pSite->vTrigger.size();
-	pSite->vTriggerMutex.unlock();
+	int triggerCount = vTrigger.size();
 
 	// If any webs triggered, return true to prevent further association
 	if (triggerCount > 0) {

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -419,8 +419,10 @@ bool CPick::nucleate() {
 			// get the number of picks we have now
 			int npick = hypo->getVPickSize();
 
-			snprintf(sLog, sizeof(sLog), "CPick::nucleate: -- Pass %d %d/%d %s",
-						ipass, npick, ncut, hypo->getPid().c_str());
+			snprintf(sLog, sizeof(sLog), "CPick::nucleate: -- Pass:%d; nPick:%d"
+						"/nCut:%d; bayes:%f/thresh:%f; %s",
+						ipass, npick, ncut, bayes, thresh,
+						hypo->getPid().c_str());
 			glassutil::CLogit::log(sLog);
 
 			// check to see if we still have a high enough bayes value for this
@@ -430,7 +432,7 @@ bool CPick::nucleate() {
 				snprintf(sLog, sizeof(sLog),
 							"CPick::nucleate: -- Abandoning solution %s "
 							"due to low bayes value "
-							"(bayes: %f, thresh:%f)",
+							"(bayes:%f/thresh:%f)",
 							hypo->getPid().c_str(), bayes, thresh);
 				glassutil::CLogit::log(sLog);
 
@@ -449,7 +451,7 @@ bool CPick::nucleate() {
 				snprintf(sLog, sizeof(sLog),
 							"CPick::nucleate: -- Abandoning solution %s "
 							"due to lack of picks "
-							"(npick: %d, ncut:%d)",
+							"(npick:%d/ncut:%d)",
 							hypo->getPid().c_str(), npick, ncut);
 				glassutil::CLogit::log(sLog);
 

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -35,7 +35,8 @@ CPick::CPick(std::shared_ptr<CSite> pickSite, double pickTime, int pickId,
 }
 
 // ---------------------------------------------------------CPick
-CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
+CPick::CPick(std::shared_ptr<json::Object> pick, int pickId,
+				CSiteList *pSiteList) {
 	clear();
 
 	// null check json
@@ -103,10 +104,6 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 					glassutil::log_level::error,
 					"CPick::CPick: Missing required Station Key.");
 
-			// cleanup
-			delete (pick);
-			pick = NULL;
-
 			return;
 		}
 
@@ -127,10 +124,6 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 					glassutil::log_level::error,
 					"CPick::CPick: Missing required Network Key.");
 
-			// cleanup
-			delete (pick);
-			pick = NULL;
-
 			return;
 		}
 
@@ -146,10 +139,6 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CPick::CPick: Missing required Site Key.");
 
-		// cleanup
-		delete (pick);
-		pick = NULL;
-
 		return;
 	}
 
@@ -163,18 +152,11 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		glassutil::CLogit::log(glassutil::log_level::warn,
 								"CPick::CPick: site is null.");
 
-		// cleanup
-		delete (pick);
-		pick = NULL;
-
 		return;
 	}
 
 	// check to see if we're using this site
 	if (!site->getUse()) {
-		// cleanup
-		delete (pick);
-		pick = NULL;
 		return;
 	}
 
@@ -197,10 +179,6 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 				glassutil::log_level::error,
 				"CPick::CPick: Missing required Time or T Key.");
 
-		// cleanup
-		delete (pick);
-		pick = NULL;
-
 		return;
 	}
 
@@ -216,10 +194,6 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 		glassutil::CLogit::log(
 				glassutil::log_level::warn,
 				"CPick::CPick: Missing required ID or Pid Key.");
-
-		// cleanup
-		delete (pick);
-		pick = NULL;
 
 		return;
 	}
@@ -257,11 +231,6 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 	if (!initialize(site, tpick, pickId, pid, backAzimuth, slowness)) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CPick::CPick: Failed to initialize pick.");
-
-		// cleanup
-		delete (pick);
-		pick = NULL;
-
 		return;
 	}
 
@@ -269,12 +238,7 @@ CPick::CPick(json::Object *pick, int pickId, CSiteList *pSiteList) {
 
 	// remember input json for hypo message generation
 	// note, move to init?
-	// std::shared_ptr<json::Object> jpck(new json::Object(*pick));
-	jPick = std::make_shared<json::Object>(json::Object(*pick));
-
-	// cleanup
-	delete (pick);
-	pick = NULL;
+	jPick = pick;
 }
 
 // ---------------------------------------------------------~CPick

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -502,14 +502,14 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 	char sLog[1024];
 
 	glassutil::CLogit::log(glassutil::log_level::debug,
-							"CPickList::scavenge. " + hyp->sPid);
+							"CPickList::scavenge. " + hyp->getPid());
 
 	// Calculate range for possible associations
 	double sdassoc = pGlass->sdAssociate;
 
 	// get the index of the pick to start with
 	// based on the hypo origin time
-	int it1 = indexPick(hyp->tOrg);
+	int it1 = indexPick(hyp->getTOrg());
 
 	// index can't be negative
 	// Primarily occurs if origin time is before first pick
@@ -519,7 +519,7 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 
 	// get the index of the pick to end with by using the hypo
 	// origin time plus the provided duration
-	int it2 = indexPick(hyp->tOrg + tDuration);
+	int it2 = indexPick(hyp->getTOrg() + tDuration);
 
 	// don't bother if there's no picks
 	if (it1 == it2) {
@@ -559,10 +559,10 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 			if (pGlass->bTrack) {
 				snprintf(
 						sLog, sizeof(sLog), "WAF %s %s %s (%d)\n",
-						hyp->sPid.substr(0, 4).c_str(),
+						hyp->getPid().substr(0, 4).c_str(),
 						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
 						pck->getSite()->sScnl.c_str(),
-						static_cast<int>(hyp->vPick.size()));
+						static_cast<int>(hyp->getVPickSize()));
 				glassutil::CLogit::Out(sLog);
 			}
 
@@ -583,7 +583,7 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CPickList::scavenge " + hyp->sPid + " added:"
+			"CPickList::scavenge " + hyp->getPid() + " added:"
 					+ std::to_string(addCount));
 
 	// return whether we've associated at least one pick
@@ -640,7 +640,7 @@ std::vector<std::shared_ptr<CPick>> CPickList::rogues(std::string pidHyp,
 		std::shared_ptr<CHypo> pickHyp = pck->getHypo();
 
 		// if the current pick is associated to this event
-		if ((pickHyp != NULL) && (pickHyp->sPid == pidHyp)) {
+		if ((pickHyp != NULL) && (pickHyp->getPid() == pidHyp)) {
 			// skip to next pick
 			continue;
 		}

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -206,6 +206,7 @@ bool CPickList::addPick(std::shared_ptr<json::Object> pick) {
 			|| (newPick->getPid() == "")) {
 		// cleanup
 		delete (newPick);
+		// message was processed
 		return (true);
 	}
 
@@ -220,6 +221,7 @@ bool CPickList::addPick(std::shared_ptr<json::Object> pick) {
 					glassutil::log_level::warn,
 					"CPickList::addPick: Duplicate pick not passed in.");
 			delete (newPick);
+			// message was processed
 			return (true);
 		}
 	}
@@ -327,7 +329,7 @@ bool CPickList::addPick(std::shared_ptr<json::Object> pick) {
 		m_qProcessMutex.unlock();
 	}
 
-	// we're done
+	// we're done, message was processed
 	return (true);
 }
 

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -106,7 +106,7 @@ void CPickList::clearPicks() {
 }
 
 // ---------------------------------------------------------Dispatch
-bool CPickList::dispatch(json::Object *com) {
+bool CPickList::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -154,7 +154,7 @@ bool CPickList::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------addPick
-bool CPickList::addPick(json::Object *pick) {
+bool CPickList::addPick(std::shared_ptr<json::Object> pick) {
 	// null check json
 	if (pick == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -206,7 +206,7 @@ bool CPickList::addPick(json::Object *pick) {
 			|| (newPick->getPid() == "")) {
 		// cleanup
 		delete (newPick);
-		return (false);
+		return (true);
 	}
 
 	// check if pick is duplicate, if pGlass exists
@@ -220,7 +220,7 @@ bool CPickList::addPick(json::Object *pick) {
 					glassutil::log_level::warn,
 					"CPickList::addPick: Duplicate pick not passed in.");
 			delete (newPick);
-			return (false);
+			return (true);
 		}
 	}
 

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -76,7 +76,7 @@ CPickList::~CPickList() {
 
 // ---------------------------------------------------------~clear
 void CPickList::clear() {
-	std::lock_guard<std::recursive_mutex> listGuard(m_vPickMutex);
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
 
 	pGlass = NULL;
 	pSiteList = NULL;
@@ -797,4 +797,50 @@ bool CPickList::statusCheck() {
 	// everything is awesome
 	return (true);
 }
+
+const CSiteList* CPickList::getSiteList() const {
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
+	return (pSiteList);
+}
+
+void CPickList::setSiteList(CSiteList* siteList) {
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
+	pSiteList = siteList;
+}
+
+const CGlass* CPickList::getGlass() const {
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
+	return (pGlass);
+}
+
+void CPickList::setGlass(CGlass* glass) {
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
+	pGlass = glass;
+}
+
+int CPickList::getNPick() const {
+	std::lock_guard<std::recursive_mutex> vPickGuard(m_vPickMutex);
+	return (nPick);
+}
+
+int CPickList::getNPickMax() const {
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
+	return (nPickMax);
+}
+
+void CPickList::setNPickMax(int picknMax) {
+	std::lock_guard<std::recursive_mutex> pickListGuard(m_PickListMutex);
+	nPickMax = picknMax;
+}
+
+int CPickList::getNPickTotal() const {
+	std::lock_guard<std::recursive_mutex> vPickGuard(m_vPickMutex);
+	return (nPickTotal);
+}
+
+int CPickList::getVPickSize() const {
+	std::lock_guard<std::recursive_mutex> vPickGuard(m_vPickMutex);
+	return (vPick.size());
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -458,16 +458,16 @@ bool CPickList::checkDuplicate(CPick *newPick, double window) {
 		// check if time difference is within window
 		if (std::abs(newPick->getTPick() - pck->getTPick()) < window) {
 			// check if sites match
-			if (newPick->getSite()->sScnl == pck->getSite()->sScnl) {
+			if (newPick->getSite()->getScnl() == pck->getSite()->getScnl()) {
 				// if match is found, set to true, log, and break out of loop
 				matched = true;
 				glassutil::CLogit::log(
 						glassutil::log_level::warn,
 						"CPickList::checkDuplicat: Duplicate (window = "
 								+ std::to_string(window) + ") : old:"
-								+ pck->getSite()->sScnl + " "
+								+ pck->getSite()->getScnl() + " "
 								+ std::to_string(pck->getTPick()) + " new(del):"
-								+ newPick->getSite()->sScnl + " "
+								+ newPick->getSite()->getScnl() + " "
 								+ std::to_string(newPick->getTPick()));
 				break;
 			}
@@ -561,7 +561,7 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 						sLog, sizeof(sLog), "WAF %s %s %s (%d)\n",
 						hyp->getPid().substr(0, 4).c_str(),
 						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-						pck->getSite()->sScnl.c_str(),
+						pck->getSite()->getScnl().c_str(),
 						static_cast<int>(hyp->getVPickSize()));
 				glassutil::CLogit::Out(sLog);
 			}

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -211,7 +211,8 @@ bool CPickList::addPick(json::Object *pick) {
 
 	// check if pick is duplicate, if pGlass exists
 	if (pGlass) {
-		bool duplicate = checkDuplicate(newPick, pGlass->pickDuplicateWindow);
+		bool duplicate = checkDuplicate(newPick,
+										pGlass->getPickDuplicateWindow());
 
 		// it is a duplicate, log and don't add pick
 		if (duplicate) {
@@ -244,7 +245,7 @@ bool CPickList::addPick(json::Object *pick) {
 	// get maximum number of picks
 	// use max picks from pGlass if we have it
 	if (pGlass) {
-		nPickMax = pGlass->nPickMax;
+		nPickMax = pGlass->getPickMax();
 	}
 
 	// create pair for insertion
@@ -310,7 +311,7 @@ bool CPickList::addPick(json::Object *pick) {
 	// wait until there's space in the queue
 	// we don't want to build up a huge queue of unprocessed
 	// picks
-	if ((pGlass) && (pGlass->pHypoList)) {
+	if ((pGlass) && (pGlass->getHypoList())) {
 		while (queueSize >= (m_iNumThreads)) {
 			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
@@ -505,7 +506,7 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 							"CPickList::scavenge. " + hyp->getPid());
 
 	// Calculate range for possible associations
-	double sdassoc = pGlass->sdAssociate;
+	double sdassoc = pGlass->getSdAssociate();
 
 	// get the index of the pick to start with
 	// based on the hypo origin time
@@ -556,15 +557,6 @@ bool CPickList::scavenge(std::shared_ptr<CHypo> hyp, double tDuration) {
 
 			// add pick to this hypo
 			hyp->addPick(pck);
-			if (pGlass->bTrack) {
-				snprintf(
-						sLog, sizeof(sLog), "WAF %s %s %s (%d)\n",
-						hyp->getPid().substr(0, 4).c_str(),
-						glassutil::CDate::encodeDateTime(pck->getTPick()).c_str(),
-						pck->getSite()->getScnl().c_str(),
-						static_cast<int>(hyp->getVPickSize()));
-				glassutil::CLogit::Out(sLog);
-			}
 
 			// we've associated a pick
 			bAss = true;
@@ -669,7 +661,7 @@ void CPickList::processPick() {
 			// on to the next loop
 			continue;
 		}
-		if (pGlass->pHypoList == NULL) {
+		if (pGlass->getHypoList() == NULL) {
 			// give up some time at the end of the loop
 			jobSleep();
 
@@ -710,7 +702,7 @@ void CPickList::processPick() {
 		// Attempt both association and nucleation of the new pick.
 		// If both succeed, the mess is sorted out in darwin/evolve
 		// associate
-		pGlass->pHypoList->associate(pck);
+		pGlass->getHypoList()->associate(pck);
 
 		// nucleate
 		pck->nucleate();

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -114,6 +114,11 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
 					"CSite::CSite: Missing required Station Key.");
+
+			// cleanup
+				delete(site);
+				site = NULL;
+
 			return;
 		}
 
@@ -133,6 +138,11 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
 					"CSite::CSite: Missing required Network Key.");
+
+			// cleanup
+				delete(site);
+				site = NULL;
+
 			return;
 		}
 
@@ -152,6 +162,11 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 	} else {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CSite::CSite: Missing required Site Object.");
+
+		// cleanup
+			delete(site);
+			site = NULL;
+
 		return;
 	}
 
@@ -162,6 +177,11 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 	} else {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CSite::CSite: Missing required Latitude Key.");
+
+		// cleanup
+			delete(site);
+			site = NULL;
+
 		return;
 	}
 
@@ -173,6 +193,11 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CSite::CSite: Missing required Longitude Key.");
+
+		// cleanup
+			delete(site);
+			site = NULL;
+
 		return;
 	}
 
@@ -184,6 +209,11 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CSite::CSite: Missing required Elevation Key.");
+
+		// cleanup
+			delete(site);
+			site = NULL;
+
 		return;
 	}
 
@@ -218,6 +248,7 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 
 	// cleanup
 	delete(site);
+	site = NULL;
 }
 
 // ---------------------------------------------------------CSite

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -223,6 +223,8 @@ bool CSite::initialize(std::string sta, std::string comp, std::string net,
 						CGlass *glassPtr) {
 	clear();
 
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+
 	// generate scnl
 	sScnl = "";
 
@@ -298,6 +300,7 @@ CSite::~CSite() {
 }
 
 void CSite::clear() {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
 	// clear scnl
 	sScnl = "";
 	sSite = "";
@@ -308,11 +311,8 @@ void CSite::clear() {
 	bUse = true;
 	bUseForTele = true;
 	dQual = 1.0;
-	dTrav = 0.0;
 
 	pGlass = NULL;
-	pNode = NULL;
-	qNode = NULL;
 
 	// clear geographic
 	geo = glassutil::CGeo();
@@ -338,6 +338,7 @@ void CSite::clear() {
 }
 
 void CSite::update(CSite *site) {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
 	// scnl check
 	if (sScnl != site->sScnl) {
 		return;
@@ -359,6 +360,7 @@ void CSite::update(CSite *site) {
 
 // ---------------------------------------------------------setLocation
 void CSite::setLocation(double lat, double lon, double z) {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
 	// construct unit vector in cartesian earth coordinates
 	double rxy = cos(DEG2RAD * lat);
 	dVec[0] = rxy * cos(DEG2RAD * lon);
@@ -624,5 +626,67 @@ int CSite::getNodeLinksCount() {
 	int size = vNode.size();
 
 	return (size);
+}
+
+bool CSite::getUse()  {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+	return (bUse);
+}
+
+void CSite::setUse(bool use) {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+	bUse = use;
+}
+
+bool CSite::getUseForTele() {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+	return (bUseForTele);
+}
+
+void CSite::setUseForTele(bool useForTele) {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+	bUseForTele = useForTele;
+}
+
+double CSite::getQual() {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+	return (dQual);
+}
+
+void CSite::setQual(double qual) {
+	std::lock_guard<std::recursive_mutex> guard(siteMutex);
+	dQual = qual;
+}
+
+glassutil::CGeo& CSite::getGeo() {
+	return (geo);
+}
+
+int CSite::getSitePickMax() const {
+	return (nSitePickMax);
+}
+
+CGlass* CSite::getGlass() const {
+	return (pGlass);
+}
+
+const std::string& CSite::getComp() const {
+	return (sComp);
+}
+
+const std::string& CSite::getLoc() const {
+	return (sLoc);
+}
+
+const std::string& CSite::getNet() const {
+	return (sNet);
+}
+
+const std::string& CSite::getScnl() const {
+	return (sScnl);
+}
+
+const std::string& CSite::getSite() const {
+	return (sSite);
 }
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -59,7 +59,7 @@ CSite::CSite(std::string sta, std::string comp, std::string net,
 }
 
 // ---------------------------------------------------------CSite
-CSite::CSite(json::Object *site, CGlass *glassPtr) {
+CSite::CSite(std::shared_ptr<json::Object> site, CGlass *glassPtr) {
 	clear();
 
 	// null check json
@@ -115,10 +115,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 					glassutil::log_level::error,
 					"CSite::CSite: Missing required Station Key.");
 
-			// cleanup
-				delete(site);
-				site = NULL;
-
 			return;
 		}
 
@@ -138,10 +134,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
 					"CSite::CSite: Missing required Network Key.");
-
-			// cleanup
-				delete(site);
-				site = NULL;
 
 			return;
 		}
@@ -163,10 +155,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CSite::CSite: Missing required Site Object.");
 
-		// cleanup
-			delete(site);
-			site = NULL;
-
 		return;
 	}
 
@@ -177,10 +165,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 	} else {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CSite::CSite: Missing required Latitude Key.");
-
-		// cleanup
-			delete(site);
-			site = NULL;
 
 		return;
 	}
@@ -194,10 +178,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 				glassutil::log_level::error,
 				"CSite::CSite: Missing required Longitude Key.");
 
-		// cleanup
-			delete(site);
-			site = NULL;
-
 		return;
 	}
 
@@ -209,10 +189,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
 				"CSite::CSite: Missing required Elevation Key.");
-
-		// cleanup
-			delete(site);
-			site = NULL;
 
 		return;
 	}
@@ -245,10 +221,6 @@ CSite::CSite(json::Object *site, CGlass *glassPtr) {
 	// pass to initialization function
 	initialize(station, channel, network, location, latitude, longitude,
 				elevation, quality, enable, useForTelesiesmic, glassPtr);
-
-	// cleanup
-	delete(site);
-	site = NULL;
 }
 
 // ---------------------------------------------------------CSite

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -510,7 +510,7 @@ void CSite::remNode(std::string nodeID) {
 		}
 
 		// check to see if we have a match
-		if (aNode->sPid == nodeID) {
+		if (aNode->getPid() == nodeID) {
 			// remember which one to delete
 			nodeLinkToDelete = link;
 
@@ -577,7 +577,7 @@ void CSite::nucleate(double tPick) {
 					"CSite::nucleate: " + sScnl + " No valid travel times. ("
 							+ std::to_string(travelTime1) + ", "
 							+ std::to_string(travelTime2) + ") web: "
-							+ node->pWeb->sName);
+							+ node->getWeb()->sName);
 		}
 	}
 }
@@ -592,7 +592,7 @@ void CSite::addTrigger(std::shared_ptr<CNode> node) {
 		auto q = vTrigger[iq];
 
 		// if current triggered node is part of latest node's web
-		if (node->pWeb->sName == q->pWeb->sName) {
+		if (node->getWeb()->sName == q->getWeb()->sName) {
 			// if latest node's sum is greater than current triggered node's
 			// sum, replace it
 
@@ -608,7 +608,7 @@ void CSite::addTrigger(std::shared_ptr<CNode> node) {
 			// + std::to_string(q->dZ) + ", "
 			// + std::to_string(q->dSum));
 
-			if (node->dSum > q->dSum) {
+			if (node->getSum() > q->getSum()) {
 				vTrigger[iq] = node;
 			}
 

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -581,7 +581,7 @@ void CSite::nucleate(double tPick) {
 					"CSite::nucleate: " + sScnl + " No valid travel times. ("
 							+ std::to_string(travelTime1) + ", "
 							+ std::to_string(travelTime2) + ") web: "
-							+ node->getWeb()->sName);
+							+ node->getWeb()->getName());
 		}
 	}
 }
@@ -596,7 +596,7 @@ void CSite::addTrigger(std::shared_ptr<CNode> node) {
 		auto q = vTrigger[iq];
 
 		// if current triggered node is part of latest node's web
-		if (node->getWeb()->sName == q->getWeb()->sName) {
+		if (node->getWeb()->getName() == q->getWeb()->getName()) {
 			// if latest node's sum is greater than current triggered node's
 			// sum, replace it
 

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -34,7 +34,7 @@ std::vector<std::string> &split(const std::string &s, char delim,
 }
 
 std::vector<std::string> split(const std::string &s, char delim) {
-	std::vector < std::string > elems;
+	std::vector<std::string> elems;
 
 	// split using string and delimiter
 	split(s, delim, elems);
@@ -277,16 +277,17 @@ bool CSite::initialize(std::string sta, std::string comp, std::string net,
 		nSitePickMax = pGlass->nSitePickMax;
 	}
 
-	glassutil::CLogit::log(
-			glassutil::log_level::debug,
-			"CSite::initialize: sScnl:" + sScnl + "; sSite:" + sSite
-					+ "; sComp:" + sComp + "; sNet:" + sNet + "; sLoc:" + sLoc
-					+ "; dLat:" + std::to_string(geo.dLat) + "; dLon:"
-					+ std::to_string(geo.dLon) + "; dZ:"
-					+ std::to_string(geo.dZ) + "; dQual:"
-					+ std::to_string(dQual) + "; bUse:" + std::to_string(bUse)
-					+ "; bUseForTele:" + std::to_string(bUseForTele)
-					+ "; nSitePickMax:" + std::to_string(nSitePickMax));
+	/*glassutil::CLogit::log(
+	 glassutil::log_level::debug,
+	 "CSite::initialize: sScnl:" + sScnl + "; sSite:" + sSite
+	 + "; sComp:" + sComp + "; sNet:" + sNet + "; sLoc:" + sLoc
+	 + "; dLat:" + std::to_string(geo.dLat) + "; dLon:"
+	 + std::to_string(geo.dLon) + "; dZ:"
+	 + std::to_string(geo.dZ) + "; dQual:"
+	 + std::to_string(dQual) + "; bUse:" + std::to_string(bUse)
+	 + "; bUseForTele:" + std::to_string(bUseForTele)
+	 + "; nSitePickMax:" + std::to_string(nSitePickMax));
+	 */
 
 	return (true);
 }
@@ -406,7 +407,7 @@ double CSite::getDistance(std::shared_ptr<CSite> site) {
 // ---------------------------------------------------------addPick
 void CSite::addPick(std::shared_ptr<CPick> pck) {
 	// lock for editing
-	std::lock_guard < std::mutex > guard(vPickMutex);
+	std::lock_guard<std::mutex> guard(vPickMutex);
 
 	// nullcheck
 	if (pck == NULL) {
@@ -438,7 +439,7 @@ void CSite::addPick(std::shared_ptr<CPick> pck) {
 // ---------------------------------------------------------remPick
 void CSite::remPick(std::shared_ptr<CPick> pck) {
 	// lock for editing
-	std::lock_guard < std::mutex > guard(vPickMutex);
+	std::lock_guard<std::mutex> guard(vPickMutex);
 
 	// nullcheck
 	if (pck == NULL) {
@@ -458,7 +459,7 @@ void CSite::remPick(std::shared_ptr<CPick> pck) {
 void CSite::addNode(std::shared_ptr<CNode> node, double travelTime1,
 					double travelTime2) {
 	// lock for editing
-	std::lock_guard < std::mutex > guard(vNodeMutex);
+	std::lock_guard<std::mutex> guard(vNodeMutex);
 
 	// nullcheck
 	if (node == NULL) {
@@ -485,7 +486,7 @@ void CSite::addNode(std::shared_ptr<CNode> node, double travelTime1,
 // ---------------------------------------------------------remNode
 void CSite::remNode(std::string nodeID) {
 	// lock for editing
-	std::lock_guard < std::mutex > guard(vNodeMutex);
+	std::lock_guard<std::mutex> guard(vNodeMutex);
 
 	// nullcheck
 	if (nodeID == "") {
@@ -499,7 +500,7 @@ void CSite::remNode(std::string nodeID) {
 	// remove the node identified by the id
 	for (const auto &link : vNode) {
 		// third is shared pointer to node
-		std::shared_ptr<CNode> aNode = std::get < LINK_PTR > (link);
+		std::shared_ptr<CNode> aNode = std::get< LINK_PTR>(link);
 
 		// nullcheck
 		if (aNode == NULL) {
@@ -525,7 +526,7 @@ void CSite::remNode(std::string nodeID) {
 
 // ---------------------------------------------------------Nucleate
 void CSite::nucleate(double tPick) {
-	std::lock_guard < std::mutex > guard(vNodeMutex);
+	std::lock_guard<std::mutex> guard(vNodeMutex);
 
 	// clear any previous triggering nodes
 	vTriggerMutex.lock();
@@ -536,13 +537,13 @@ void CSite::nucleate(double tPick) {
 	for (const auto &link : vNode) {
 		// compute potential origin time from tpick and traveltime to node
 		// first get traveltime1 to node
-		double travelTime1 = std::get < LINK_TT1 > (link);
+		double travelTime1 = std::get< LINK_TT1>(link);
 
 		// second get traveltime2 to node
-		double travelTime2 = std::get < LINK_TT2 > (link);
+		double travelTime2 = std::get< LINK_TT2>(link);
 
 		// third get shared pointer to node
-		std::shared_ptr<CNode> node = std::get < LINK_PTR > (link);
+		std::shared_ptr<CNode> node = std::get< LINK_PTR>(link);
 
 		// compute first origin time
 		double tOrigin1 = -1;
@@ -581,7 +582,7 @@ void CSite::nucleate(double tPick) {
 
 // ---------------------------------------------------------addTrigger
 void CSite::addTrigger(std::shared_ptr<CNode> node) {
-	std::lock_guard < std::mutex > guard(vTriggerMutex);
+	std::lock_guard<std::mutex> guard(vTriggerMutex);
 
 	// for each known triggering node
 	for (int iq = 0; iq < vTrigger.size(); iq++) {
@@ -619,7 +620,7 @@ void CSite::addTrigger(std::shared_ptr<CNode> node) {
 }
 
 int CSite::getNodeLinksCount() {
-	std::lock_guard < std::mutex > guard(vNodeMutex);
+	std::lock_guard<std::mutex> guard(vNodeMutex);
 	int size = vNode.size();
 
 	return (size);

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -286,18 +286,6 @@ bool CSite::initialize(std::string sta, std::string comp, std::string net,
 		nSitePickMax = pGlass->getSitePickMax();
 	}
 
-	/*glassutil::CLogit::log(
-	 glassutil::log_level::debug,
-	 "CSite::initialize: sScnl:" + sScnl + "; sSite:" + sSite
-	 + "; sComp:" + sComp + "; sNet:" + sNet + "; sLoc:" + sLoc
-	 + "; dLat:" + std::to_string(geo.dLat) + "; dLon:"
-	 + std::to_string(geo.dLon) + "; dZ:"
-	 + std::to_string(geo.dZ) + "; dQual:"
-	 + std::to_string(dQual) + "; bUse:" + std::to_string(bUse)
-	 + "; bUseForTele:" + std::to_string(bUseForTele)
-	 + "; nSitePickMax:" + std::to_string(nSitePickMax));
-	 */
-
 	return (true);
 }
 
@@ -632,16 +620,7 @@ void CSite::addTrigger(std::vector<std::shared_ptr<CTrigger>> *vTrigger,
 
 		// if current trigger is part of latest trigger's web
 		if (trigger->getWeb()->getName() == aTrigger->getWeb()->getName()) {
-			/* glassutil::CLogit::log(
-			 glassutil::log_level::debug,
-			 "CSite::addTrigger Trigger 1:" + std::to_string(trigger->dLat)
-			 + ", " + std::to_string(trigger->dLon) + ", "
-			 + std::to_string(trigger->dZ) + ", "
-			 + std::to_string(trigger->dSum) + ", Trigger 2:"
-			 + std::to_string(aTrigger->dLat) + ", "
-			 + std::to_string(aTrigger->dLon) + ", "
-			 + std::to_string(aTrigger->dZ) + ", "
-			 + std::to_string(aTrigger->dSum));*/
+			// if current trigger's sum is less than latest trigger's sum
 			if (trigger->getSum() > aTrigger->getSum()) {
 				it = vTrigger->erase(it);
 				it = vTrigger->insert(it, trigger);
@@ -653,40 +632,6 @@ void CSite::addTrigger(std::vector<std::shared_ptr<CTrigger>> *vTrigger,
 			++it;
 		}
 	}
-
-	/*	// for each known trigger
-	 for (int triggerIndex = 0; triggerIndex < vTrigger->size();
-	 triggerIndex++) {
-	 // get current trigger
-	 std::shared_ptr<CTrigger> aTrigger = vTrigger->at(triggerIndex);
-	 // if current trigger is part of latest trigger's web
-	 if (trigger->pWeb->sName == aTrigger->pWeb->sName) {
-	 // if latest triger''s sum is greater than current trigger's
-	 // sum, replace it
-	 glassutil::CLogit::log(
-	 glassutil::log_level::debug,
-	 "CSite::addTrigger Trigger 1:" + std::to_string(trigger->dLat)
-	 + ", " + std::to_string(trigger->dLon) + ", "
-	 + std::to_string(trigger->dZ) + ", "
-	 + std::to_string(trigger->dSum) + ", Trigger 2:"
-	 + std::to_string(aTrigger->dLat) + ", "
-	 + std::to_string(aTrigger->dLon) + ", "
-	 + std::to_string(aTrigger->dZ) + ", "
-	 + std::to_string(aTrigger->dSum));
-	 if (trigger->dSum > aTrigger->dSum) {
-	 vTrigger[triggerIndex] = trigger;
-	 }
-	 // we're done
-	 return;
-	 }
-	 }*/
-
-	/*	glassutil::CLogit::log(
-	 glassutil::log_level::debug,
-	 "CSite::addTrigger New Trigger:" + std::to_string(trigger->dLat)
-	 + ", " + std::to_string(trigger->dLon) + ", "
-	 + std::to_string(trigger->dZ) + ", "
-	 + std::to_string(trigger->dSum));*/
 
 	// add triggering node to vector of triggered nodes
 	vTrigger->push_back(trigger);

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -59,20 +59,20 @@ CSite::CSite(std::string sta, std::string comp, std::string net,
 }
 
 // ---------------------------------------------------------CSite
-CSite::CSite(json::Object *com, CGlass *glassPtr) {
+CSite::CSite(json::Object *site, CGlass *glassPtr) {
 	clear();
 
 	// null check json
-	if (com == NULL) {
+	if (site == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
-								"CSite::CSite: NULL json communication.");
+								"CSite::CSite: NULL json site.");
 		return;
 	}
 
 	// check type
-	if (com->HasKey("Type")
-			&& ((*com)["Type"].GetType() == json::ValueType::StringVal)) {
-		std::string type = (*com)["Type"].ToString();
+	if (site->HasKey("Type")
+			&& ((*site)["Type"].GetType() == json::ValueType::StringVal)) {
+		std::string type = (*site)["Type"].ToString();
 
 		if (type != "StationInfo") {
 			glassutil::CLogit::log(
@@ -102,9 +102,9 @@ CSite::CSite(json::Object *com, CGlass *glassPtr) {
 
 	// get site information from json
 	// scnl
-	if (((*com).HasKey("Site"))
-			&& ((*com)["Site"].GetType() == json::ValueType::ObjectVal)) {
-		json::Object siteobj = (*com)["Site"].ToObject();
+	if (((*site).HasKey("Site"))
+			&& ((*site)["Site"].GetType() == json::ValueType::ObjectVal)) {
+		json::Object siteobj = (*site)["Site"].ToObject();
 
 		// station
 		if (siteobj.HasKey("Station")
@@ -156,9 +156,9 @@ CSite::CSite(json::Object *com, CGlass *glassPtr) {
 	}
 
 	// latitude for this site
-	if (((*com).HasKey("Latitude"))
-			&& ((*com)["Latitude"].GetType() == json::ValueType::DoubleVal)) {
-		latitude = (*com)["Latitude"].ToDouble();
+	if (((*site).HasKey("Latitude"))
+			&& ((*site)["Latitude"].GetType() == json::ValueType::DoubleVal)) {
+		latitude = (*site)["Latitude"].ToDouble();
 	} else {
 		glassutil::CLogit::log(glassutil::log_level::error,
 								"CSite::CSite: Missing required Latitude Key.");
@@ -166,9 +166,9 @@ CSite::CSite(json::Object *com, CGlass *glassPtr) {
 	}
 
 	// longitude for this site
-	if (((*com).HasKey("Longitude"))
-			&& ((*com)["Longitude"].GetType() == json::ValueType::DoubleVal)) {
-		longitude = (*com)["Longitude"].ToDouble();
+	if (((*site).HasKey("Longitude"))
+			&& ((*site)["Longitude"].GetType() == json::ValueType::DoubleVal)) {
+		longitude = (*site)["Longitude"].ToDouble();
 	} else {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
@@ -177,9 +177,9 @@ CSite::CSite(json::Object *com, CGlass *glassPtr) {
 	}
 
 	// elevation for this site
-	if (((*com).HasKey("Elevation"))
-			&& ((*com)["Elevation"].GetType() == json::ValueType::DoubleVal)) {
-		elevation = (*com)["Elevation"].ToDouble();
+	if (((*site).HasKey("Elevation"))
+			&& ((*site)["Elevation"].GetType() == json::ValueType::DoubleVal)) {
+		elevation = (*site)["Elevation"].ToDouble();
 	} else {
 		glassutil::CLogit::log(
 				glassutil::log_level::error,
@@ -188,26 +188,26 @@ CSite::CSite(json::Object *com, CGlass *glassPtr) {
 	}
 
 	// quality for this site (if present)
-	if (((*com).HasKey("Quality"))
-			&& ((*com)["Quality"].GetType() == json::ValueType::DoubleVal)) {
-		quality = (*com)["Quality"].ToDouble();
+	if (((*site).HasKey("Quality"))
+			&& ((*site)["Quality"].GetType() == json::ValueType::DoubleVal)) {
+		quality = (*site)["Quality"].ToDouble();
 	} else {
 		quality = 1.0;
 	}
 
 	// enable for this site (if present)
-	if (((*com).HasKey("Enable"))
-			&& ((*com)["Enable"].GetType() == json::ValueType::BoolVal)) {
-		enable = (*com)["Enable"].ToBool();
+	if (((*site).HasKey("Enable"))
+			&& ((*site)["Enable"].GetType() == json::ValueType::BoolVal)) {
+		enable = (*site)["Enable"].ToBool();
 	} else {
 		enable = true;
 	}
 
 	// enable for this site (if present)
-	if (((*com).HasKey("UseForTeleseismic"))
-			&& ((*com)["UseForTeleseismic"].GetType()
+	if (((*site).HasKey("UseForTeleseismic"))
+			&& ((*site)["UseForTeleseismic"].GetType()
 					== json::ValueType::BoolVal)) {
-		useForTelesiesmic = (*com)["UseForTeleseismic"].ToBool();
+		useForTelesiesmic = (*site)["UseForTeleseismic"].ToBool();
 	} else {
 		useForTelesiesmic = true;
 	}
@@ -215,6 +215,9 @@ CSite::CSite(json::Object *com, CGlass *glassPtr) {
 	// pass to initialization function
 	initialize(station, channel, network, location, latitude, longitude,
 				elevation, quality, enable, useForTelesiesmic, glassPtr);
+
+	// cleanup
+	delete(site);
 }
 
 // ---------------------------------------------------------CSite

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -417,11 +417,11 @@ void CSite::addPick(std::shared_ptr<CPick> pck) {
 	}
 
 	// ensure this pick is for this site
-	if (pck->pSite->sScnl != sScnl) {
+	if (pck->getSite()->sScnl != sScnl) {
 		glassutil::CLogit::log(
 				glassutil::log_level::warn,
 				"CSite::addPick: CPick for different site: (" + sScnl + "!="
-						+ pck->pSite->sScnl + ")");
+						+ pck->getSite()->sScnl + ")");
 		return;
 	}
 

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -621,14 +621,14 @@ void CSite::addTrigger(std::shared_ptr<CNode> node) {
 	vTrigger.push_back(node);
 }
 
-int CSite::getNodeLinksCount() {
+int CSite::getNodeLinksCount() const {
 	std::lock_guard<std::mutex> guard(vNodeMutex);
 	int size = vNode.size();
 
 	return (size);
 }
 
-bool CSite::getUse()  {
+bool CSite::getUse() const {
 	std::lock_guard<std::recursive_mutex> guard(siteMutex);
 	return (bUse);
 }
@@ -638,7 +638,7 @@ void CSite::setUse(bool use) {
 	bUse = use;
 }
 
-bool CSite::getUseForTele() {
+bool CSite::getUseForTele() const {
 	std::lock_guard<std::recursive_mutex> guard(siteMutex);
 	return (bUseForTele);
 }
@@ -648,7 +648,7 @@ void CSite::setUseForTele(bool useForTele) {
 	bUseForTele = useForTele;
 }
 
-double CSite::getQual() {
+double CSite::getQual() const {
 	std::lock_guard<std::recursive_mutex> guard(siteMutex);
 	return (dQual);
 }

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -325,9 +325,7 @@ void CSite::clear() {
 	vNode.clear();
 	vNodeMutex.unlock();
 
-	vPickMutex.lock();
-	vPick.clear();
-	vPickMutex.unlock();
+	clearVPick();
 
 	vTriggerMutex.lock();
 	vTrigger.clear();
@@ -335,6 +333,12 @@ void CSite::clear() {
 
 	// reset max picks
 	nSitePickMax = 200;
+}
+
+void CSite::clearVPick() {
+	vPickMutex.lock();
+	vPick.clear();
+	vPickMutex.unlock();
 }
 
 void CSite::update(CSite *site) {
@@ -689,4 +693,15 @@ const std::string& CSite::getScnl() const {
 const std::string& CSite::getSite() const {
 	return (sSite);
 }
+
+const std::vector<std::shared_ptr<CPick> > CSite::getVPick() const {
+	std::lock_guard<std::mutex> guard(vPickMutex);
+	return (vPick);
+}
+
+const std::vector<std::shared_ptr<CNode> > CSite::getVTrigger() const {
+	std::lock_guard<std::mutex> guard(vTriggerMutex);
+	return (vTrigger);
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -276,7 +276,7 @@ bool CSite::initialize(std::string sta, std::string comp, std::string net,
 	pGlass = glassPtr;
 
 	if (pGlass) {
-		nSitePickMax = pGlass->nSitePickMax;
+		nSitePickMax = pGlass->getSitePickMax();
 	}
 
 	/*glassutil::CLogit::log(

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -126,7 +126,7 @@ bool CSiteList::addSite(json::Object *com) {
 	CSite * site = new CSite(com, pGlass);
 
 	// make sure a site was actually created
-	if (site->sScnl == "") {
+	if (site->getScnl() == "") {
 		glassutil::CLogit::log(glassutil::log_level::warn,
 								"CSiteList::addSite: Site not created.");
 		delete (site);
@@ -181,7 +181,7 @@ bool CSiteList::addSiteList(json::Object *com) {
 				CSite * site = new CSite(&siteObj, pGlass);
 
 				// make sure a site was actually created
-				if (site->sScnl == "") {
+				if (site->getScnl() == "") {
 					glassutil::CLogit::log(
 							glassutil::log_level::warn,
 							"CSiteList::addSiteList: Site not created.");
@@ -216,7 +216,7 @@ bool CSiteList::addSite(std::shared_ptr<CSite> site) {
 	}
 
 	// check to see if we have an existing site
-	std::shared_ptr<CSite> oldSite = getSite(site->sScnl);
+	std::shared_ptr<CSite> oldSite = getSite(site->getScnl());
 
 	std::lock_guard<std::mutex> guard(vSiteMutex);
 
@@ -234,7 +234,7 @@ bool CSiteList::addSite(std::shared_ptr<CSite> site) {
 	} else {
 		// add new site to list and map
 		vSite.push_back(site);
-		mSite[site->sScnl] = site;
+		mSite[site->getScnl()] = site;
 
 		// pass new site to webs
 		if (pGlass) {
@@ -386,7 +386,7 @@ bool CSiteList::reqSiteList() {
 		double z;
 
 		// convert to geographic coordinates
-		site->geo.getGeographic(&lat, &lon, &z);
+		site->getGeo().getGeographic(&lat, &lon, &z);
 
 		// convert from earth radius to elevation
 		double elv = (z - 6317.0) * -1000.0;
@@ -395,17 +395,17 @@ bool CSiteList::reqSiteList() {
 		stationObj["Lat"] = lat;
 		stationObj["Lon"] = lon;
 		stationObj["Z"] = elv;
-		stationObj["Qual"] = site->dQual;
-		stationObj["Use"] = site->bUse;
-		stationObj["UseForTele"] = site->bUseForTele;
+		stationObj["Qual"] = site->getQual();
+		stationObj["Use"] = site->getUse();
+		stationObj["UseForTele"] = site->getUseForTele();
 
-		stationObj["Sta"] = site->sSite;
-		if (site->sComp != "") {
-			stationObj["Comp"] = site->sComp;
+		stationObj["Sta"] = site->getSite();
+		if (site->getComp() != "") {
+			stationObj["Comp"] = site->getComp();
 		}
-		stationObj["Net"] = site->sNet;
-		if (site->sLoc != "") {
-			stationObj["Loc"] = site->sLoc;
+		stationObj["Net"] = site->getNet();
+		if (site->getLoc() != "") {
+			stationObj["Loc"] = site->getLoc();
 		}
 
 		// add to station list

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -46,7 +46,7 @@ void CSiteList::clearSites() {
 }
 
 // ---------------------------------------------------------dispatch
-bool CSiteList::dispatch(json::Object *com) {
+bool CSiteList::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -98,7 +98,7 @@ bool CSiteList::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------addSite
-bool CSiteList::addSite(json::Object *com) {
+bool CSiteList::addSite(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -141,7 +141,7 @@ bool CSiteList::addSite(json::Object *com) {
 }
 
 // ---------------------------------------------------------addSiteList
-bool CSiteList::addSiteList(json::Object *com) {
+bool CSiteList::addSiteList(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(
@@ -176,7 +176,8 @@ bool CSiteList::addSiteList(json::Object *com) {
 		for (auto v : stationList) {
 			if (v.GetType() == json::ValueType::ObjectVal) {
 				// convert object to json pointer
-				json::Object * siteObj = new json::Object(v.ToObject());
+				std::shared_ptr<json::Object> siteObj = std::make_shared<
+						json::Object>(v.ToObject());
 
 				// create a new a site from the station json;
 				CSite * site = new CSite(siteObj, pGlass);
@@ -344,23 +345,22 @@ std::shared_ptr<CSite> CSiteList::getSite(std::string site, std::string comp,
 	if (lookup) {
 		if (pGlass) {
 			// construct request json message
-			json::Object obj;
-			obj["Type"] = "SiteLookup";
-			obj["Site"] = site;
-			obj["Comp"] = comp;
-			obj["Net"] = net;
-			obj["Loc"] = loc;
+			std::shared_ptr<json::Object> request = std::make_shared<
+					json::Object>(json::Object());
+			(*request)["Type"] = "SiteLookup";
+			(*request)["Site"] = site;
+			(*request)["Comp"] = comp;
+			(*request)["Net"] = net;
+			(*request)["Loc"] = loc;
 
 			// send request
-			pGlass->send(&obj);
+			pGlass->send(request);
 
 			char sLog[1024];
-			snprintf(
-					sLog,
-					sizeof(sLog),
-					"CSiteList::getSite: SCNL:%s not on station list, "
-					"requesting information.",
-					scnl.c_str());
+			snprintf(sLog, sizeof(sLog),
+						"CSiteList::getSite: SCNL:%s not on station list, "
+						"requesting information.",
+						scnl.c_str());
 			glassutil::CLogit::log(sLog);
 		}
 	}
@@ -371,8 +371,9 @@ std::shared_ptr<CSite> CSiteList::getSite(std::string site, std::string comp,
 // ---------------------------------------------------------getSiteList
 bool CSiteList::reqSiteList() {
 	// construct request json message
-	json::Object sitelistObj;
-	sitelistObj["Cmd"] = "SiteList";
+	std::shared_ptr<json::Object> sitelistObj = std::make_shared<json::Object>(
+			json::Object());
+	(*sitelistObj)["Cmd"] = "SiteList";
 
 	// array to hold data
 	json::Array stationList;
@@ -413,10 +414,10 @@ bool CSiteList::reqSiteList() {
 		stationList.push_back(stationObj);
 	}
 
-	sitelistObj["SiteList"] = stationList;
+	(*sitelistObj)["SiteList"] = stationList;
 
 	if (pGlass) {
-		pGlass->send(&sitelistObj);
+		pGlass->send(sitelistObj);
 	}
 
 	return (true);

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -176,10 +176,10 @@ bool CSiteList::addSiteList(json::Object *com) {
 		for (auto v : stationList) {
 			if (v.GetType() == json::ValueType::ObjectVal) {
 				// convert object to json pointer
-				json::Object siteObj = v.ToObject();
+				json::Object * siteObj = new json::Object(v.ToObject());
 
 				// create a new a site from the station json;
-				CSite * site = new CSite(&siteObj, pGlass);
+				CSite * site = new CSite(siteObj, pGlass);
 
 				// make sure a site was actually created
 				if (site->getScnl() == "") {

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -228,8 +228,8 @@ bool CSiteList::addSite(std::shared_ptr<CSite> site) {
 
 		// pass updated site to webs
 		if (pGlass) {
-			if (pGlass->pWebList) {
-				pGlass->pWebList->addSite(oldSite);
+			if (pGlass->getWebList()) {
+				pGlass->getWebList()->addSite(oldSite);
 			}
 		}
 	} else {
@@ -239,8 +239,8 @@ bool CSiteList::addSite(std::shared_ptr<CSite> site) {
 
 		// pass new site to webs
 		if (pGlass) {
-			if (pGlass->pWebList) {
-				pGlass->pWebList->addSite(site);
+			if (pGlass->getWebList()) {
+				pGlass->getWebList()->addSite(site);
 			}
 		}
 	}

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -25,6 +25,7 @@ CSiteList::~CSiteList() {
 
 // ---------------------------------------------------------clear
 void CSiteList::clear() {
+	std::lock_guard<std::recursive_mutex> siteListGuard(m_SiteListMutex);
 	pGlass = NULL;
 
 	// clear sites
@@ -420,4 +421,20 @@ bool CSiteList::reqSiteList() {
 
 	return (true);
 }
+
+const CGlass* CSiteList::getGlass() const {
+	std::lock_guard<std::recursive_mutex> siteListGuard(m_SiteListMutex);
+	return (pGlass);
+}
+
+void CSiteList::setGlass(CGlass* glass) {
+	std::lock_guard<std::recursive_mutex> siteListGuard(m_SiteListMutex);
+	pGlass = glass;
+}
+
+int CSiteList::getVSiteSize() const {
+	std::lock_guard<std::mutex> vSiteGuard(vSiteMutex);
+	return (vSite.size());
+}
+
 }  // namespace glasscore

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -36,7 +36,7 @@ void CSiteList::clearSites() {
 	std::lock_guard<std::mutex> guard(vSiteMutex);
 	// remove all picks from sites
 	for (auto site : vSite) {
-		site->vPick.clear();
+		site->clearVPick();
 	}
 
 	// clear the vector and map

--- a/glasscore/glasslib/src/Trigger.cpp
+++ b/glasscore/glasslib/src/Trigger.cpp
@@ -1,0 +1,119 @@
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include <mutex>
+#include <algorithm>
+#include "Trigger.h"
+#include "Pick.h"
+#include "Logit.h"
+
+namespace glasscore {
+
+// ---------------------------------------------------------CTrigger
+CTrigger::CTrigger() {
+	clear();
+}
+
+// ---------------------------------------------------------CNode
+CTrigger::CTrigger(double lat, double lon, double z, double ot,
+					double resolution, double sum, int count,
+					std::vector<std::shared_ptr<CPick>> picks, CWeb *web) {
+	if (!initialize(lat, lon, z, ot, resolution, sum, count, picks, web)) {
+		clear();
+	}
+}
+
+// ---------------------------------------------------------~CTrigger
+CTrigger::~CTrigger() {
+	clear();
+}
+
+// ---------------------------------------------------------clear
+void CTrigger::clear() {
+	std::lock_guard<std::recursive_mutex> guard(triggerMutex);
+
+	dLat = 0;
+	dLon = 0;
+	dZ = 0;
+	tOrg = 0;
+	dResolution = 0;
+	dSum = 0;
+	nCount = 0;
+	pWeb = NULL;
+
+	vPick.clear();
+}
+
+bool CTrigger::initialize(double lat, double lon, double z, double ot,
+							double resolution, double sum, int count,
+							std::vector<std::shared_ptr<CPick>> picks,
+							CWeb *web) {
+	clear();
+
+	std::lock_guard<std::recursive_mutex> guard(triggerMutex);
+
+	dLat = lat;
+	dLon = lon;
+	dZ = z;
+	tOrg = ot;
+	dResolution = resolution;
+	dSum = sum;
+	nCount = count;
+	pWeb = web;
+
+	for (auto aPick : picks) {
+		vPick.push_back(aPick);
+	}
+
+/*	glassutil::CLogit::log(
+			glassutil::log_level::debug,
+			"CTrigger::initialize: dLat:" + std::to_string(dLat) + "; dLon:"
+					+ std::to_string(dLon) + "; dZ:" + std::to_string(dZ)
+					+ "; tOrg:" + std::to_string(tOrg) + "; dResolution:"
+					+ std::to_string(dResolution) + "; dSum:"
+					+ std::to_string(dSum) + "; nCount:"
+					+ std::to_string(nCount) + "; vPick Size:"
+					+ std::to_string(vPick.size()));*/
+
+	return (true);
+}
+
+double CTrigger::getLat() const {
+	return (dLat);
+}
+
+double CTrigger::getLon() const {
+	return (dLon);
+}
+
+double CTrigger::getZ() const {
+	return (dZ);
+}
+
+double CTrigger::getTOrg() const {
+	return (tOrg);
+}
+
+double CTrigger::getResolution() const {
+	return (dResolution);
+}
+
+double CTrigger::getSum() const {
+	return (dSum);
+}
+
+int CTrigger::getCount() const {
+	return (nCount);
+}
+
+const CWeb* CTrigger::getWeb() const {
+	return (pWeb);
+}
+
+const std::vector<std::shared_ptr<CPick> > CTrigger::getVPick() const {
+	std::lock_guard<std::recursive_mutex> guard(triggerMutex);
+	return (vPick);
+}
+
+}  // namespace glasscore

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -172,7 +172,7 @@ bool CWeb::initialize(std::string name, double thresh, int numDetect,
 }
 
 // ---------------------------------------------------------Dispatch
-bool CWeb::dispatch(json::Object *com) {
+bool CWeb::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -207,7 +207,7 @@ bool CWeb::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------Global
-bool CWeb::global(json::Object*com) {
+bool CWeb::global(std::shared_ptr<json::Object> com) {
 	glassutil::CLogit::log(glassutil::log_level::debug, "CWeb::global");
 
 	// nullchecks
@@ -452,7 +452,7 @@ bool CWeb::global(json::Object*com) {
 }
 
 // ---------------------------------------------------------Grid
-bool CWeb::grid(json::Object *com) {
+bool CWeb::grid(std::shared_ptr<json::Object> com) {
 	glassutil::CLogit::log(glassutil::log_level::debug, "CWeb::grid");
 	// nullchecks
 	// check json
@@ -752,7 +752,7 @@ bool CWeb::grid(json::Object *com) {
 }
 
 // ---------------------------------------------Grid w/ explicit nodes
-bool CWeb::grid_explicit(json::Object *com) {
+bool CWeb::grid_explicit(std::shared_ptr<json::Object> com) {
 	glassutil::CLogit::log(glassutil::log_level::debug, "CWeb::grid_explicit");
 
 	// nullchecks
@@ -1138,7 +1138,7 @@ bool CWeb::loadTravelTimes(json::Object *com) {
 }
 
 // ---------------------------------------------------------genSiteFilters
-bool CWeb::genSiteFilters(json::Object *com) {
+bool CWeb::genSiteFilters(std::shared_ptr<json::Object> com) {
 	// nullchecks
 	// check json
 	if (com == NULL) {

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -1047,11 +1047,10 @@ bool CWeb::loadTravelTimes(json::Object *com) {
 		// set up the first phase travel time
 		if (pTrv1->setup(phs, file) == false) {
 			glassutil::CLogit::log(
-								glassutil::log_level::error,
-								"CWeb::loadTravelTimes: Failed to load file "
-								"location " + file + " for first phase: "
-								+ phs);
-			return(false);
+					glassutil::log_level::error,
+					"CWeb::loadTravelTimes: Failed to load file "
+							"location " + file + " for first phase: " + phs);
+			return (false);
 		}
 
 	} else {
@@ -1112,11 +1111,10 @@ bool CWeb::loadTravelTimes(json::Object *com) {
 		// set up the second phase travel time
 		if (pTrv2->setup(phs, file) == false) {
 			glassutil::CLogit::log(
-								glassutil::log_level::error,
-								"CWeb::loadTravelTimes: Failed to load file "
-								"location " + file + " for second phase: "
-								+ phs);
-			return(false);
+					glassutil::log_level::error,
+					"CWeb::loadTravelTimes: Failed to load file "
+							"location " + file + " for second phase: " + phs);
+			return (false);
 		}
 	} else {
 		// no second phase
@@ -1216,14 +1214,14 @@ bool CWeb::isSiteAllowed(std::shared_ptr<CSite> site) {
 
 	// if we have a network filter, make sure network is allowed before adding
 	if ((vNetFilter.size() > 0)
-			&& (find(vNetFilter.begin(), vNetFilter.end(), site->sNet)
+			&& (find(vNetFilter.begin(), vNetFilter.end(), site->getNet())
 					!= vNetFilter.end())) {
 		return (true);
 	}
 
 	// if we have a site filter, make sure site is allowed before adding
 	if ((vSitesFilter.size() > 0)
-			&& (find(vSitesFilter.begin(), vSitesFilter.end(), site->sScnl)
+			&& (find(vSitesFilter.begin(), vSitesFilter.end(), site->getScnl())
 					!= vSitesFilter.end())) {
 		return (true);
 	}
@@ -1266,7 +1264,7 @@ bool CWeb::genSiteList() {
 		// get site from the overall site list
 		std::shared_ptr<CSite> site = pSiteList->getSite(isite);
 
-		if (site->bUse == false) {
+		if (site->getUse() == false) {
 			continue;
 		}
 
@@ -1427,22 +1425,22 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 	}
 
 	// if this is a remove, send to remSite
-	if (site->bUse == false) {
+	if (site->getUse() == false) {
 		remSite(site);
 		return;
 	}
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CWeb::addSite: New potential station " + site->sScnl + " for web: "
-					+ sName + ".");
+			"CWeb::addSite: New potential station " + site->getScnl()
+					+ " for web: " + sName + ".");
 
 	// don't bother if this site isn't allowed
 	if (isSiteAllowed(site) == false) {
 		glassutil::CLogit::log(
 				glassutil::log_level::debug,
-				"CWeb::addSite: Station " + site->sScnl + " not allowed in web "
-						+ sName + ".");
+				"CWeb::addSite: Station " + site->getScnl()
+						+ " not allowed in web " + sName + ".");
 		return;
 	}
 
@@ -1457,7 +1455,7 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 		if (nodeCount % 1000 == 0) {
 			glassutil::CLogit::log(
 					glassutil::log_level::debug,
-					"CWeb::addSite: Station " + site->sScnl + " processed "
+					"CWeb::addSite: Station " + site->getScnl() + " processed "
 							+ std::to_string(nodeCount) + " out of "
 							+ std::to_string(totalNodes) + " nodes in web: "
 							+ sName + ". Modified "
@@ -1465,7 +1463,7 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 		}
 
 		// check to see if we have this site
-		std::shared_ptr<CSite> foundSite = node->getSite(site->sScnl);
+		std::shared_ptr<CSite> foundSite = node->getSite(site->getScnl());
 
 		// update?
 		if (foundSite != NULL) {
@@ -1480,7 +1478,7 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 		geo.setGeographic(node->dLat, node->dLon, 6371.0);
 
 		// compute delta distance between site and node
-		double newDistance = RAD2DEG * site->geo.delta(&geo);
+		double newDistance = RAD2DEG * site->getGeo().delta(&geo);
 
 		// get site in node list
 		// NOTE: this assumes that the node site list is sorted
@@ -1488,7 +1486,7 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 		std::shared_ptr<CSite> furthestSite = node->getLastSite();
 
 		// compute distance to farthest site
-		double maxDistance = RAD2DEG * geo.delta(&furthestSite->geo);
+		double maxDistance = RAD2DEG * geo.delta(&furthestSite->getGeo());
 
 		// Ignore if new site is farther than last linked site
 		if (newDistance > maxDistance) {
@@ -1537,13 +1535,14 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 		char sLog[1024];
 		snprintf(sLog, sizeof(sLog), "CWeb::addSite: Added site: %s to %d "
 					"node(s) in web: %s",
-					site->sScnl.c_str(), nodeModCount, sName.c_str());
+					site->getScnl().c_str(), nodeModCount, sName.c_str());
 		glassutil::CLogit::log(glassutil::log_level::info, sLog);
 	} else {
 		glassutil::CLogit::log(
 				glassutil::log_level::debug,
-				"CWeb::addSite: Station " + site->sScnl + " not added to any "
-						"nodes in web: " + sName + ".");
+				"CWeb::addSite: Station " + site->getScnl()
+						+ " not added to any "
+								"nodes in web: " + sName + ".");
 	}
 }
 
@@ -1558,14 +1557,14 @@ void CWeb::remSite(std::shared_ptr<CSite> site) {
 	if (isSiteAllowed(site) == false) {
 		glassutil::CLogit::log(
 				glassutil::log_level::debug,
-				"CWeb::remSite: Station " + site->sScnl + " not allowed in web "
-						+ sName + ".");
+				"CWeb::remSite: Station " + site->getScnl()
+						+ " not allowed in web " + sName + ".");
 		return;
 	}
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CWeb::remSite: Trying to remove station " + site->sScnl
+			"CWeb::remSite: Trying to remove station " + site->getScnl()
 					+ " from web " + sName + ".");
 
 	// init flag to check to see if we've generated a site list for this web
@@ -1576,7 +1575,7 @@ void CWeb::remSite(std::shared_ptr<CSite> site) {
 	// for each node in web
 	for (auto &node : vNode) {
 		// search through each site linked to this node, see if we have it
-		std::shared_ptr<CSite> foundSite = node->getSite(site->sScnl);
+		std::shared_ptr<CSite> foundSite = node->getSite(site->getScnl());
 
 		// don't bother if this node doesn't have this site
 		if (foundSite == NULL) {
@@ -1626,8 +1625,9 @@ void CWeb::remSite(std::shared_ptr<CSite> site) {
 					== false) {
 				glassutil::CLogit::log(
 						glassutil::log_level::error,
-						"CWeb::remSite: Failed to add station " + newSite->sScnl
-								+ " to web " + sName + ".");
+						"CWeb::remSite: Failed to add station "
+								+ newSite->getScnl() + " to web " + sName
+								+ ".");
 			}
 
 			// resort site links
@@ -1638,7 +1638,7 @@ void CWeb::remSite(std::shared_ptr<CSite> site) {
 		} else {
 			glassutil::CLogit::log(
 					glassutil::log_level::error,
-					"CWeb::remSite: Failed to remove station " + site->sScnl
+					"CWeb::remSite: Failed to remove station " + site->getScnl()
 							+ " from web " + sName + ".");
 		}
 
@@ -1652,12 +1652,12 @@ void CWeb::remSite(std::shared_ptr<CSite> site) {
 		snprintf(
 				sLog, sizeof(sLog),
 				"CWeb::remSite: Removed site: %s from %d node(s) in web: %s",
-				site->sScnl.c_str(), nodeCount, sName.c_str());
+				site->getScnl().c_str(), nodeCount, sName.c_str());
 		glassutil::CLogit::log(glassutil::log_level::info, sLog);
 	} else {
 		glassutil::CLogit::log(
 				glassutil::log_level::debug,
-				"CWeb::remSite: Station " + site->sScnl
+				"CWeb::remSite: Station " + site->getScnl()
 						+ " not removed from any nodes in web: " + sName + ".");
 	}
 }
@@ -1817,12 +1817,12 @@ bool CWeb::hasSite(std::shared_ptr<CSite> site) {
 	// for each node in web
 	for (auto &node : vNode) {
 		// check to see if we have this site
-		if (node->getSite(site->sScnl) != NULL) {
-			return(true);
+		if (node->getSite(site->getScnl()) != NULL) {
+			return (true);
 		}
 	}
 
 	// site not found
-	return(false);
+	return (false);
 }
 }  // namespace glasscore

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -1427,6 +1427,11 @@ std::shared_ptr<CNode> CWeb::genNodeSites(std::shared_ptr<CNode> node) {
 			travelTime2 = pTrv2->T(delta);
 		}
 
+		// skip site if there are no valid times
+		if ((travelTime1 < 0) && (travelTime2 < 0)) {
+			continue;
+		}
+
 		// Link node to site using traveltimes
 		node->linkSite(site, node, travelTime1, travelTime2);
 	}

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -133,11 +133,11 @@ void CWeb::clear() {
 			node->clear();
 		}
 		vNode.clear();
-	} catch (const std::exception &e) {
+	} catch (...) {
 		// ensure the vNode mutex is unlocked
 		m_vNodeMutex.unlock();
 
-		throw e;
+		throw;
 	}
 	m_vNodeMutex.unlock();
 
@@ -149,11 +149,11 @@ void CWeb::clear() {
 	try {
 		vSiteMutex.lock();
 		vSite.clear();
-	} catch (const std::exception &e) {
+	} catch (...) {
 		// ensure the vSite mutex is unlocked
 		vSiteMutex.unlock();
 
-		throw e;
+		throw;
 	}
 	vSiteMutex.unlock();
 

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -1366,13 +1366,21 @@ std::shared_ptr<CNode> CWeb::genNodeSites(std::shared_ptr<CNode> node) {
 	}
 	// check sites
 	if (vSite.size() == 0) {
+		glassutil::CLogit::log(glassutil::log_level::error,
+								"CWeb::genNodeSites: No sites.");
 		return (node);
 	}
 	// check nDetect
 	if (nDetect == 0) {
+		glassutil::CLogit::log(glassutil::log_level::error,
+								"CWeb::genNodeSites: nDetect is 0.");
 		return (node);
 	}
 	if (vSite.size() < nDetect) {
+		glassutil::CLogit::log(glassutil::log_level::error,
+								"CWeb::genNodeSites: nDetect is greater "
+								"than the number of sites.");
+
 		return (node);
 	}
 

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -228,9 +228,9 @@ bool CWeb::global(json::Object*com) {
 
 	// check pGlass
 	if (pGlass != NULL) {
-		detect = pGlass->nDetect;
-		nucleate = pGlass->nNucleate;
-		thresh = pGlass->dThresh;
+		detect = pGlass->getDetect();
+		nucleate = pGlass->getNucleate();
+		thresh = pGlass->getThresh();
 	}
 
 	double resol = 100;
@@ -472,9 +472,9 @@ bool CWeb::grid(json::Object *com) {
 
 	// check pGlass
 	if (pGlass != NULL) {
-		detect = pGlass->nDetect;
-		nucleate = pGlass->nNucleate;
-		thresh = pGlass->dThresh;
+		detect = pGlass->getDetect();
+		nucleate = pGlass->getNucleate();
+		thresh = pGlass->getThresh();
 	}
 
 	double resol = 0;
@@ -774,9 +774,9 @@ bool CWeb::grid_explicit(json::Object *com) {
 
 	// check pGlass
 	if (pGlass != NULL) {
-		detect = pGlass->nDetect;
-		nucleate = pGlass->nNucleate;
-		thresh = pGlass->dThresh;
+		detect = pGlass->getDetect();
+		nucleate = pGlass->getNucleate();
+		thresh = pGlass->getThresh();
 	}
 
 	int nN = 0;
@@ -1000,8 +1000,8 @@ bool CWeb::loadTravelTimes(json::Object *com) {
 		pTrv1.reset();
 
 		// use overall glass default if available
-		if ((pGlass != NULL) && (pGlass->pTrvDefault != NULL)) {
-			pTrv1 = pGlass->pTrvDefault;
+		if ((pGlass != NULL) && (pGlass->getTrvDefault() != NULL)) {
+			pTrv1 = pGlass->getTrvDefault();
 		} else {
 			// create new traveltime
 			pTrv1 = std::make_shared<traveltime::CTravelTime>();
@@ -1066,8 +1066,8 @@ bool CWeb::loadTravelTimes(json::Object *com) {
 		pTrv1.reset();
 
 		// use overall glass default if available
-		if (pGlass->pTrvDefault != NULL) {
-			pTrv1 = pGlass->pTrvDefault;
+		if (pGlass->getTrvDefault() != NULL) {
+			pTrv1 = pGlass->getTrvDefault();
 		} else {
 			// create new traveltime
 			pTrv1 = std::make_shared<traveltime::CTravelTime>();

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -127,11 +127,18 @@ void CWeb::clear() {
 	bUpdate = false;
 
 	// clear out all the nodes in the web
-	m_vNodeMutex.lock();
-	for (auto &node : vNode) {
-		node->clear();
+	try {
+		m_vNodeMutex.lock();
+		for (auto &node : vNode) {
+			node->clear();
+		}
+		vNode.clear();
+	} catch (const std::exception &e) {
+		// ensure the vNode mutex is unlocked
+		m_vNodeMutex.unlock();
+
+		throw e;
 	}
-	vNode.clear();
 	m_vNodeMutex.unlock();
 
 	// clear the network and site filters
@@ -139,8 +146,15 @@ void CWeb::clear() {
 	vSitesFilter.clear();
 
 	// clear sites
-	vSiteMutex.lock();
-	vSite.clear();
+	try {
+		vSiteMutex.lock();
+		vSite.clear();
+	} catch (const std::exception &e) {
+		// ensure the vSite mutex is unlocked
+		vSiteMutex.unlock();
+
+		throw e;
+	}
 	vSiteMutex.unlock();
 
 	pTrv1 = NULL;

--- a/glasscore/glasslib/src/WebList.cpp
+++ b/glasscore/glasslib/src/WebList.cpp
@@ -38,7 +38,7 @@ void CWebList::clear() {
 }
 
 // ---------------------------------------------------------Dispatch
-bool CWebList::dispatch(json::Object *com) {
+bool CWebList::dispatch(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -68,7 +68,7 @@ bool CWebList::dispatch(json::Object *com) {
 }
 
 // ---------------------------------------------------------AddWeb
-bool CWebList::addWeb(json::Object *com) {
+bool CWebList::addWeb(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(glassutil::log_level::error,
@@ -120,7 +120,7 @@ bool CWebList::addWeb(json::Object *com) {
 }
 
 // ---------------------------------------------------------RemoveWeb
-bool CWebList::removeWeb(json::Object *com) {
+bool CWebList::removeWeb(std::shared_ptr<json::Object> com) {
 	// null check json
 	if (com == NULL) {
 		glassutil::CLogit::log(

--- a/glasscore/glasslib/src/WebList.cpp
+++ b/glasscore/glasslib/src/WebList.cpp
@@ -168,7 +168,7 @@ void CWebList::addSite(std::shared_ptr<CSite> site) {
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CWebList::addSite: Adding station " + site->sScnl + ".");
+			"CWebList::addSite: Adding station " + site->getScnl() + ".");
 
 	// Update all web node site lists that might be changed
 	// by the addition of this site
@@ -190,7 +190,7 @@ void CWebList::remSite(std::shared_ptr<CSite> site) {
 
 	glassutil::CLogit::log(
 			glassutil::log_level::debug,
-			"CWebList::addSite: Removing station " + site->sScnl + ".");
+			"CWebList::addSite: Removing station " + site->getScnl() + ".");
 
 	// Remove site from all web nodes that link to it and restructure
 	// node site lists

--- a/glasscore/tests/correlation_unittest.cpp
+++ b/glasscore/tests/correlation_unittest.cpp
@@ -185,11 +185,12 @@ TEST(CorrelationTest, HypoOperations) {
 			LON, Z, CORRELATION);
 
 	// create a hypo
-	traveltime::CTravelTime* nullTrav = NULL;
+	std::shared_ptr<traveltime::CTravelTime> nullTrav;
+	std::shared_ptr<traveltime::CTTT> nullTTT;
 	glasscore::CHypo * testHypo = new glasscore::CHypo(0.0, 0.0, 0.0, 0.0, "1",
 														"test", 0.0, 0.0, 0,
 														nullTrav, nullTrav,
-														NULL);
+														nullTTT);
 
 	// create new shared pointer to the hypo
 	std::shared_ptr<glasscore::CHypo> sharedHypo(testHypo);

--- a/glasscore/tests/correlation_unittest.cpp
+++ b/glasscore/tests/correlation_unittest.cpp
@@ -29,72 +29,72 @@
 void checkdata(glasscore::CCorrelation * corrleationobject,
 			   const std::string &testinfo) {
 	// check scnl
-	std::string sitescnl = corrleationobject->pSite->sScnl;
+	std::string sitescnl = corrleationobject->getSite()->sScnl;
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str());
 
 	// check site
-	std::string sitesite = corrleationobject->pSite->sSite;
+	std::string sitesite = corrleationobject->getSite()->sSite;
 	std::string expectedsite = std::string(SITE);
 	ASSERT_STREQ(sitesite.c_str(), expectedsite.c_str());
 
 	// check comp
-	std::string sitecomp = corrleationobject->pSite->sComp;
+	std::string sitecomp = corrleationobject->getSite()->sComp;
 	std::string expectedcomp = std::string(COMP);
 	ASSERT_STREQ(sitecomp.c_str(), expectedcomp.c_str());
 
 	// check net
-	std::string sitenet = corrleationobject->pSite->sNet;
+	std::string sitenet = corrleationobject->getSite()->sNet;
 	std::string expectednet = std::string(NET);
 	ASSERT_STREQ(sitenet.c_str(), expectednet.c_str());
 
 	// check loc
-	std::string siteloc = corrleationobject->pSite->sLoc;
+	std::string siteloc = corrleationobject->getSite()->sLoc;
 	std::string expectedloc = std::string(LOC);
 	ASSERT_STREQ(siteloc.c_str(), expectedloc.c_str());
 
 	// check time
-	double correlationtime = corrleationobject->tCorrelation;
+	double correlationtime = corrleationobject->getTCorrelation();
 	double expectedcorrelationtime = CORRELATIONTIME;
 	ASSERT_NEAR(correlationtime, expectedcorrelationtime, 0.0001);
 
 	// check id
-	int id = corrleationobject->idCorrelation;
+	int id = corrleationobject->getIdCorrelation();
 	int expectedid = CORRELATIONID;
 	ASSERT_EQ(id, expectedid);
 
 	// check string id
-	std::string stringid = corrleationobject->sPid;
+	std::string stringid = corrleationobject->getPid();
 	std::string expectedstringid = std::string(CORRELATIONIDSTRING);
 	ASSERT_STREQ(stringid.c_str(), expectedstringid.c_str());
 
 	// check origin time
-	double origintime = corrleationobject->tOrg;
+	double origintime = corrleationobject->getTOrg();
 	double expectedorigintime = ORIGINTIME;
 	ASSERT_NEAR(origintime, expectedorigintime, 0.0001);
 
 	// check lat
-	double lat = corrleationobject->dLat;
+	double lat = corrleationobject->getLat();
 	double expectedlat = LAT;
 	ASSERT_NEAR(lat, expectedlat, 0.0001);
 
 	// check lon
-	double lon = corrleationobject->dLon;
+	double lon = corrleationobject->getLon();
 	double expectedlon = LON;
 	ASSERT_NEAR(lon, expectedlon, 0.0001);
 
 	// check rad
-	double z = corrleationobject->dZ;
+	double z = corrleationobject->getZ();
 	double expectedz = Z;
 	ASSERT_NEAR(z, expectedz, 0.0001);
 
 	// check correlation
-	double correlation = corrleationobject->dCorrelation;
+	double correlation = corrleationobject->getCorrelation();
 	double expectedcorrelation = CORRELATION;
 	ASSERT_NEAR(correlation, expectedcorrelation, 0.0001);
 
 	// check phase
-	std::string stringphase = corrleationobject->sPhs;
+	std::string stringphase = corrleationobject->getPhs();
 	std::string expectedstringphase = std::string(PHASE);
 	ASSERT_STREQ(stringphase.c_str(), expectedstringphase.c_str());
 }
@@ -107,22 +107,22 @@ TEST(CorrelationTest, Construction) {
 	glasscore::CCorrelation * testCorrelation = new glasscore::CCorrelation();
 
 	// assert default values
-	ASSERT_EQ(0, testCorrelation->tCorrelation)<< "time is zero";
-	ASSERT_EQ(0, testCorrelation->idCorrelation)<< "id is zero";
-	ASSERT_EQ(0, testCorrelation->tOrg)<< "origin time is zero";
-	ASSERT_EQ(0, testCorrelation->dLat)<< "lat is zero";
-	ASSERT_EQ(0, testCorrelation->dLon)<< "lon is zero";
-	ASSERT_EQ(0, testCorrelation->dZ)<< "z is zero";
-	ASSERT_EQ(0, testCorrelation->dCorrelation)<< "correlation is zero";
+	ASSERT_EQ(0, testCorrelation->getTCorrelation())<< "time is zero";
+	ASSERT_EQ(0, testCorrelation->getIdCorrelation())<< "id is zero";
+	ASSERT_EQ(0, testCorrelation->getTOrg())<< "origin time is zero";
+	ASSERT_EQ(0, testCorrelation->getLat())<< "lat is zero";
+	ASSERT_EQ(0, testCorrelation->getLon())<< "lon is zero";
+	ASSERT_EQ(0, testCorrelation->getZ())<< "z is zero";
+	ASSERT_EQ(0, testCorrelation->getCorrelation())<< "correlation is zero";
 
-	ASSERT_STREQ("", testCorrelation->sAss.c_str());
-	ASSERT_STREQ("", testCorrelation->sPhs.c_str());
-	ASSERT_STREQ("", testCorrelation->sPid.c_str());
+	ASSERT_STREQ("", testCorrelation->getAss().c_str());
+	ASSERT_STREQ("", testCorrelation->getPhs().c_str());
+	ASSERT_STREQ("", testCorrelation->getPid().c_str());
 
 	// pointers
-	ASSERT_TRUE(testCorrelation->pSite == NULL)<< "pSite null";
-	ASSERT_TRUE(testCorrelation->pHypo == NULL)<< "pHypo null";
-	ASSERT_TRUE(testCorrelation->jCorrelation == NULL)<< "jCorrelation null";
+	ASSERT_TRUE(testCorrelation->getSite() == NULL)<< "pSite null";
+	ASSERT_TRUE(testCorrelation->getHypo() == NULL)<< "pHypo null";
+	ASSERT_TRUE(testCorrelation->getJCorrelation() == NULL)<< "jCorrelation null";
 
 	// create  shared pointer to the site
 	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
@@ -195,11 +195,11 @@ TEST(CorrelationTest, HypoOperations) {
 	testCorrelation->addHypo(sharedHypo);
 
 	// check hypo
-	ASSERT_TRUE(testCorrelation->pHypo != NULL)<< "pHypo  not null";
+	ASSERT_TRUE(testCorrelation->getHypo() != NULL)<< "pHypo  not null";
 
 	// remove hypo from correlation
 	testCorrelation->remHypo(sharedHypo);
 
 	// check hypo
-	ASSERT_TRUE(testCorrelation->pHypo == NULL)<< "pHypo null";
+	ASSERT_TRUE(testCorrelation->getHypo() == NULL)<< "pHypo null";
 }

--- a/glasscore/tests/correlation_unittest.cpp
+++ b/glasscore/tests/correlation_unittest.cpp
@@ -125,8 +125,8 @@ TEST(CorrelationTest, Construction) {
 	ASSERT_TRUE(testCorrelation->getJCorrelation() == NULL)<< "jCorrelation null";
 
 	// create  shared pointer to the site
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
 			new glasscore::CSite(siteJSON, NULL));
 
@@ -149,15 +149,15 @@ TEST(CorrelationTest, JSONConstruction) {
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITEJSON))));
 
 	// add site to site list
 	testSiteList->addSite(siteJSON);
 
 	// construct a correlation using a JSON object
-	json::Object * correlationJSON = new json::Object(
-			json::Deserialize(std::string(CORRELATIONJSON)));
+	std::shared_ptr<json::Object> correlationJSON = std::make_shared<json::Object>(
+					json::Object(json::Deserialize(std::string(CORRELATIONJSON))));
 	glasscore::CCorrelation * testCorrelation = new glasscore::CCorrelation(
 			correlationJSON, CORRELATIONID, testSiteList);
 
@@ -172,10 +172,10 @@ TEST(CorrelationTest, HypoOperations) {
 	glassutil::CLogit::disable();
 
 	// create  shared pointer to the site
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-			new glasscore::CSite(siteJSON, NULL));
+				new glasscore::CSite(siteJSON, NULL));
 
 	// create correlation
 	glasscore::CCorrelation *testCorrelation = new glasscore::CCorrelation(

--- a/glasscore/tests/correlation_unittest.cpp
+++ b/glasscore/tests/correlation_unittest.cpp
@@ -29,27 +29,27 @@
 void checkdata(glasscore::CCorrelation * corrleationobject,
 			   const std::string &testinfo) {
 	// check scnl
-	std::string sitescnl = corrleationobject->getSite()->sScnl;
+	std::string sitescnl = corrleationobject->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str());
 
 	// check site
-	std::string sitesite = corrleationobject->getSite()->sSite;
+	std::string sitesite = corrleationobject->getSite()->getSite();
 	std::string expectedsite = std::string(SITE);
 	ASSERT_STREQ(sitesite.c_str(), expectedsite.c_str());
 
 	// check comp
-	std::string sitecomp = corrleationobject->getSite()->sComp;
+	std::string sitecomp = corrleationobject->getSite()->getComp();
 	std::string expectedcomp = std::string(COMP);
 	ASSERT_STREQ(sitecomp.c_str(), expectedcomp.c_str());
 
 	// check net
-	std::string sitenet = corrleationobject->getSite()->sNet;
+	std::string sitenet = corrleationobject->getSite()->getNet();
 	std::string expectednet = std::string(NET);
 	ASSERT_STREQ(sitenet.c_str(), expectednet.c_str());
 
 	// check loc
-	std::string siteloc = corrleationobject->getSite()->sLoc;
+	std::string siteloc = corrleationobject->getSite()->getLoc();
 	std::string expectedloc = std::string(LOC);
 	ASSERT_STREQ(siteloc.c_str(), expectedloc.c_str());
 

--- a/glasscore/tests/correlation_unittest.cpp
+++ b/glasscore/tests/correlation_unittest.cpp
@@ -27,7 +27,7 @@
 
 // check site data for validity
 void checkdata(glasscore::CCorrelation * corrleationobject,
-			   const std::string &testinfo) {
+				const std::string &testinfo) {
 	// check scnl
 	std::string sitescnl = corrleationobject->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
@@ -125,9 +125,10 @@ TEST(CorrelationTest, Construction) {
 	ASSERT_TRUE(testCorrelation->getJCorrelation() == NULL)<< "jCorrelation null";
 
 	// create  shared pointer to the site
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-			new glasscore::CSite(&siteJSON, NULL));
+			new glasscore::CSite(siteJSON, NULL));
 
 	// now init
 	testCorrelation->initialize(sharedTestSite, CORRELATIONTIME, CORRELATIONID,
@@ -148,21 +149,22 @@ TEST(CorrelationTest, JSONConstruction) {
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 
 	// add site to site list
-	testSiteList->addSite(&siteJSON);
+	testSiteList->addSite(siteJSON);
 
 	// construct a correlation using a JSON object
-	json::Object correlationJSON = json::Deserialize(
-			std::string(CORRELATIONJSON));
+	json::Object * correlationJSON = new json::Object(
+			json::Deserialize(std::string(CORRELATIONJSON)));
 	glasscore::CCorrelation * testCorrelation = new glasscore::CCorrelation(
-			&correlationJSON, CORRELATIONID, testSiteList);
+			correlationJSON, CORRELATIONID, testSiteList);
 
 	// check results
 	checkdata(testCorrelation, "json construction check");
 
-	delete(testCorrelation);
+	delete (testCorrelation);
 }
 
 // tests correlation hypo operations
@@ -170,9 +172,10 @@ TEST(CorrelationTest, HypoOperations) {
 	glassutil::CLogit::disable();
 
 	// create  shared pointer to the site
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-			new glasscore::CSite(&siteJSON, NULL));
+			new glasscore::CSite(siteJSON, NULL));
 
 	// create correlation
 	glasscore::CCorrelation *testCorrelation = new glasscore::CCorrelation(

--- a/glasscore/tests/correlationlist_unittest.cpp
+++ b/glasscore/tests/correlationlist_unittest.cpp
@@ -111,7 +111,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	// check testcorrelation
 	ASSERT_TRUE(testCorrelation != NULL)<< "testCorrelation not null";
 	// check scnl
-	std::string sitescnl = testCorrelation->pSite->sScnl;
+	std::string sitescnl = testCorrelation->getSite()->sScnl;
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"testCorrelation has right scnl";
@@ -140,7 +140,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 			testCorrelationList->getCorrelation(2);
 
 	// check scnl
-	sitescnl = test2Correlation->pSite->sScnl;
+	sitescnl = test2Correlation->getSite()->sScnl;
 	expectedscnl = std::string(SCNL2);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"test2Correlation has right scnl";

--- a/glasscore/tests/correlationlist_unittest.cpp
+++ b/glasscore/tests/correlationlist_unittest.cpp
@@ -62,25 +62,31 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	glassutil::CLogit::disable();
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
-	json::Object * site2JSON = new json::Object(
-			json::Deserialize(std::string(SITE2JSON)));
-	json::Object * site3JSON = new json::Object(
-			json::Deserialize(std::string(SITE3JSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
+	std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITE2JSON))));
+	std::shared_ptr<json::Object> site3JSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITE3JSON))));
 
-	json::Object * correlationJSON = new json::Object(
-			json::Deserialize(std::string(CORRELATIONJSON)));
-	json::Object * correlation2JSON = new json::Object(
-			json::Deserialize(std::string(CORRELATION2JSON)));
-	json::Object * correlation3JSON = new json::Object(
-			json::Deserialize(std::string(CORRELATION3JSON)));
-	json::Object * correlation4JSON = new json::Object(
-			json::Deserialize(std::string(CORRELATION4JSON)));
-	json::Object * correlation5JSON = new json::Object(
-			json::Deserialize(std::string(CORRELATION5JSON)));
-	json::Object * correlation6JSON = new json::Object(
-			json::Deserialize(std::string(CORRELATION6JSON)));
+	std::shared_ptr<json::Object> correlationJSON = std::make_shared<
+			json::Object>(
+			json::Object(json::Deserialize(std::string(CORRELATIONJSON))));
+	std::shared_ptr<json::Object> correlation2JSON = std::make_shared<
+			json::Object>(
+			json::Object(json::Deserialize(std::string(CORRELATION2JSON))));
+	std::shared_ptr<json::Object> correlation3JSON = std::make_shared<
+			json::Object>(
+			json::Object(json::Deserialize(std::string(CORRELATION3JSON))));
+	std::shared_ptr<json::Object> correlation4JSON = std::make_shared<
+			json::Object>(
+			json::Object(json::Deserialize(std::string(CORRELATION4JSON))));
+	std::shared_ptr<json::Object> correlation5JSON = std::make_shared<
+			json::Object>(
+			json::Object(json::Deserialize(std::string(CORRELATION5JSON))));
+	std::shared_ptr<json::Object> correlation6JSON = std::make_shared<
+			json::Object>(
+			json::Object(json::Deserialize(std::string(CORRELATION6JSON))));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();

--- a/glasscore/tests/correlationlist_unittest.cpp
+++ b/glasscore/tests/correlationlist_unittest.cpp
@@ -42,12 +42,12 @@ TEST(CorrelationListTest, Construction) {
 
 	// assert default values
 	ASSERT_EQ(-1, testCorrelationList->getNCorrelationTotal())<<
-			"nCorrelationTotal is 0";
+	"nCorrelationTotal is 0";
 	ASSERT_EQ(0, testCorrelationList->getNCorrelation())<< "nCorrelation is 0";
 
 	// lists
 	ASSERT_EQ(0, testCorrelationList->getVCorrelationSize())<<
-			"vCorrelation.size() is 0";
+	"vCorrelation.size() is 0";
 
 	// pointers
 	ASSERT_EQ(NULL, testCorrelationList->getGlass())<< "pGlass null";
@@ -62,30 +62,33 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	glassutil::CLogit::disable();
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
-	json::Object site2JSON = json::Deserialize(std::string(SITE2JSON));
-	json::Object site3JSON = json::Deserialize(std::string(SITE3JSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
+	json::Object * site2JSON = new json::Object(
+			json::Deserialize(std::string(SITE2JSON)));
+	json::Object * site3JSON = new json::Object(
+			json::Deserialize(std::string(SITE3JSON)));
 
-	json::Object correlationJSON = json::Deserialize(
-			std::string(CORRELATIONJSON));
-	json::Object correlation2JSON = json::Deserialize(
-			std::string(CORRELATION2JSON));
-	json::Object correlation3JSON = json::Deserialize(
-			std::string(CORRELATION3JSON));
-	json::Object correlation4JSON = json::Deserialize(
-			std::string(CORRELATION4JSON));
-	json::Object correlation5JSON = json::Deserialize(
-			std::string(CORRELATION5JSON));
-	json::Object correlation6JSON = json::Deserialize(
-			std::string(CORRELATION6JSON));
+	json::Object * correlationJSON = new json::Object(
+			json::Deserialize(std::string(CORRELATIONJSON)));
+	json::Object * correlation2JSON = new json::Object(
+			json::Deserialize(std::string(CORRELATION2JSON)));
+	json::Object * correlation3JSON = new json::Object(
+			json::Deserialize(std::string(CORRELATION3JSON)));
+	json::Object * correlation4JSON = new json::Object(
+			json::Deserialize(std::string(CORRELATION4JSON)));
+	json::Object * correlation5JSON = new json::Object(
+			json::Deserialize(std::string(CORRELATION5JSON)));
+	json::Object * correlation6JSON = new json::Object(
+			json::Deserialize(std::string(CORRELATION6JSON)));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// add sites to site list
-	testSiteList->addSite(&siteJSON);
-	testSiteList->addSite(&site2JSON);
-	testSiteList->addSite(&site3JSON);
+	testSiteList->addSite(siteJSON);
+	testSiteList->addSite(site2JSON);
+	testSiteList->addSite(site3JSON);
 
 	// construct a correlationlist
 	glasscore::CCorrelationList * testCorrelationList =
@@ -95,14 +98,14 @@ TEST(CorrelationListTest, CorrelationOperations) {
 
 	// test indexcorrelation when empty
 	ASSERT_EQ(-2, testCorrelationList->indexCorrelation(0))<<
-			"test indexcorrelation when empty";
+	"test indexcorrelation when empty";
 
 	// test adding correlations by addCorrelation and dispatch
-	testCorrelationList->addCorrelation(&correlationJSON);
-	testCorrelationList->dispatch(&correlation3JSON);
+	testCorrelationList->addCorrelation(correlationJSON);
+	testCorrelationList->dispatch(correlation3JSON);
 	int expectedSize = 2;
 	ASSERT_EQ(expectedSize, testCorrelationList->getNCorrelation())<<
-			"Added Correlations";
+	"Added Correlations";
 
 	// test getting a correlation (first correlation, id 1)
 	std::shared_ptr<glasscore::CCorrelation> testCorrelation =
@@ -113,26 +116,26 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	std::string sitescnl = testCorrelation->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
-			"testCorrelation has right scnl";
+	"testCorrelation has right scnl";
 
 	// test indexcorrelation
 	ASSERT_EQ(-1, testCorrelationList->indexCorrelation(TCORRELATION))<<
-			"test indexcorrelation with time before";
+	"test indexcorrelation with time before";
 	ASSERT_EQ(1, testCorrelationList->indexCorrelation(TCORRELATION2))<<
-			"test indexcorrelation with time after";
+	"test indexcorrelation with time after";
 	ASSERT_EQ(0, testCorrelationList->indexCorrelation(TCORRELATION3))<<
-			"test indexcorrelation with time within";
+	"test indexcorrelation with time within";
 
 	// add more correlations
-	testCorrelationList->addCorrelation(&correlation2JSON);
-	testCorrelationList->addCorrelation(&correlation4JSON);
-	testCorrelationList->addCorrelation(&correlation5JSON);
-	testCorrelationList->addCorrelation(&correlation6JSON);
+	testCorrelationList->addCorrelation(correlation2JSON);
+	testCorrelationList->addCorrelation(correlation4JSON);
+	testCorrelationList->addCorrelation(correlation5JSON);
+	testCorrelationList->addCorrelation(correlation6JSON);
 
 	// check to make sure the size isn't any larger than our max
 	expectedSize = MAXNCORRELATION;
 	ASSERT_EQ(expectedSize, testCorrelationList->getVCorrelationSize())<<
-			"testCorrelationList not larger than max";
+	"testCorrelationList not larger than max";
 
 	// get first correlation, which is now id 2
 	std::shared_ptr<glasscore::CCorrelation> test2Correlation =
@@ -142,13 +145,13 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	sitescnl = test2Correlation->getSite()->getScnl();
 	expectedscnl = std::string(SCNL2);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
-			"test2Correlation has right scnl";
+	"test2Correlation has right scnl";
 
 	// test clearing correlations
 	testCorrelationList->clearCorrelations();
 	expectedSize = 0;
 	ASSERT_EQ(expectedSize, testCorrelationList->getNCorrelation())<<
-			"Cleared Correlations";
+	"Cleared Correlations";
 
 	// cleanup
 	delete (testCorrelationList);

--- a/glasscore/tests/correlationlist_unittest.cpp
+++ b/glasscore/tests/correlationlist_unittest.cpp
@@ -111,7 +111,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	// check testcorrelation
 	ASSERT_TRUE(testCorrelation != NULL)<< "testCorrelation not null";
 	// check scnl
-	std::string sitescnl = testCorrelation->getSite()->sScnl;
+	std::string sitescnl = testCorrelation->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"testCorrelation has right scnl";
@@ -140,7 +140,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 			testCorrelationList->getCorrelation(2);
 
 	// check scnl
-	sitescnl = test2Correlation->getSite()->sScnl;
+	sitescnl = test2Correlation->getSite()->getScnl();
 	expectedscnl = std::string(SCNL2);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"test2Correlation has right scnl";

--- a/glasscore/tests/correlationlist_unittest.cpp
+++ b/glasscore/tests/correlationlist_unittest.cpp
@@ -41,18 +41,17 @@ TEST(CorrelationListTest, Construction) {
 			new glasscore::CCorrelationList();
 
 	// assert default values
-	ASSERT_EQ(-1, testCorrelationList->nCorrelationTotal)<<
+	ASSERT_EQ(-1, testCorrelationList->getNCorrelationTotal())<<
 			"nCorrelationTotal is 0";
-	ASSERT_EQ(0, testCorrelationList->nCorrelation)<< "nCorrelation is 0";
+	ASSERT_EQ(0, testCorrelationList->getNCorrelation())<< "nCorrelation is 0";
 
 	// lists
-	ASSERT_EQ(0, testCorrelationList->vCorrelation.size())<<
+	ASSERT_EQ(0, testCorrelationList->getVCorrelationSize())<<
 			"vCorrelation.size() is 0";
-	ASSERT_EQ(0, testCorrelationList->mCorrelation.size())<<
-			"mCorrelation.size() is 0";
 
 	// pointers
-	ASSERT_EQ(NULL, testCorrelationList->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testCorrelationList->getGlass())<< "pGlass null";
+	ASSERT_EQ(NULL, testCorrelationList->getSiteList())<< "pSiteList null";
 
 	// cleanup
 	delete (testCorrelationList);
@@ -91,8 +90,8 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	// construct a correlationlist
 	glasscore::CCorrelationList * testCorrelationList =
 			new glasscore::CCorrelationList();
-	testCorrelationList->pSiteList = testSiteList;
-	testCorrelationList->nCorrelationMax = MAXNCORRELATION;
+	testCorrelationList->setSiteList(testSiteList);
+	testCorrelationList->setNCorrelationMax(MAXNCORRELATION);
 
 	// test indexcorrelation when empty
 	ASSERT_EQ(-2, testCorrelationList->indexCorrelation(0))<<
@@ -102,7 +101,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	testCorrelationList->addCorrelation(&correlationJSON);
 	testCorrelationList->dispatch(&correlation3JSON);
 	int expectedSize = 2;
-	ASSERT_EQ(expectedSize, testCorrelationList->nCorrelation)<<
+	ASSERT_EQ(expectedSize, testCorrelationList->getNCorrelation())<<
 			"Added Correlations";
 
 	// test getting a correlation (first correlation, id 1)
@@ -132,7 +131,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 
 	// check to make sure the size isn't any larger than our max
 	expectedSize = MAXNCORRELATION;
-	ASSERT_EQ(expectedSize, testCorrelationList->vCorrelation.size())<<
+	ASSERT_EQ(expectedSize, testCorrelationList->getVCorrelationSize())<<
 			"testCorrelationList not larger than max";
 
 	// get first correlation, which is now id 2
@@ -148,7 +147,7 @@ TEST(CorrelationListTest, CorrelationOperations) {
 	// test clearing correlations
 	testCorrelationList->clearCorrelations();
 	expectedSize = 0;
-	ASSERT_EQ(expectedSize, testCorrelationList->nCorrelation)<<
+	ASSERT_EQ(expectedSize, testCorrelationList->getNCorrelation())<<
 			"Cleared Correlations";
 
 	// cleanup

--- a/glasscore/tests/hypo_unittest.cpp
+++ b/glasscore/tests/hypo_unittest.cpp
@@ -136,19 +136,19 @@ TEST(HypoTest, PickOperations) {
 														NULL);
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
-	json::Object * site2JSON = new json::Object(
-			json::Deserialize(std::string(SITE2JSON)));
-	json::Object * site3JSON = new json::Object(
-			json::Deserialize(std::string(SITE3JSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
+	std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITE2JSON))));
+	std::shared_ptr<json::Object> site3JSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITE3JSON))));
 
-	json::Object * pickJSON = new json::Object(
-			json::Deserialize(std::string(PICKJSON)));
-	json::Object * pick2JSON = new json::Object(
-			json::Deserialize(std::string(PICK2JSON)));
-	json::Object * pick3JSON = new json::Object(
-			json::Deserialize(std::string(PICK3JSON)));
+	std::shared_ptr<json::Object> pickJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(PICKJSON))));
+	std::shared_ptr<json::Object> pick2JSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(PICK2JSON))));
+	std::shared_ptr<json::Object> pick3JSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(PICK3JSON))));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();

--- a/glasscore/tests/hypo_unittest.cpp
+++ b/glasscore/tests/hypo_unittest.cpp
@@ -112,10 +112,11 @@ TEST(HypoTest, Construction) {
 	ASSERT_TRUE(testHypo->getGlass() == NULL)<< "pGlass null";
 
 	// now init
-	traveltime::CTravelTime* nullTrav = NULL;
+	std::shared_ptr<traveltime::CTravelTime> nullTrav;
+	std::shared_ptr<traveltime::CTTT> nullTTT;
 	testHypo->initialize(LATITUDE, LONGITUDE, DEPTH, TIME, std::string(ID),
 							std::string(WEB), BAYES, THRESH, CUT, nullTrav,
-							nullTrav, NULL);
+							nullTrav, nullTTT);
 
 	// check results
 	checkdata(testHypo, "initialize check");
@@ -126,14 +127,15 @@ TEST(HypoTest, PickOperations) {
 	glassutil::CLogit::disable();
 
 	// construct a hypo
-	traveltime::CTravelTime* nullTrav = NULL;
+	std::shared_ptr<traveltime::CTravelTime> nullTrav;
+	std::shared_ptr<traveltime::CTTT> nullTTT;
 	glasscore::CHypo * testHypo = new glasscore::CHypo(LATITUDE, LONGITUDE,
 	DEPTH,
 														TIME, std::string(ID),
 														std::string(WEB), BAYES,
 														THRESH,
 														CUT, nullTrav, nullTrav,
-														NULL);
+														nullTTT);
 
 	// create json objects from the strings
 	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(

--- a/glasscore/tests/hypo_unittest.cpp
+++ b/glasscore/tests/hypo_unittest.cpp
@@ -132,32 +132,38 @@ TEST(HypoTest, PickOperations) {
 														TIME, std::string(ID),
 														std::string(WEB), BAYES,
 														THRESH,
-														CUT, nullTrav,
-														nullTrav, NULL);
+														CUT, nullTrav, nullTrav,
+														NULL);
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
-	json::Object site2JSON = json::Deserialize(std::string(SITE2JSON));
-	json::Object site3JSON = json::Deserialize(std::string(SITE3JSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
+	json::Object * site2JSON = new json::Object(
+			json::Deserialize(std::string(SITE2JSON)));
+	json::Object * site3JSON = new json::Object(
+			json::Deserialize(std::string(SITE3JSON)));
 
-	json::Object pickJSON = json::Deserialize(std::string(PICKJSON));
-	json::Object pick2JSON = json::Deserialize(std::string(PICK2JSON));
-	json::Object pick3JSON = json::Deserialize(std::string(PICK3JSON));
+	json::Object * pickJSON = new json::Object(
+			json::Deserialize(std::string(PICKJSON)));
+	json::Object * pick2JSON = new json::Object(
+			json::Deserialize(std::string(PICK2JSON)));
+	json::Object * pick3JSON = new json::Object(
+			json::Deserialize(std::string(PICK3JSON)));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// add sites to site list
-	testSiteList->addSite(&siteJSON);
-	testSiteList->addSite(&site2JSON);
-	testSiteList->addSite(&site3JSON);
+	testSiteList->addSite(siteJSON);
+	testSiteList->addSite(site2JSON);
+	testSiteList->addSite(site3JSON);
 
 	// create picks
-	glasscore::CPick * testPick = new glasscore::CPick(&pickJSON, 1,
+	glasscore::CPick * testPick = new glasscore::CPick(pickJSON, 1,
 														testSiteList);
-	glasscore::CPick * testPick2 = new glasscore::CPick(&pick2JSON, 2,
+	glasscore::CPick * testPick2 = new glasscore::CPick(pick2JSON, 2,
 														testSiteList);
-	glasscore::CPick * testPick3 = new glasscore::CPick(&pick3JSON, 3,
+	glasscore::CPick * testPick3 = new glasscore::CPick(pick3JSON, 3,
 														testSiteList);
 
 	// create new shared pointers to the picks

--- a/glasscore/tests/hypo_unittest.cpp
+++ b/glasscore/tests/hypo_unittest.cpp
@@ -35,47 +35,47 @@
 // check site data for validity
 void checkdata(glasscore::CHypo *hypoobject, const std::string &testinfo) {
 	// check lat
-	double latitude = hypoobject->dLat;
+	double latitude = hypoobject->getLat();
 	double expectedLatitude = LATITUDE;
 	ASSERT_NEAR(latitude, expectedLatitude, 0.0001);
 
 	// check lon
-	double longitude = hypoobject->dLon;
+	double longitude = hypoobject->getLon();
 	double expectedLongitude = LONGITUDE;
 	ASSERT_NEAR(longitude, expectedLongitude, 0.0001);
 
 	// check depth
-	double depth = hypoobject->dZ;
+	double depth = hypoobject->getZ();
 	double expectedDepth = DEPTH;
 	ASSERT_NEAR(depth, expectedDepth, 0.0001);
 
 	// check time
-	double time = hypoobject->tOrg;
+	double time = hypoobject->getTOrg();
 	double expectedTime = TIME;
 	ASSERT_NEAR(time, expectedTime, 0.0001);
 
 	// check id
-	std::string id = hypoobject->sPid;
+	std::string id = hypoobject->getPid();
 	std::string expectedId = ID;
 	ASSERT_STREQ(id.c_str(), expectedId.c_str());
 
 	// check web
-	std::string web = hypoobject->sWeb;
+	std::string web = hypoobject->getWebName();
 	std::string expectedWeb = std::string(WEB);
 	ASSERT_STREQ(web.c_str(), expectedWeb.c_str());
 
 	// check bayes
-	double bayes = hypoobject->dBayes;
+	double bayes = hypoobject->getBayes();
 	double expectedBayes = BAYES;
 	ASSERT_NEAR(bayes, expectedBayes, 0.0001);
 
 	// check bayes
-	double thresh = hypoobject->dThresh;
+	double thresh = hypoobject->getThresh();
 	double expectedThresh = THRESH;
 	ASSERT_NEAR(thresh, expectedThresh, 0.0001);
 
 	// check cut
-	int cut = hypoobject->nCut;
+	int cut = hypoobject->getCut();
 	int expectedCut = CUT;
 	ASSERT_EQ(cut, expectedCut);
 }
@@ -88,32 +88,28 @@ TEST(HypoTest, Construction) {
 	glasscore::CHypo * testHypo = new glasscore::CHypo();
 
 	// assert default values
-	ASSERT_EQ(0, testHypo->dLat)<< "dLat is zero";
-	ASSERT_EQ(0, testHypo->dLon)<< "dLon is zero";
-	ASSERT_EQ(0, testHypo->dZ)<< "dZ is zero";
-	ASSERT_EQ(0, testHypo->tOrg)<< "tOrg is zero";
-	ASSERT_STREQ("", testHypo->sPid.c_str())<< "sPid is empty";
-	ASSERT_STREQ("", testHypo->sWeb.c_str())<< "sWeb is empty";
-	ASSERT_EQ(0, testHypo->dBayes)<< "dBayes is zero";
-	ASSERT_EQ(0, testHypo->dThresh)<< "dThresh is zero";
-	ASSERT_EQ(0, testHypo->nCut)<< "nCut is zero";
-	ASSERT_EQ(0, testHypo->iCycle)<< "iCycle is zero";
-	ASSERT_EQ(0, testHypo->nWts)<< "nWts is zero";
-	ASSERT_EQ(0, testHypo->dMed)<< "dMed is zero";
-	ASSERT_EQ(0, testHypo->dMin)<< "dMin is zero";
-	ASSERT_EQ(0, testHypo->dGap)<< "dGap is zero";
-	ASSERT_EQ(0, testHypo->dSig)<< "dSig is zero";
-	ASSERT_EQ(0, testHypo->dKrt)<< "dKrt is zero";
-	ASSERT_FALSE(testHypo->bFixed)<< "bFixed is false";
-	ASSERT_FALSE(testHypo->bRefine)<< "bRefine is false";
-	ASSERT_FALSE(testHypo->bQuake)<< "bQuake is false";
-	ASSERT_FALSE(testHypo->bEvent)<< "bEvent is false";
+	ASSERT_EQ(0, testHypo->getLat())<< "dLat is zero";
+	ASSERT_EQ(0, testHypo->getLon())<< "dLon is zero";
+	ASSERT_EQ(0, testHypo->getZ())<< "dZ is zero";
+	ASSERT_EQ(0, testHypo->getTOrg())<< "tOrg is zero";
+	ASSERT_STREQ("", testHypo->getPid().c_str())<< "sPid is empty";
+	ASSERT_STREQ("", testHypo->getWebName().c_str())<< "sWeb is empty";
+	ASSERT_EQ(0, testHypo->getBayes())<< "dBayes is zero";
+	ASSERT_EQ(0, testHypo->getThresh())<< "dThresh is zero";
+	ASSERT_EQ(0, testHypo->getCut())<< "nCut is zero";
+	ASSERT_EQ(0, testHypo->getCycle())<< "iCycle is zero";
+	ASSERT_EQ(0, testHypo->getMed())<< "dMed is zero";
+	ASSERT_EQ(0, testHypo->getMin())<< "dMin is zero";
+	ASSERT_EQ(0, testHypo->getGap())<< "dGap is zero";
+	ASSERT_EQ(0, testHypo->getSig())<< "dSig is zero";
+	ASSERT_EQ(0, testHypo->getKrt())<< "dKrt is zero";
+	ASSERT_FALSE(testHypo->getFixed())<< "bFixed is false";
+	ASSERT_FALSE(testHypo->getEvent())<< "bEvent is false";
 
-	ASSERT_EQ(0, testHypo->vPick.size())<< "vPick size is zero";
-	ASSERT_EQ(0, testHypo->vWts.size())<< "vWts size is zero";
+	ASSERT_EQ(0, testHypo->getVPickSize())<< "vPick size is zero";
 
 	// pointers
-	ASSERT_TRUE(testHypo->pGlass == NULL)<< "pGlass null";
+	ASSERT_TRUE(testHypo->getGlass() == NULL)<< "pGlass null";
 
 	// now init
 	traveltime::CTravelTime* nullTrav = NULL;
@@ -176,7 +172,7 @@ TEST(HypoTest, PickOperations) {
 
 	// check to make sure the size isn't any larger than our max
 	int expectedSize = MAXNPICK;
-	ASSERT_EQ(expectedSize, testHypo->vPick.size())<<
+	ASSERT_EQ(expectedSize, testHypo->getVPickSize())<<
 	"hypo vPick not larger than max";
 
 	// remove picks from hypo
@@ -185,5 +181,5 @@ TEST(HypoTest, PickOperations) {
 
 	// check to see that only one pick remains
 	expectedSize = 1;
-	ASSERT_EQ(expectedSize, testHypo->vPick.size())<< "hypo has only one pick";
+	ASSERT_EQ(expectedSize, testHypo->getVPickSize())<< "hypo has only one pick";
 }

--- a/glasscore/tests/hypolist_unittest.cpp
+++ b/glasscore/tests/hypolist_unittest.cpp
@@ -127,7 +127,7 @@ TEST(HypoListTest, HypoOperations) {
 	ASSERT_TRUE(testHypo != NULL)<< "testHypo not null";
 
 	// check id
-	std::string hypoId = testHypo->sPid;
+	std::string hypoId = testHypo->getPid();
 	std::string expectedId = std::string(TESTHYPOID);
 	ASSERT_STREQ(hypoId.c_str(), expectedId.c_str())<< "testHypo has right id";
 

--- a/glasscore/tests/hypolist_unittest.cpp
+++ b/glasscore/tests/hypolist_unittest.cpp
@@ -32,16 +32,15 @@ TEST(HypoListTest, Construction) {
 	glasscore::CHypoList * testHypoList = new glasscore::CHypoList();
 
 	// assert default values
-	ASSERT_EQ(-1, testHypoList->nHypoTotal)<< "nPickTotal is 0";
-	ASSERT_EQ(0, testHypoList->nHypo)<< "nHypo is 0";
+	ASSERT_EQ(-1, testHypoList->getNHypoTotal())<< "nPickTotal is 0";
+	ASSERT_EQ(0, testHypoList->getNHypo())<< "nHypo is 0";
 
 	// lists
-	ASSERT_EQ(0, testHypoList->vHypo.size())<< "vHypo.size() is 0";
-	ASSERT_EQ(0, testHypoList->mHypo.size())<< "mHypo.size() is 0";
-	ASSERT_EQ(0, testHypoList->qFifo.size())<< "qFifo.size() is 0";
+	ASSERT_EQ(0, testHypoList->getVHypoSize())<< "vHypo.size() is 0";
+	ASSERT_EQ(0, testHypoList->getFifoSize())<< "qFifo.size() is 0";
 
 	// pointers
-	ASSERT_EQ(NULL, testHypoList->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testHypoList->getGlass())<< "pGlass null";
 
 	// cleanup
 	delete (testHypoList);
@@ -89,7 +88,7 @@ TEST(HypoListTest, HypoOperations) {
 	// construct a hypolist
 	glasscore::CHypoList * testHypoList = new glasscore::CHypoList();
 
-	testHypoList->nHypoMax = MAXNHYPO;
+	testHypoList->setNHypoMax(MAXNHYPO);
 
 	// test indexpick when empty
 	ASSERT_EQ(-2, testHypoList->indexHypo(0))<< "test indexHypo when empty";
@@ -98,7 +97,7 @@ TEST(HypoListTest, HypoOperations) {
 	testHypoList->addHypo(hypo1, false);
 	testHypoList->addHypo(hypo2, false);
 	int expectedSize = 2;
-	ASSERT_EQ(expectedSize, testHypoList->nHypo)<< "Added Hypos";
+	ASSERT_EQ(expectedSize, testHypoList->getNHypo())<< "Added Hypos";
 
 	// test indexHypo
 	ASSERT_EQ(-1, testHypoList->indexHypo(TORG))<<
@@ -116,7 +115,7 @@ TEST(HypoListTest, HypoOperations) {
 
 	// check to make sure the size isn't any larger than our max
 	expectedSize = MAXNHYPO;
-	ASSERT_EQ(expectedSize, (int)testHypoList->vHypo.size())<<
+	ASSERT_EQ(expectedSize, (int)testHypoList->getVHypoSize())<<
 	"testHypoList not larger than max";
 
 	// test getting a hypo
@@ -136,13 +135,13 @@ TEST(HypoListTest, HypoOperations) {
 
 	// check to make sure the size is now one less
 	expectedSize = MAXNHYPO - 1;
-	ASSERT_EQ(expectedSize, (int)testHypoList->vHypo.size())<<
+	ASSERT_EQ(expectedSize, (int)testHypoList->getVHypoSize())<<
 	"testHypoList is one smaller";
 
 	// test clearing hypos
 	testHypoList->clearHypos();
 	expectedSize = 0;
-	ASSERT_EQ(expectedSize, (int)testHypoList->nHypo)<< "Cleared Hypos";
+	ASSERT_EQ(expectedSize, (int)testHypoList->getNHypo())<< "Cleared Hypos";
 
 	// cleanup
 	delete (testHypoList);

--- a/glasscore/tests/hypolist_unittest.cpp
+++ b/glasscore/tests/hypolist_unittest.cpp
@@ -50,40 +50,39 @@ TEST(HypoListTest, Construction) {
 TEST(HypoListTest, HypoOperations) {
 	glassutil::CLogit::disable();
 
-	traveltime::CTTT * nullTTT = NULL;
-
 	// create hypo objects
-	traveltime::CTravelTime* nullTrav = NULL;
+	std::shared_ptr<traveltime::CTravelTime> nullTrav;
+	std::shared_ptr<traveltime::CTTT> nullTTT;
 	std::shared_ptr<glasscore::CHypo> hypo1 =
 			std::make_shared<glasscore::CHypo>(-21.84, 170.03, 10.0,
 												3648585210.926340, "1", "Test",
-												0.0, 0.5, 6, nullTrav,
-												nullTrav, nullTTT);
+												0.0, 0.5, 6, nullTrav, nullTrav,
+												nullTTT);
 	std::shared_ptr<glasscore::CHypo> hypo2 =
 			std::make_shared<glasscore::CHypo>(22.84, 70.03, 12.0,
 												3648585208.926340, "2", "Test",
-												0.0, 0.5, 6, nullTrav,
-												nullTrav, nullTTT);
+												0.0, 0.5, 6, nullTrav, nullTrav,
+												nullTTT);
 	std::shared_ptr<glasscore::CHypo> hypo3 =
 			std::make_shared<glasscore::CHypo>(41.84, -120.03, 8.0,
 												3648585222.926340, "3", "Test",
-												0.0, 0.5, 6, nullTrav,
-												nullTrav, nullTTT);
+												0.0, 0.5, 6, nullTrav, nullTrav,
+												nullTTT);
 	std::shared_ptr<glasscore::CHypo> hypo4 =
 			std::make_shared<glasscore::CHypo>(-1.84, 10.03, 100.0,
 												3648585250.926340, "4", "Test",
-												0.0, 0.5, 6, nullTrav,
-												nullTrav, nullTTT);
+												0.0, 0.5, 6, nullTrav, nullTrav,
+												nullTTT);
 	std::shared_ptr<glasscore::CHypo> hypo5 =
 			std::make_shared<glasscore::CHypo>(1.84, -170.03, 67.0,
 												3648585233.926340, "5", "Test",
-												0.0, 0.5, 6, nullTrav,
-												nullTrav, nullTTT);
+												0.0, 0.5, 6, nullTrav, nullTrav,
+												nullTTT);
 	std::shared_ptr<glasscore::CHypo> hypo6 =
 			std::make_shared<glasscore::CHypo>(46.84, 135.03, 42.0,
 												3648585211.926340, "6", "Test",
-												0.0, 0.5, 6, nullTrav,
-												nullTrav, nullTTT);
+												0.0, 0.5, 6, nullTrav, nullTrav,
+												nullTTT);
 
 	// construct a hypolist
 	glasscore::CHypoList * testHypoList = new glasscore::CHypoList();

--- a/glasscore/tests/node_unittest.cpp
+++ b/glasscore/tests/node_unittest.cpp
@@ -68,10 +68,11 @@ TEST(NodeTest, SiteOperations) {
 														std::string(NODEID));
 
 	// create json object from the string
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+					json::Object(json::Deserialize(std::string(SITEJSON))));
 
 	// construct sites using JSON objects
-	glasscore::CSite * testSite = new glasscore::CSite(&siteJSON, NULL);
+	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
 
 	// create new shared pointer to the node
 	std::shared_ptr<glasscore::CNode> sharedTestNode(testNode);

--- a/glasscore/tests/node_unittest.cpp
+++ b/glasscore/tests/node_unittest.cpp
@@ -32,23 +32,23 @@ TEST(NodeTest, Construction) {
 														std::string(NODEID));
 
 	// name
-	ASSERT_STREQ(std::string(NAME).c_str(), testNode->sName.c_str())<<
+	ASSERT_STREQ(std::string(NAME).c_str(), testNode->getName().c_str())<<
 			"Node Name Matches";
 
 	// latitude
-	ASSERT_EQ(LATITUDE, testNode->dLat)<< "Node Latitude Check";
+	ASSERT_EQ(LATITUDE, testNode->getLat())<< "Node Latitude Check";
 
 	// longitude
-	ASSERT_EQ(LONGITUDE, testNode->dLon)<< "Node Longitude Check";
+	ASSERT_EQ(LONGITUDE, testNode->getLon())<< "Node Longitude Check";
 
 	// depth
-	ASSERT_EQ(DEPTH, testNode->dZ)<< "Node Depth Check";
+	ASSERT_EQ(DEPTH, testNode->getZ())<< "Node Depth Check";
 
 	// resolution
-	ASSERT_EQ(RESOLUTION, testNode->dResolution)<< "Node Resolution Check";
+	ASSERT_EQ(RESOLUTION, testNode->getResolution())<< "Node Resolution Check";
 
 	// id
-	ASSERT_STREQ(std::string(NODEID).c_str(), testNode->sPid.c_str())<<
+	ASSERT_STREQ(std::string(NODEID).c_str(), testNode->getPid().c_str())<<
 			"Node ID Matches";
 
 	// site list

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -157,11 +157,12 @@ TEST(PickTest, HypoOperations) {
 			std::string(PICKIDSTRING), BACKAZIMUTH, SLOWNESS);
 
 	// create a hypo
-	traveltime::CTravelTime* nullTrav = NULL;
+	std::shared_ptr<traveltime::CTravelTime> nullTrav;
+	std::shared_ptr<traveltime::CTTT> nullTTT;
 	glasscore::CHypo * testHypo = new glasscore::CHypo(0.0, 0.0, 0.0, 0.0, "1",
 														"test", 0.0, 0.0, 0,
 														nullTrav, nullTrav,
-														NULL);
+														nullTTT);
 
 	// create new shared pointer to the hypo
 	std::shared_ptr<glasscore::CHypo> sharedHypo(testHypo);

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -28,52 +28,52 @@
 // check site data for validity
 void checkdata(glasscore::CPick * pickobject, const std::string &testinfo) {
 	// check scnl
-	std::string sitescnl = pickobject->pSite->sScnl;
+	std::string sitescnl = pickobject->getSite()->sScnl;
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str());
 
 	// check site
-	std::string sitesite = pickobject->pSite->sSite;
+	std::string sitesite = pickobject->getSite()->sSite;
 	std::string expectedsite = std::string(SITE);
 	ASSERT_STREQ(sitesite.c_str(), expectedsite.c_str());
 
 	// check comp
-	std::string sitecomp = pickobject->pSite->sComp;
+	std::string sitecomp = pickobject->getSite()->sComp;
 	std::string expectedcomp = std::string(COMP);
 	ASSERT_STREQ(sitecomp.c_str(), expectedcomp.c_str());
 
 	// check net
-	std::string sitenet = pickobject->pSite->sNet;
+	std::string sitenet = pickobject->getSite()->sNet;
 	std::string expectednet = std::string(NET);
 	ASSERT_STREQ(sitenet.c_str(), expectednet.c_str());
 
 	// check loc
-	std::string siteloc = pickobject->pSite->sLoc;
+	std::string siteloc = pickobject->getSite()->sLoc;
 	std::string expectedloc = std::string(LOC);
 	ASSERT_STREQ(siteloc.c_str(), expectedloc.c_str());
 
 	// check time
-	double picktime = pickobject->tPick;
+	double picktime = pickobject->getTPick();
 	double expectedtime = PICKTIME;
 	ASSERT_NEAR(picktime, expectedtime, 0.0001);
 
 	// check backazimuth
-	double beambackazimuth = pickobject->dBackAzimuth;
+	double beambackazimuth = pickobject->getBackAzimuth();
 	double expectedbackazimuth = BACKAZIMUTH;
 	ASSERT_EQ(beambackazimuth, expectedbackazimuth);
 
 	// check slowness
-	double beamslowness = pickobject->dSlowness;
+	double beamslowness = pickobject->getSlowness();
 	double expectedslowness = SLOWNESS;
 	ASSERT_EQ(beamslowness, expectedslowness);
 
 	// check id
-	int pickid = pickobject->idPick;
+	int pickid = pickobject->getIdPick();
 	double expectedpickid = PICKID;
 	ASSERT_EQ(pickid, expectedpickid);
 
 	// check string id
-	std::string pickstringid = pickobject->sPid;
+	std::string pickstringid = pickobject->getPid();
 	std::string expectedstringid = std::string(PICKIDSTRING);
 	ASSERT_STREQ(pickstringid.c_str(), expectedstringid.c_str());
 }
@@ -86,18 +86,18 @@ TEST(PickTest, Construction) {
 	glasscore::CPick * testPick = new glasscore::CPick();
 
 	// assert default values
-	ASSERT_EQ(0, testPick->tPick)<< "time is zero";
-	ASSERT_EQ(-1, testPick->dBackAzimuth)<< "backazimuth is -1";
-	ASSERT_EQ(-1, testPick->dSlowness)<< "slowness is -1";
-	ASSERT_EQ(0, testPick->idPick)<< "id is zero";
-	ASSERT_STREQ("", testPick->sAss.c_str());
-	ASSERT_STREQ("", testPick->sPhs.c_str());
-	ASSERT_STREQ("", testPick->sPid.c_str());
+	ASSERT_EQ(0, testPick->getTPick())<< "time is zero";
+	ASSERT_EQ(-1, testPick->getBackAzimuth())<< "backazimuth is -1";
+	ASSERT_EQ(-1, testPick->getSlowness())<< "slowness is -1";
+	ASSERT_EQ(0, testPick->getIdPick())<< "id is zero";
+	ASSERT_STREQ("", testPick->getAss().c_str());
+	ASSERT_STREQ("", testPick->getPhs().c_str());
+	ASSERT_STREQ("", testPick->getPid().c_str());
 
 	// pointers
-	ASSERT_TRUE(testPick->pSite == NULL)<< "pSite null";
-	ASSERT_TRUE(testPick->pHypo == NULL)<< "pHypo null";
-	ASSERT_TRUE(testPick->jPick == NULL)<< "jPick null";
+	ASSERT_TRUE(testPick->getSite() == NULL)<< "pSite null";
+	ASSERT_TRUE(testPick->getHypo() == NULL)<< "pHypo null";
+	ASSERT_TRUE(testPick->getJPick() == NULL)<< "jPick null";
 
 	// create  shared pointer to the site
 	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
@@ -165,11 +165,11 @@ TEST(PickTest, HypoOperations) {
 	testPick->addHypo(sharedHypo);
 
 	// check hypo
-	ASSERT_TRUE(testPick->pHypo != NULL)<< "pHypo  not null";
+	ASSERT_TRUE(testPick->getHypo() != NULL)<< "pHypo  not null";
 
 	// remove hypo from pick
 	testPick->remHypo(sharedHypo);
 
 	// check hypo
-	ASSERT_TRUE(testPick->pHypo == NULL)<< "pHypo null";
+	ASSERT_TRUE(testPick->getHypo() == NULL)<< "pHypo null";
 }

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -100,9 +100,10 @@ TEST(PickTest, Construction) {
 	ASSERT_TRUE(testPick->getJPick() == NULL)<< "jPick null";
 
 	// create  shared pointer to the site
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-			new glasscore::CSite(&siteJSON, NULL));
+			new glasscore::CSite(siteJSON, NULL));
 
 	// now init
 	testPick->initialize(sharedTestSite, PICKTIME, PICKID,
@@ -111,7 +112,7 @@ TEST(PickTest, Construction) {
 	// check results
 	checkdata(testPick, "initialize check");
 
-	delete(testPick);
+	delete (testPick);
 }
 
 // tests to see if the pick can be constructed from JSON
@@ -122,14 +123,16 @@ TEST(PickTest, JSONConstruction) {
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 
 	// add site to site list
-	testSiteList->addSite(&siteJSON);
+	testSiteList->addSite(siteJSON);
 
 	// construct a pick using a JSON object
-	json::Object pickJSON = json::Deserialize(std::string(PICKJSON));
-	glasscore::CPick * testPick = new glasscore::CPick(&pickJSON, PICKID,
+	json::Object * pickJSON = new json::Object(
+			json::Deserialize(std::string(PICKJSON)));
+	glasscore::CPick * testPick = new glasscore::CPick(pickJSON, PICKID,
 														testSiteList);
 
 	// check results
@@ -141,9 +144,10 @@ TEST(PickTest, HypoOperations) {
 	glassutil::CLogit::disable();
 
 	// create  shared pointer to the site
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-			new glasscore::CSite(&siteJSON, NULL));
+			new glasscore::CSite(siteJSON, NULL));
 
 	// create pick
 	glasscore::CPick * testPick = new glasscore::CPick(

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -28,27 +28,27 @@
 // check site data for validity
 void checkdata(glasscore::CPick * pickobject, const std::string &testinfo) {
 	// check scnl
-	std::string sitescnl = pickobject->getSite()->sScnl;
+	std::string sitescnl = pickobject->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str());
 
 	// check site
-	std::string sitesite = pickobject->getSite()->sSite;
+	std::string sitesite = pickobject->getSite()->getSite();
 	std::string expectedsite = std::string(SITE);
 	ASSERT_STREQ(sitesite.c_str(), expectedsite.c_str());
 
 	// check comp
-	std::string sitecomp = pickobject->getSite()->sComp;
+	std::string sitecomp = pickobject->getSite()->getComp();
 	std::string expectedcomp = std::string(COMP);
 	ASSERT_STREQ(sitecomp.c_str(), expectedcomp.c_str());
 
 	// check net
-	std::string sitenet = pickobject->getSite()->sNet;
+	std::string sitenet = pickobject->getSite()->getNet();
 	std::string expectednet = std::string(NET);
 	ASSERT_STREQ(sitenet.c_str(), expectednet.c_str());
 
 	// check loc
-	std::string siteloc = pickobject->getSite()->sLoc;
+	std::string siteloc = pickobject->getSite()->getLoc();
 	std::string expectedloc = std::string(LOC);
 	ASSERT_STREQ(siteloc.c_str(), expectedloc.c_str());
 

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -100,8 +100,8 @@ TEST(PickTest, Construction) {
 	ASSERT_TRUE(testPick->getJPick() == NULL)<< "jPick null";
 
 	// create  shared pointer to the site
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
 			new glasscore::CSite(siteJSON, NULL));
 
@@ -123,15 +123,16 @@ TEST(PickTest, JSONConstruction) {
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
 
 	// add site to site list
 	testSiteList->addSite(siteJSON);
 
 	// construct a pick using a JSON object
-	json::Object * pickJSON = new json::Object(
-			json::Deserialize(std::string(PICKJSON)));
+	std::shared_ptr<json::Object> pickJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(PICKJSON))));
+
 	glasscore::CPick * testPick = new glasscore::CPick(pickJSON, PICKID,
 														testSiteList);
 
@@ -144,10 +145,10 @@ TEST(PickTest, HypoOperations) {
 	glassutil::CLogit::disable();
 
 	// create  shared pointer to the site
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-			new glasscore::CSite(siteJSON, NULL));
+					new glasscore::CSite(siteJSON, NULL));
 
 	// create pick
 	glasscore::CPick * testPick = new glasscore::CPick(

--- a/glasscore/tests/picklist_unittest.cpp
+++ b/glasscore/tests/picklist_unittest.cpp
@@ -59,25 +59,25 @@ TEST(PickListTest, PickOperations) {
 	glassutil::CLogit::disable();
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
-	json::Object * site2JSON = new json::Object(
-			json::Deserialize(std::string(SITE2JSON)));
-	json::Object * site3JSON = new json::Object(
-			json::Deserialize(std::string(SITE3JSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITEJSON))));
+	std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITE2JSON))));
+	std::shared_ptr<json::Object> site3JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITE3JSON))));
 
-	json::Object *pickJSON = new json::Object(
-			json::Deserialize(std::string(PICKJSON)));
-	json::Object *pick2JSON = new json::Object(
-			json::Deserialize(std::string(PICK2JSON)));
-	json::Object *pick3JSON = new json::Object(
-			json::Deserialize(std::string(PICK3JSON)));
-	json::Object *pick4JSON = new json::Object(
-			json::Deserialize(std::string(PICK4JSON)));
-	json::Object *pick5JSON = new json::Object(
-			json::Deserialize(std::string(PICK5JSON)));
-	json::Object *pick6JSON = new json::Object(
-			json::Deserialize(std::string(PICK6JSON)));
+	std::shared_ptr<json::Object> pickJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(PICKJSON))));
+	std::shared_ptr<json::Object> pick2JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(PICK2JSON))));
+	std::shared_ptr<json::Object> pick3JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(PICK3JSON))));
+	std::shared_ptr<json::Object> pick4JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(PICK4JSON))));
+	std::shared_ptr<json::Object> pick5JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(PICK5JSON))));
+	std::shared_ptr<json::Object> pick6JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(PICK6JSON))));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();

--- a/glasscore/tests/picklist_unittest.cpp
+++ b/glasscore/tests/picklist_unittest.cpp
@@ -97,7 +97,7 @@ TEST(PickListTest, PickOperations) {
 	// check testpick
 	ASSERT_TRUE(testPick != NULL)<< "testPick not null";
 	// check scnl
-	std::string sitescnl = testPick->getSite()->sScnl;
+	std::string sitescnl = testPick->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"testPick has right scnl";
@@ -125,7 +125,7 @@ TEST(PickListTest, PickOperations) {
 	std::shared_ptr<glasscore::CPick> test2Pick = testPickList->getPick(2);
 
 	// check scnl
-	sitescnl = test2Pick->getSite()->sScnl;
+	sitescnl = test2Pick->getSite()->getScnl();
 	expectedscnl = std::string(SCNL2);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"test2Pick has right scnl";

--- a/glasscore/tests/picklist_unittest.cpp
+++ b/glasscore/tests/picklist_unittest.cpp
@@ -40,15 +40,15 @@ TEST(PickListTest, Construction) {
 	glasscore::CPickList * testPickList = new glasscore::CPickList();
 
 	// assert default values
-	ASSERT_EQ(-1, testPickList->nPickTotal)<< "nPickTotal is 0";
-	ASSERT_EQ(0, testPickList->nPick)<< "nPick is 0";
+	ASSERT_EQ(-1, testPickList->getNPickTotal())<< "nPickTotal is 0";
+	ASSERT_EQ(0, testPickList->getNPick())<< "nPick is 0";
 
 	// lists
-	ASSERT_EQ(0, testPickList->vPick.size())<< "vPick.size() is 0";
-	ASSERT_EQ(0, testPickList->mPick.size())<< "mPick.size() is 0";
+	ASSERT_EQ(0, testPickList->getVPickSize())<< "getVPickSize() is 0";
 
 	// pointers
-	ASSERT_EQ(NULL, testPickList->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testPickList->getGlass())<< "pGlass null";
+	ASSERT_EQ(NULL, testPickList->getSiteList())<< "pSiteList null";
 
 	// cleanup
 	delete (testPickList);
@@ -80,8 +80,8 @@ TEST(PickListTest, PickOperations) {
 
 	// construct a picklist
 	glasscore::CPickList * testPickList = new glasscore::CPickList();
-	testPickList->pSiteList = testSiteList;
-	testPickList->nPickMax = MAXNPICK;
+	testPickList->setSiteList(testSiteList);
+	testPickList->setNPickMax(MAXNPICK);
 
 	// test indexpick when empty
 	ASSERT_EQ(-2, testPickList->indexPick(0))<< "test indexpick when empty";
@@ -90,7 +90,7 @@ TEST(PickListTest, PickOperations) {
 	testPickList->addPick(&pickJSON);
 	testPickList->dispatch(&pick3JSON);
 	int expectedSize = 2;
-	ASSERT_EQ(expectedSize, testPickList->nPick)<< "Added Picks";
+	ASSERT_EQ(expectedSize, testPickList->getNPick())<< "Added Picks";
 
 	// test getting a pick (first pick, id 1)
 	std::shared_ptr<glasscore::CPick> testPick = testPickList->getPick(1);
@@ -118,7 +118,7 @@ TEST(PickListTest, PickOperations) {
 
 	// check to make sure the size isn't any larger than our max
 	expectedSize = MAXNPICK;
-	ASSERT_EQ(expectedSize, testPickList->vPick.size())<<
+	ASSERT_EQ(expectedSize, testPickList->getVPickSize())<<
 			"testPickList not larger than max";
 
 	// get first pick, which is now id 2
@@ -133,7 +133,7 @@ TEST(PickListTest, PickOperations) {
 	// test clearing picks
 	testPickList->clearPicks();
 	expectedSize = 0;
-	ASSERT_EQ(expectedSize, testPickList->nPick)<< "Cleared Picks";
+	ASSERT_EQ(expectedSize, testPickList->getNPick())<< "Cleared Picks";
 
 	// cleanup
 	delete (testPickList);

--- a/glasscore/tests/picklist_unittest.cpp
+++ b/glasscore/tests/picklist_unittest.cpp
@@ -97,7 +97,7 @@ TEST(PickListTest, PickOperations) {
 	// check testpick
 	ASSERT_TRUE(testPick != NULL)<< "testPick not null";
 	// check scnl
-	std::string sitescnl = testPick->pSite->sScnl;
+	std::string sitescnl = testPick->getSite()->sScnl;
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"testPick has right scnl";
@@ -125,7 +125,7 @@ TEST(PickListTest, PickOperations) {
 	std::shared_ptr<glasscore::CPick> test2Pick = testPickList->getPick(2);
 
 	// check scnl
-	sitescnl = test2Pick->pSite->sScnl;
+	sitescnl = test2Pick->getSite()->sScnl;
 	expectedscnl = std::string(SCNL2);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
 			"test2Pick has right scnl";

--- a/glasscore/tests/picklist_unittest.cpp
+++ b/glasscore/tests/picklist_unittest.cpp
@@ -59,24 +59,33 @@ TEST(PickListTest, PickOperations) {
 	glassutil::CLogit::disable();
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
-	json::Object site2JSON = json::Deserialize(std::string(SITE2JSON));
-	json::Object site3JSON = json::Deserialize(std::string(SITE3JSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
+	json::Object * site2JSON = new json::Object(
+			json::Deserialize(std::string(SITE2JSON)));
+	json::Object * site3JSON = new json::Object(
+			json::Deserialize(std::string(SITE3JSON)));
 
-	json::Object pickJSON = json::Deserialize(std::string(PICKJSON));
-	json::Object pick2JSON = json::Deserialize(std::string(PICK2JSON));
-	json::Object pick3JSON = json::Deserialize(std::string(PICK3JSON));
-	json::Object pick4JSON = json::Deserialize(std::string(PICK4JSON));
-	json::Object pick5JSON = json::Deserialize(std::string(PICK5JSON));
-	json::Object pick6JSON = json::Deserialize(std::string(PICK6JSON));
+	json::Object *pickJSON = new json::Object(
+			json::Deserialize(std::string(PICKJSON)));
+	json::Object *pick2JSON = new json::Object(
+			json::Deserialize(std::string(PICK2JSON)));
+	json::Object *pick3JSON = new json::Object(
+			json::Deserialize(std::string(PICK3JSON)));
+	json::Object *pick4JSON = new json::Object(
+			json::Deserialize(std::string(PICK4JSON)));
+	json::Object *pick5JSON = new json::Object(
+			json::Deserialize(std::string(PICK5JSON)));
+	json::Object *pick6JSON = new json::Object(
+			json::Deserialize(std::string(PICK6JSON)));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// add sites to site list
-	testSiteList->addSite(&siteJSON);
-	testSiteList->addSite(&site2JSON);
-	testSiteList->addSite(&site3JSON);
+	testSiteList->addSite(siteJSON);
+	testSiteList->addSite(site2JSON);
+	testSiteList->addSite(site3JSON);
 
 	// construct a picklist
 	glasscore::CPickList * testPickList = new glasscore::CPickList();
@@ -87,8 +96,8 @@ TEST(PickListTest, PickOperations) {
 	ASSERT_EQ(-2, testPickList->indexPick(0))<< "test indexpick when empty";
 
 	// test adding picks by addPick and dispatch
-	testPickList->addPick(&pickJSON);
-	testPickList->dispatch(&pick3JSON);
+	testPickList->addPick(pickJSON);
+	testPickList->dispatch(pick3JSON);
 	int expectedSize = 2;
 	ASSERT_EQ(expectedSize, testPickList->getNPick())<< "Added Picks";
 
@@ -100,26 +109,26 @@ TEST(PickListTest, PickOperations) {
 	std::string sitescnl = testPick->getSite()->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
-			"testPick has right scnl";
+	"testPick has right scnl";
 
 	// test indexpick
 	ASSERT_EQ(-1, testPickList->indexPick(TPICK))<<
-			"test indexpick with time before";
+	"test indexpick with time before";
 	ASSERT_EQ(1, testPickList->indexPick(TPICK2))<<
-			"test indexpick with time after";
+	"test indexpick with time after";
 	ASSERT_EQ(0, testPickList->indexPick(TPICK3))<<
-			"test indexpick with time within";
+	"test indexpick with time within";
 
 	// add more picks
-	testPickList->addPick(&pick2JSON);
-	testPickList->addPick(&pick4JSON);
-	testPickList->addPick(&pick5JSON);
-	testPickList->addPick(&pick6JSON);
+	testPickList->addPick(pick2JSON);
+	testPickList->addPick(pick4JSON);
+	testPickList->addPick(pick5JSON);
+	testPickList->addPick(pick6JSON);
 
 	// check to make sure the size isn't any larger than our max
 	expectedSize = MAXNPICK;
 	ASSERT_EQ(expectedSize, testPickList->getVPickSize())<<
-			"testPickList not larger than max";
+	"testPickList not larger than max";
 
 	// get first pick, which is now id 2
 	std::shared_ptr<glasscore::CPick> test2Pick = testPickList->getPick(2);
@@ -128,7 +137,7 @@ TEST(PickListTest, PickOperations) {
 	sitescnl = test2Pick->getSite()->getScnl();
 	expectedscnl = std::string(SCNL2);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str())<<
-			"test2Pick has right scnl";
+	"test2Pick has right scnl";
 
 	// test clearing picks
 	testPickList->clearPicks();

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -194,7 +194,6 @@ TEST(SiteTest, PickOperations) {
 
 	// construct a site using a JSON object
 	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
-	glasscore::CSite * testSite2 = new glasscore::CSite(site2JSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
 						new glasscore::CSite(siteJSON, NULL));
 	std::shared_ptr<glasscore::CSite> sharedTestSite2(

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -33,61 +33,61 @@
 // check site data for validity
 void checkdata(glasscore::CSite * siteobject, const std::string &testinfo) {
 	// check scnl
-	std::string sitescnl = siteobject->sScnl;
+	std::string sitescnl = siteobject->getScnl();
 	std::string expectedscnl = std::string(SCNL);
 	ASSERT_STREQ(sitescnl.c_str(), expectedscnl.c_str());
 
 	// check site
-	std::string sitesite = siteobject->sSite;
+	std::string sitesite = siteobject->getSite();
 	std::string expectedsite = std::string(SITE);
 	ASSERT_STREQ(sitesite.c_str(), expectedsite.c_str());
 
 	// check comp
-	std::string sitecomp = siteobject->sComp;
+	std::string sitecomp = siteobject->getComp();
 	std::string expectedcomp = std::string(COMP);
 	ASSERT_STREQ(sitecomp.c_str(), expectedcomp.c_str());
 
 	// check net
-	std::string sitenet = siteobject->sNet;
+	std::string sitenet = siteobject->getNet();
 	std::string expectednet = std::string(NET);
 	ASSERT_STREQ(sitenet.c_str(), expectednet.c_str());
 
 	// check loc
-	std::string siteloc = siteobject->sLoc;
+	std::string siteloc = siteobject->getLoc();
 	std::string expectedloc = std::string(LOC);
 	ASSERT_STREQ(siteloc.c_str(), expectedloc.c_str());
 
 	// check latitude
-	double sitelatitude = siteobject->geo.dLat;
+	double sitelatitude = siteobject->getGeo().dLat;
 	// NOTE: expected latitude is in geocentric coordinates
 	double expectedlatitude = GEOCENTRIC_LATITUDE;
 	ASSERT_NEAR(sitelatitude, expectedlatitude, 0.000001);
 
 	// check longitude
-	double sitelongitude = siteobject->geo.dLon;
+	double sitelongitude = siteobject->getGeo().dLon;
 	// NOTE: expected longitude is the same in geocentric and geographic
 	// coordinates
 	double expectedlongitude = LONGITUDE;
 	ASSERT_NEAR(sitelongitude, expectedlongitude, 0.000001);
 
 	// check elevation
-	double siteelevation = siteobject->geo.dZ;
+	double siteelevation = siteobject->getGeo().dZ;
 	// NOTE: expected elevation is in geocentric coordinates
 	double expectedelevation = GEOCENTRID_ELEVATION;
 	ASSERT_NEAR(siteelevation, expectedelevation, 0.000001);
 
 	// check use
-	bool siteuse = siteobject->bUse;
+	bool siteuse = siteobject->getUse();
 	bool expecteduse = USE;
 	ASSERT_EQ(siteuse, expecteduse);
 
 	// check useforTele
-	bool siteusefortele = siteobject->bUseForTele;
+	bool siteusefortele = siteobject->getUseForTele();
 	bool expectedusefortele = USEFORTELE;
 	ASSERT_EQ(siteusefortele, expectedusefortele);
 
 	// check qual
-	double sitequal = siteobject->dQual;
+	double sitequal = siteobject->getQual();
 	double expectedqual = QUALITY;
 	ASSERT_NEAR(sitequal, expectedqual, 0.000001);
 }
@@ -101,29 +101,23 @@ TEST(SiteTest, Construction) {
 
 	// assert default values
 	// scnl
-	ASSERT_STREQ("", testSite->sScnl.c_str())<< "sScnl Empty";
-	ASSERT_STREQ("", testSite->sSite.c_str())<< "sSite Empty";
-	ASSERT_STREQ("", testSite->sComp.c_str())<< "sComp Empty";
-	ASSERT_STREQ("", testSite->sNet.c_str())<< "sNet Empty";
-	ASSERT_STREQ("", testSite->sLoc.c_str())<< "sLoc Empty";
+	ASSERT_STREQ("", testSite->getScnl().c_str())<< "sScnl Empty";
+	ASSERT_STREQ("", testSite->getSite().c_str())<< "sSite Empty";
+	ASSERT_STREQ("", testSite->getComp().c_str())<< "sComp Empty";
+	ASSERT_STREQ("", testSite->getNet().c_str())<< "sNet Empty";
+	ASSERT_STREQ("", testSite->getLoc().c_str())<< "sLoc Empty";
 
-	ASSERT_EQ(true, testSite->bUse)<< "bUse false";
-	ASSERT_EQ(true, testSite->bUseForTele)<< "bUseForTele false";
-	ASSERT_EQ(0, testSite->dTrav)<< "dTrav zero";
-	ASSERT_EQ(1, testSite->dQual)<< "dQual one";
+	ASSERT_EQ(true, testSite->getUse())<< "bUse false";
+	ASSERT_EQ(true, testSite->getUseForTele())<< "bUseForTele false";
+	ASSERT_EQ(1, testSite->getQual())<< "dQual one";
 
 	// pointers
-	ASSERT_EQ(NULL, testSite->pGlass)<< "pGlass null";
-	ASSERT_EQ(NULL, testSite->pNode.get())<< "pNode null";
-	ASSERT_EQ(NULL, testSite->qNode.get())<< "qNode null";
+	ASSERT_EQ(NULL, testSite->getGlass())<< "pGlass null";
 
 	// geographic
-	ASSERT_EQ(0, testSite->geo.dLat)<< "geo.dLat 0";
-	ASSERT_EQ(0, testSite->geo.dLon)<< "geo.dLon 0";
-	ASSERT_EQ(0, testSite->geo.dZ)<< "geo.dZ 0";
-	ASSERT_EQ(0, testSite->dVec[0])<< "dVec[0] 0";
-	ASSERT_EQ(0, testSite->dVec[1])<< "dVec[1] 0";
-	ASSERT_EQ(0, testSite->dVec[2])<< "dVec[2] 0";
+	ASSERT_EQ(0, testSite->getGeo().dLat)<< "geo.dLat 0";
+	ASSERT_EQ(0, testSite->getGeo().dLon)<< "geo.dLon 0";
+	ASSERT_EQ(0, testSite->getGeo().dZ)<< "geo.dZ 0";
 
 	// lists
 	ASSERT_EQ(0, testSite->getNodeLinksCount())<< "vNode.size() 0";
@@ -183,7 +177,7 @@ TEST(SiteTest, Distance) {
 
 	// test getDelta
 	double expectedDelta = SITE2DELTA;
-	ASSERT_DOUBLE_EQ(expectedDelta, testSite->getDelta(&testSite2->geo));
+	ASSERT_DOUBLE_EQ(expectedDelta, testSite->getDelta(&testSite2->getGeo()));
 }
 
 // tests to see if picks can be added to and removed from the site

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -143,10 +143,11 @@ TEST(SiteTest, JSONConstruction) {
 	glassutil::CLogit::disable();
 
 	// create a json object from the string
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 
 	// construct a site using a JSON object
-	glasscore::CSite * testSite = new glasscore::CSite(&siteJSON, NULL);
+	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
 
 	// check results
 	checkdata(testSite, "json construction check");
@@ -160,12 +161,14 @@ TEST(SiteTest, Distance) {
 	glassutil::CLogit::disable();
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
-	json::Object site2JSON = json::Deserialize(std::string(SITE2JSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
+	json::Object * site2JSON = new json::Object(
+			json::Deserialize(std::string(SITE2JSON)));
 
 	// construct sites using JSON objects
-	glasscore::CSite * testSite = new glasscore::CSite(&siteJSON, NULL);
-	glasscore::CSite * testSite2 = new glasscore::CSite(&site2JSON, NULL);
+	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
+	glasscore::CSite * testSite2 = new glasscore::CSite(site2JSON, NULL);
 
 	// create new shared pointer to the site
 	std::shared_ptr<glasscore::CSite> sharedTestSite2(testSite2);
@@ -184,12 +187,14 @@ TEST(SiteTest, PickOperations) {
 	glassutil::CLogit::disable();
 
 	// create a json object from the string
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
-	json::Object site2JSON = json::Deserialize(std::string(SITE2JSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
+	json::Object * site2JSON = new json::Object(
+			json::Deserialize(std::string(SITE2JSON)));
 
 	// construct a site using a JSON object
-	glasscore::CSite * testSite = new glasscore::CSite(&siteJSON, NULL);
-	glasscore::CSite * testSite2 = new glasscore::CSite(&site2JSON, NULL);
+	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
+	glasscore::CSite * testSite2 = new glasscore::CSite(site2JSON, NULL);
 
 	// create new shared pointers to the sites
 	std::shared_ptr<glasscore::CSite> sharedTestSite(testSite);
@@ -213,7 +218,7 @@ TEST(SiteTest, PickOperations) {
 	// test adding pick from different station
 	testSite->addPick(sharedTestPick2);
 	ASSERT_EQ(expectedSize, testSite->getVPick().size())<<
-			"Added pick from different station";
+	"Added pick from different station";
 
 	// test removing pick
 	testSite->remPick(sharedTestPick);
@@ -226,10 +231,11 @@ TEST(SiteTest, NodeOperations) {
 	glassutil::CLogit::disable();
 
 	// create a json object from the string
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
 
 	// construct a site using a JSON object
-	glasscore::CSite * testSite = new glasscore::CSite(&siteJSON, NULL);
+	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
 
 	// create node objects
 	glasscore::CNode * testNode = new glasscore::CNode("test", 0.0, 0.0, 10,

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -249,7 +249,7 @@ TEST(SiteTest, NodeOperations) {
 	ASSERT_EQ(expectedSize, testSite->getNodeLinksCount())<< "Added Nodes";
 
 	// test removing nodes from site
-	testSite->remNode(testNode->sPid);
+	testSite->remNode(testNode->getPid());
 	expectedSize = 1;
 	ASSERT_EQ(expectedSize, testSite->getNodeLinksCount())<< "Removed Node";
 }

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -143,8 +143,8 @@ TEST(SiteTest, JSONConstruction) {
 	glassutil::CLogit::disable();
 
 	// create a json object from the string
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+					json::Object(json::Deserialize(std::string(SITEJSON))));
 
 	// construct a site using a JSON object
 	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
@@ -161,10 +161,10 @@ TEST(SiteTest, Distance) {
 	glassutil::CLogit::disable();
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
-	json::Object * site2JSON = new json::Object(
-			json::Deserialize(std::string(SITE2JSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+					json::Object(json::Deserialize(std::string(SITEJSON))));
+	std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
+					json::Object(json::Deserialize(std::string(SITE2JSON))));
 
 	// construct sites using JSON objects
 	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
@@ -187,18 +187,18 @@ TEST(SiteTest, PickOperations) {
 	glassutil::CLogit::disable();
 
 	// create a json object from the string
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
-	json::Object * site2JSON = new json::Object(
-			json::Deserialize(std::string(SITE2JSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
+		std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
+						json::Object(json::Deserialize(std::string(SITE2JSON))));
 
 	// construct a site using a JSON object
 	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
 	glasscore::CSite * testSite2 = new glasscore::CSite(site2JSON, NULL);
-
-	// create new shared pointers to the sites
-	std::shared_ptr<glasscore::CSite> sharedTestSite(testSite);
-	std::shared_ptr<glasscore::CSite> sharedTestSite2(testSite2);
+	std::shared_ptr<glasscore::CSite> sharedTestSite(
+						new glasscore::CSite(siteJSON, NULL));
+	std::shared_ptr<glasscore::CSite> sharedTestSite2(
+						new glasscore::CSite(site2JSON, NULL));
 
 	// create pick objects
 	glasscore::CPick * testPick = new glasscore::CPick(sharedTestSite, 10.0, 1,
@@ -231,8 +231,8 @@ TEST(SiteTest, NodeOperations) {
 	glassutil::CLogit::disable();
 
 	// create a json object from the string
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+							json::Object(json::Deserialize(std::string(SITEJSON))));
 
 	// construct a site using a JSON object
 	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -122,7 +122,6 @@ TEST(SiteTest, Construction) {
 	// lists
 	ASSERT_EQ(0, testSite->getNodeLinksCount())<< "vNode.size() 0";
 	ASSERT_EQ(0, testSite->getVPick().size())<< "vPick.size() 0";
-	ASSERT_EQ(0, testSite->getVTrigger().size())<< "vTrigger.size() 0";
 
 	// now init
 	testSite->initialize(std::string(SITE), std::string(COMP), std::string(NET),

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -121,8 +121,8 @@ TEST(SiteTest, Construction) {
 
 	// lists
 	ASSERT_EQ(0, testSite->getNodeLinksCount())<< "vNode.size() 0";
-	ASSERT_EQ(0, testSite->vPick.size())<< "vPick.size() 0";
-	ASSERT_EQ(0, testSite->vTrigger.size())<< "vTrigger.size() 0";
+	ASSERT_EQ(0, testSite->getVPick().size())<< "vPick.size() 0";
+	ASSERT_EQ(0, testSite->getVTrigger().size())<< "vTrigger.size() 0";
 
 	// now init
 	testSite->initialize(std::string(SITE), std::string(COMP), std::string(NET),
@@ -209,17 +209,17 @@ TEST(SiteTest, PickOperations) {
 	// test adding pick to site
 	testSite->addPick(sharedTestPick);
 	int expectedSize = 1;
-	ASSERT_EQ(expectedSize, testSite->vPick.size())<< "Added Pick";
+	ASSERT_EQ(expectedSize, testSite->getVPick().size())<< "Added Pick";
 
 	// test adding pick from different station
 	testSite->addPick(sharedTestPick2);
-	ASSERT_EQ(expectedSize, testSite->vPick.size())<<
+	ASSERT_EQ(expectedSize, testSite->getVPick().size())<<
 			"Added pick from different station";
 
 	// test removing pick
 	testSite->remPick(sharedTestPick);
 	expectedSize = 0;
-	ASSERT_EQ(expectedSize, testSite->vPick.size())<< "Removed pick";
+	ASSERT_EQ(expectedSize, testSite->getVPick().size())<< "Removed pick";
 }
 
 // tests to see if nodes can be added to and removed from the site

--- a/glasscore/tests/sitelist_unittest.cpp
+++ b/glasscore/tests/sitelist_unittest.cpp
@@ -37,30 +37,33 @@ TEST(SiteListTest, SiteOperations) {
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// create json objects from the strings
-	json::Object siteJSON = json::Deserialize(std::string(SITEJSON));
-	json::Object site2JSON = json::Deserialize(std::string(SITE2JSON));
-	json::Object site3JSON = json::Deserialize(std::string(SITE3JSON));
-	json::Object site4JSON = json::Deserialize(std::string(SITE4JSON));
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(SITEJSON)));
+	json::Object * site2JSON = new json::Object(
+			json::Deserialize(std::string(SITE2JSON)));
+	json::Object * site3JSON = new json::Object(
+			json::Deserialize(std::string(SITE3JSON)));
+	json::Object * site4JSON = new json::Object(
+			json::Deserialize(std::string(SITE4JSON)));
+
 
 	// construct sites using JSON objects
-	glasscore::CSite * testSite = new glasscore::CSite(&siteJSON, NULL);
-	glasscore::CSite * testSite2 = new glasscore::CSite(&site2JSON, NULL);
-	glasscore::CSite * testSite3 = new glasscore::CSite(&site3JSON, NULL);
-	glasscore::CSite * testSite4 = new glasscore::CSite(&site4JSON, NULL);
+	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);
+	glasscore::CSite * testSite4 = new glasscore::CSite(site4JSON, NULL);
+
 
 	// create new shared pointer to the sites
 	std::shared_ptr<glasscore::CSite> sharedTestSite(testSite);
-	std::shared_ptr<glasscore::CSite> sharedTestSite2(testSite2);
-	std::shared_ptr<glasscore::CSite> sharedTestSite3(testSite3);
 	std::shared_ptr<glasscore::CSite> sharedTestSite4(testSite4);
 
 	// test adding sites to site list via all three methods
 	// shared_ptr, json, and dispatch (also json)
 	testSiteList->addSite(sharedTestSite);
-	testSiteList->addSite(&site2JSON);
-	testSiteList->dispatch(&site3JSON);
+	testSiteList->addSite(site2JSON);
+	testSiteList->dispatch(site3JSON);
 	int expectedSize = 3;
 	ASSERT_EQ(expectedSize, testSiteList->getSiteCount())<< "Added Sites";
+
 
 	// test updating a site, and get site
 	testSiteList->addSite(sharedTestSite4);

--- a/glasscore/tests/sitelist_unittest.cpp
+++ b/glasscore/tests/sitelist_unittest.cpp
@@ -37,15 +37,14 @@ TEST(SiteListTest, SiteOperations) {
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
 
 	// create json objects from the strings
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(SITEJSON)));
-	json::Object * site2JSON = new json::Object(
-			json::Deserialize(std::string(SITE2JSON)));
-	json::Object * site3JSON = new json::Object(
-			json::Deserialize(std::string(SITE3JSON)));
-	json::Object * site4JSON = new json::Object(
-			json::Deserialize(std::string(SITE4JSON)));
-
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITEJSON))));
+	std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITE2JSON))));
+	std::shared_ptr<json::Object> site3JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITE3JSON))));
+	std::shared_ptr<json::Object> site4JSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(SITE4JSON))));
 
 	// construct sites using JSON objects
 	glasscore::CSite * testSite = new glasscore::CSite(siteJSON, NULL);

--- a/glasscore/tests/sitelist_unittest.cpp
+++ b/glasscore/tests/sitelist_unittest.cpp
@@ -20,11 +20,10 @@ TEST(SiteListTest, Construction) {
 
 	// assert default values
 	// lists
-	ASSERT_EQ(0, testSiteList->vSite.size())<< "vSite is empty";
-	ASSERT_EQ(0, testSiteList->mSite.size())<< "mSite.size() 0";
+	ASSERT_EQ(0, testSiteList->getVSiteSize())<< "vSite is empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testSiteList->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testSiteList->getGlass())<< "pGlass null";
 
 	// cleanup
 	delete (testSiteList);

--- a/glasscore/tests/sitelist_unittest.cpp
+++ b/glasscore/tests/sitelist_unittest.cpp
@@ -66,8 +66,8 @@ TEST(SiteListTest, SiteOperations) {
 	// test updating a site, and get site
 	testSiteList->addSite(sharedTestSite4);
 	std::shared_ptr<glasscore::CSite> updatedSite = testSiteList->getSite(
-			sharedTestSite4->sScnl);
-	ASSERT_FALSE(updatedSite->bUse)<< "Updated site";
+			sharedTestSite4->getScnl());
+	ASSERT_FALSE(updatedSite->getUse())<< "Updated site";
 
 	// cleanup
 	delete (testSiteList);

--- a/glasscore/tests/trigger_unittest.cpp
+++ b/glasscore/tests/trigger_unittest.cpp
@@ -1,0 +1,171 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+#include "Trigger.h"
+#include "Web.h"
+#include "Pick.h"
+#include "Site.h"
+#include "SiteList.h"
+#include "Logit.h"
+
+#define LATITUDE -21.849968
+#define LONGITUDE 170.034750
+#define DEPTH 10.000000
+#define TIME 3648585210.926340
+#define SUM 3.5
+#define COUNT 1
+
+#define SITEJSON "{\"Type\":\"StationInfo\",\"Elevation\":2326.000000,\"Latitude\":45.822170,\"Longitude\":-112.451000,\"Site\":{\"Station\":\"LRM\",\"Channel\":\"EHZ\",\"Network\":\"MB\",\"Location\":\"\"},\"Enable\":true,\"Quality\":1.0,\"UseForTeleseismic\":true}" // NOLINT
+
+#define PICKJSON "{\"ID\":\"20682831\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"EHZ\",\"Location\":\"\",\"Network\":\"MB\",\"Station\":\"LRM\"},\"Source\":{\"AgencyID\":\"228041013\",\"Author\":\"228041013\"},\"Time\":\"2014-12-23T00:01:43.599Z\",\"Type\":\"Pick\"}"  // NOLINT
+
+#define NAME "TestWeb"
+#define THRESH 1.4
+#define NUMDETECT 5
+#define NUMNUCLEATE 4
+#define RESOLUTION 100.0
+#define NUMROWS 3
+#define NUMCOLS 4
+#define NUMZ 1
+#define UPDATE true
+
+// tests to see if the node can be constructed
+TEST(TriggerTest, Construction) {
+	glassutil::CLogit::disable();
+
+	// construct a web
+	std::shared_ptr<traveltime::CTravelTime> nullTrav;
+	glasscore::CWeb * testWeb = new glasscore::CWeb(std::string(NAME),
+	THRESH,
+													NUMDETECT,
+													NUMNUCLEATE,
+													RESOLUTION,
+													NUMROWS,
+													NUMCOLS, NUMZ,
+													UPDATE,
+													nullTrav, nullTrav);
+
+	// create  shared pointer to the site
+	// create json objects from the strings
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(SITEJSON))));
+	std::shared_ptr<json::Object> pickJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(PICKJSON))));
+
+	// construct a sitelist
+	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
+
+	// add sites to site list
+	testSiteList->addSite(siteJSON);
+
+	// create pick
+	glasscore::CPick * testPick = new glasscore::CPick(pickJSON, 1,
+														testSiteList);
+
+	std::shared_ptr<glasscore::CPick> sharedPick(testPick);
+
+	// create pick vector
+	std::vector<std::shared_ptr<glasscore::CPick>> picks;
+	picks.push_back(sharedPick);
+
+	// construct a trigger
+	glasscore::CTrigger * testTrigger = new glasscore::CTrigger();
+
+	// latitude
+	ASSERT_EQ(0, testTrigger->getLat())<< "Trigger Latitude 0";
+
+	// longitude
+	ASSERT_EQ(0, testTrigger->getLon())<< "Trigger Longitude 0";
+
+	// depth
+	ASSERT_EQ(0, testTrigger->getZ())<< "Trigger Depth 0";
+
+	// time
+	ASSERT_EQ(0, testTrigger->getTOrg())<< "Trigger Time 0";
+
+	// resolution
+	ASSERT_EQ(0, testTrigger->getResolution())<< "Trigger Resolution 0";
+
+	// Sum
+	ASSERT_EQ(0, testTrigger->getSum())<< "Trigger Sum 0";
+
+	// Count
+	ASSERT_EQ(0, testTrigger->getCount())<< "Trigger Count 0";
+
+	// web
+	ASSERT_TRUE(testTrigger->getWeb() == NULL)<< "PWeb null";
+
+	// pick list
+	ASSERT_EQ(0, testTrigger->getVPick().size())<< "Trigger pick Count 0";
+
+	// init
+	testTrigger->initialize(LATITUDE,
+	LONGITUDE,
+							DEPTH,
+							TIME,
+							RESOLUTION,
+							SUM,
+							COUNT, picks, testWeb);
+
+	// latitude
+	ASSERT_EQ(LATITUDE, testTrigger->getLat())<< "Trigger Latitude Check";
+
+	// longitude
+	ASSERT_EQ(LONGITUDE, testTrigger->getLon())<< "Trigger Longitude Check";
+
+	// depth
+	ASSERT_EQ(DEPTH, testTrigger->getZ())<< "Trigger Depth Check";
+
+	// time
+	ASSERT_EQ(TIME, testTrigger->getTOrg())<< "Trigger Time Check";
+
+	// resolution
+	ASSERT_EQ(RESOLUTION, testTrigger->getResolution())<< "Trigger Resolution "
+	"Check";
+
+	// Sum
+	ASSERT_EQ(SUM, testTrigger->getSum())<< "Trigger Sum Check";
+
+	// Count
+	ASSERT_EQ(COUNT, testTrigger->getCount())<< "Trigger Count Check";
+
+	// web
+	ASSERT_STREQ(std::string(NAME).c_str(),
+			testTrigger->getWeb()->getName().c_str())<<
+	"Trigger Web Name Matches";
+
+	// pick list
+	ASSERT_EQ(COUNT, testTrigger->getVPick().size())<< "Trigger pick Count "
+	"Check";
+
+	// clear
+	testTrigger->clear();
+
+	// latitude
+	ASSERT_EQ(0, testTrigger->getLat())<< "Trigger Latitude 0";
+
+	// longitude
+	ASSERT_EQ(0, testTrigger->getLon())<< "Trigger Longitude 0";
+
+	// depth
+	ASSERT_EQ(0, testTrigger->getZ())<< "Trigger Depth 0";
+
+	// time
+	ASSERT_EQ(0, testTrigger->getTOrg())<< "Trigger Time 0";
+
+	// resolution
+	ASSERT_EQ(0, testTrigger->getResolution())<< "Trigger Resolution 0";
+
+	// Sum
+	ASSERT_EQ(0, testTrigger->getSum())<< "Trigger Sum 0";
+
+	// Count
+	ASSERT_EQ(0, testTrigger->getCount())<< "Trigger Count 0";
+
+	// web
+	ASSERT_TRUE(testTrigger->getWeb() == NULL)<< "PWeb null";
+
+	// pick list
+	ASSERT_EQ(0, testTrigger->getVPick().size())<< "Trigger pick Count 0";
+}

--- a/glasscore/tests/web_unittest.cpp
+++ b/glasscore/tests/web_unittest.cpp
@@ -92,43 +92,43 @@ TEST(WebTest, Construction) {
 													nullTrav, nullTrav);
 
 	// name
-	ASSERT_STREQ(std::string(NAME).c_str(), testWeb->sName.c_str())<<
-	"Web sName Matches";
+	ASSERT_STREQ(std::string(NAME).c_str(), testWeb->getName().c_str())<<
+	"Web getName() Matches";
 
 	// threshold
-	ASSERT_EQ(THRESH, testWeb->dThresh)<< "Web dThresh Check";
+	ASSERT_EQ(THRESH, testWeb->getThresh())<< "Web getThresh() Check";
 
-	// nDetect
-	ASSERT_EQ(NUMDETECT, testWeb->nDetect)<< "Web nDetect Check";
+	// getDetect()
+	ASSERT_EQ(NUMDETECT, testWeb->getDetect())<< "Web getDetect() Check";
 
-	// nNucleate
-	ASSERT_EQ(NUMNUCLEATE, testWeb->nNucleate)<< "Web nNucleate Check";
+	// getNucleate()
+	ASSERT_EQ(NUMNUCLEATE, testWeb->getNucleate())<< "Web getNucleate() Check";
 
 	// resolution
-	ASSERT_EQ(RESOLUTION, testWeb->dResolution)<< "Web resolution Check";
+	ASSERT_EQ(RESOLUTION, testWeb->getResolution())<< "Web resolution Check";
 
-	// nRow
-	ASSERT_EQ(NUMROWS, testWeb->nRow)<< "Web nRow Check";
+	// getRow()
+	ASSERT_EQ(NUMROWS, testWeb->getRow())<< "Web getRow() Check";
 
-	// nCol
-	ASSERT_EQ(NUMCOLS, testWeb->nCol)<< "Web nCol Check";
+	// getCol()
+	ASSERT_EQ(NUMCOLS, testWeb->getCol())<< "Web getCol() Check";
 
-	// nZ
-	ASSERT_EQ(NUMZ, testWeb->nZ)<< "Web nZ Check";
+	// getZ()
+	ASSERT_EQ(NUMZ, testWeb->getZ())<< "Web getZ() Check";
 
-	// bUpdate
-	ASSERT_EQ(UPDATE, testWeb->bUpdate)<< "Web bUpdate Check";
+	// getUpdate()
+	ASSERT_EQ(UPDATE, testWeb->getUpdate())<< "Web getUpdate() Check";
 
 	// lists
 	int expectedSize = 0;
-	ASSERT_EQ(expectedSize, (int)testWeb->vNode.size())<< "node list empty";
-	ASSERT_EQ(expectedSize, (int)testWeb->vSitesFilter.size())<<
+	ASSERT_EQ(expectedSize, (int)testWeb->getVNodeSize())<< "node list empty";
+	ASSERT_EQ(expectedSize, (int)testWeb->getVSitesFilterSize())<<
 	"site filter list empty";
-	ASSERT_EQ(expectedSize, (int)testWeb->vNetFilter.size())<<
+	ASSERT_EQ(expectedSize, (int)testWeb->getVNetFilterSize())<<
 	"net filter list empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testWeb->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testWeb->getGlass())<< "getGlass() null";
 
 	// construct a web
 	glasscore::CWeb * testWeb2 = new glasscore::CWeb(std::string(NAME),
@@ -142,42 +142,42 @@ TEST(WebTest, Construction) {
 														nullTrav, nullTrav);
 
 	// name
-	ASSERT_STREQ(std::string(NAME).c_str(), testWeb2->sName.c_str())<<
-	"Web sName Matches";
+	ASSERT_STREQ(std::string(NAME).c_str(), testWeb2->getName().c_str())<<
+	"Web getName() Matches";
 
 	// threshold
-	ASSERT_EQ(THRESH, testWeb2->dThresh)<< "Web dThresh Check";
+	ASSERT_EQ(THRESH, testWeb2->getThresh())<< "Web getThresh() Check";
 
-	// nDetect
-	ASSERT_EQ(NUMDETECT, testWeb2->nDetect)<< "Web nDetect Check";
+	// getDetect()
+	ASSERT_EQ(NUMDETECT, testWeb2->getDetect())<< "Web getDetect() Check";
 
-	// nNucleate
-	ASSERT_EQ(NUMNUCLEATE, testWeb2->nNucleate)<< "Web nNucleate Check";
+	// getNucleate()
+	ASSERT_EQ(NUMNUCLEATE, testWeb2->getNucleate())<< "Web getNucleate() Check";
 
 	// resolution
-	ASSERT_EQ(RESOLUTION, testWeb2->dResolution)<< "Web resolution Check";
+	ASSERT_EQ(RESOLUTION, testWeb2->getResolution())<< "Web resolution Check";
 
-	// nRow
-	ASSERT_EQ(NUMROWS, testWeb2->nRow)<< "Web nRow Check";
+	// getRow()
+	ASSERT_EQ(NUMROWS, testWeb2->getRow())<< "Web getRow() Check";
 
-	// nCol
-	ASSERT_EQ(NUMCOLS, testWeb2->nCol)<< "Web nCol Check";
+	// getCol()
+	ASSERT_EQ(NUMCOLS, testWeb2->getCol())<< "Web getCol() Check";
 
-	// nZ
-	ASSERT_EQ(NUMZ, testWeb2->nZ)<< "Web nZ Check";
+	// getZ()
+	ASSERT_EQ(NUMZ, testWeb2->getZ())<< "Web getZ() Check";
 
-	// bUpdate
-	ASSERT_EQ(NOUPDATE, testWeb2->bUpdate)<< "Web bUpdate Check";
+	// getUpdate()
+	ASSERT_EQ(NOUPDATE, testWeb2->getUpdate())<< "Web getUpdate() Check";
 
 	// lists
-	ASSERT_EQ(expectedSize, (int)testWeb2->vNode.size())<< "node list empty";
-	ASSERT_EQ(expectedSize, (int)testWeb2->vSitesFilter.size())<<
+	ASSERT_EQ(expectedSize, (int)testWeb2->getVNodeSize())<< "node list empty";
+	ASSERT_EQ(expectedSize, (int)testWeb2->getVSitesFilterSize())<<
 	"site filter list empty";
-	ASSERT_EQ(expectedSize, (int)testWeb2->vNetFilter.size())<<
+	ASSERT_EQ(expectedSize, (int)testWeb2->getVNetFilterSize())<<
 	"net filter list empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testWeb2->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testWeb2->getGlass())<< "getGlass() null";
 
 	delete (testWeb);
 	delete (testWeb2);
@@ -202,39 +202,39 @@ TEST(WebTest, Initialize) {
 						nullTrav, nullTrav);
 
 	// name
-	ASSERT_STREQ(std::string(NAME).c_str(), testWeb.sName.c_str())<<
-	"Web sName Matches";
+	ASSERT_STREQ(std::string(NAME).c_str(), testWeb.getName().c_str())<<
+	"Web getName() Matches";
 
 	// threshold
-	ASSERT_EQ(THRESH, testWeb.dThresh)<< "Web dThresh Check";
+	ASSERT_EQ(THRESH, testWeb.getThresh())<< "Web getThresh() Check";
 
-	// nDetect
-	ASSERT_EQ(NUMDETECT, testWeb.nDetect)<< "Web nDetect Check";
+	// getDetect()
+	ASSERT_EQ(NUMDETECT, testWeb.getDetect())<< "Web getDetect() Check";
 
-	// nNucleate
-	ASSERT_EQ(NUMNUCLEATE, testWeb.nNucleate)<< "Web nNucleate Check";
+	// getNucleate()
+	ASSERT_EQ(NUMNUCLEATE, testWeb.getNucleate())<< "Web getNucleate() Check";
 
 	// resolution
-	ASSERT_EQ(RESOLUTION, testWeb.dResolution)<< "Web resolution Check";
+	ASSERT_EQ(RESOLUTION, testWeb.getResolution())<< "Web resolution Check";
 
-	// nRow
-	ASSERT_EQ(NUMROWS, testWeb.nRow)<< "Web nRow Check";
+	// getRow()
+	ASSERT_EQ(NUMROWS, testWeb.getRow())<< "Web getRow() Check";
 
-	// nCol
-	ASSERT_EQ(NUMCOLS, testWeb.nCol)<< "Web nCol Check";
+	// getCol()
+	ASSERT_EQ(NUMCOLS, testWeb.getCol())<< "Web getCol() Check";
 
-	// nZ
-	ASSERT_EQ(NUMZ, testWeb.nZ)<< "Web nZ Check";
+	// getZ()
+	ASSERT_EQ(NUMZ, testWeb.getZ())<< "Web getZ() Check";
 
-	// bUpdate
-	ASSERT_EQ(UPDATE, testWeb.bUpdate)<< "Web bUpdate Check";
+	// getUpdate()
+	ASSERT_EQ(UPDATE, testWeb.getUpdate())<< "Web getUpdate() Check";
 
 	// lists
 	int expectedSize = 0;
-	ASSERT_EQ(expectedSize, (int)testWeb.vNode.size())<< "node list empty";
-	ASSERT_EQ(expectedSize, (int)testWeb.vSitesFilter.size())<<
+	ASSERT_EQ(expectedSize, (int)testWeb.getVNodeSize())<< "node list empty";
+	ASSERT_EQ(expectedSize, (int)testWeb.getVSitesFilterSize())<<
 	"site filter list empty";
-	ASSERT_EQ(expectedSize, (int)testWeb.vNetFilter.size())<<
+	ASSERT_EQ(expectedSize, (int)testWeb.getVNetFilterSize())<<
 	"net filter list empty";
 
 	ASSERT_TRUE(testWeb.statusCheck())<< "status check";
@@ -275,55 +275,59 @@ TEST(WebTest, GlobalTest) {
 
 	// construct a web
 	glasscore::CWeb testGlobalWeb(UPDATE);
-	testGlobalWeb.pSiteList = testSiteList;
+	testGlobalWeb.setSiteList(testSiteList);
 	testGlobalWeb.dispatch(&globalConfig);
 
 	// name
-	ASSERT_STREQ(std::string(GLOBALNAME).c_str(), testGlobalWeb.sName.c_str())<<
-	"Web sName Matches";
+	ASSERT_STREQ(std::string(GLOBALNAME).c_str(),
+				 testGlobalWeb.getName().c_str())<<
+						 "Web getName() Matches";
 
 	// threshold
-	ASSERT_EQ(GLOBALTHRESH, testGlobalWeb.dThresh)<< "Web dThresh Check";
+	ASSERT_EQ(GLOBALTHRESH, testGlobalWeb.getThresh())<<
+			"Web getThresh() Check";
 
-	// nDetect
-	ASSERT_EQ(GLOBALNUMDETECT, testGlobalWeb.nDetect)<< "Web nDetect Check";
+	// getDetect()
+	ASSERT_EQ(GLOBALNUMDETECT, testGlobalWeb.getDetect())<<
+			"Web getDetect() Check";
 
-	// nNucleate
-	ASSERT_EQ(GLOBALNUMNUCLEATE, testGlobalWeb.nNucleate)<< "Web nNucleate Check";
+	// getNucleate()
+	ASSERT_EQ(GLOBALNUMNUCLEATE, testGlobalWeb.getNucleate())<<
+			"Web getNucleate() Check";
 
-	// dResolution
-	ASSERT_EQ(GLOBALRESOLUTION, testGlobalWeb.dResolution)<< "Web dResolution "
-	"Check";
+	// getResolution()
+	ASSERT_EQ(GLOBALRESOLUTION, testGlobalWeb.getResolution())<<
+			"Web getResolution() Check";
 
-	// nRow
-	ASSERT_EQ(0, testGlobalWeb.nRow)<< "Web nRow Check";
+	// getRow()
+	ASSERT_EQ(0, testGlobalWeb.getRow())<< "Web getRow() Check";
 
-	// nCol
-	ASSERT_EQ(0, testGlobalWeb.nCol)<< "Web nCol Check";
+	// getCol()
+	ASSERT_EQ(0, testGlobalWeb.getCol())<< "Web getCol() Check";
 
-	// nCol
-	ASSERT_EQ(GLOBALNUMZ, testGlobalWeb.nZ)<< "Web nZ Check";
+	// getCol()
+	ASSERT_EQ(GLOBALNUMZ, testGlobalWeb.getZ())<< "Web getZ() Check";
 
-	// bUpdate
-	ASSERT_EQ(UPDATE, testGlobalWeb.bUpdate)<< "Web bUpdate Check";
+	// getUpdate()
+	ASSERT_EQ(UPDATE, testGlobalWeb.getUpdate())<< "Web getUpdate() Check";
 
 	// lists
-	ASSERT_EQ(GLOBALNUMNODES, (int)testGlobalWeb.vNode.size())<< "node list";
-	ASSERT_EQ(0, (int)testGlobalWeb.vSitesFilter.size())<<
+	ASSERT_EQ(GLOBALNUMNODES, (int)testGlobalWeb.getVNodeSize())<< "node list";
+	ASSERT_EQ(0, (int)testGlobalWeb.getVSitesFilterSize())<<
 	"site filter list empty";
-	ASSERT_EQ(GLOBALNUMNETEXLUDE, (int)testGlobalWeb.vNetFilter.size())<<
+	ASSERT_EQ(GLOBALNUMNETEXLUDE, (int)testGlobalWeb.getVNetFilterSize())<<
 	"net filter list empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testGlobalWeb.pGlass)<< "pGlass null";
-	ASSERT_TRUE(NULL != testGlobalWeb.pTrv1)<< "pTrv1 not null";
-	ASSERT_TRUE(NULL != testGlobalWeb.pTrv2)<< "pTrv2 not null";
+	ASSERT_EQ(NULL, testGlobalWeb.getGlass())<< "getGlass() null";
+	ASSERT_TRUE(NULL != testGlobalWeb.getTrv1())<< "getTrv1() not null";
+	ASSERT_TRUE(NULL != testGlobalWeb.getTrv2())<< "getTrv2() not null";
 
 	// phase name
-	ASSERT_STREQ(testGlobalWeb.pTrv1->sPhase.c_str(), phasename1.c_str());
+	ASSERT_STREQ(testGlobalWeb.getTrv1()->sPhase.c_str(), phasename1.c_str());
 
 	// phase name
-	ASSERT_STREQ(testGlobalWeb.pTrv2->sPhase.c_str(), phasename2.c_str());
+	ASSERT_STREQ(testGlobalWeb.getTrv2()->sPhase.c_str(), phasename2.c_str());
 
 	// cleanup
 	delete (testSiteList);
@@ -365,55 +369,56 @@ TEST(WebTest, GridTest) {
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
-	testGridWeb.pSiteList = testSiteList;
+	testGridWeb.setSiteList(testSiteList);
 	testGridWeb.dispatch(&gridConfig);
 
 	// name
-	ASSERT_STREQ(std::string(GRIDNAME).c_str(), testGridWeb.sName.c_str())<<
-	"Web sName Matches";
+	ASSERT_STREQ(std::string(GRIDNAME).c_str(), testGridWeb.getName().c_str())<<
+	"Web getName() Matches";
 
 	// threshold
-	ASSERT_EQ(GRIDTHRESH, testGridWeb.dThresh)<< "Web dThresh Check";
+	ASSERT_EQ(GRIDTHRESH, testGridWeb.getThresh())<< "Web getThresh() Check";
 
-	// nDetect
-	ASSERT_EQ(GRIDNUMDETECT, testGridWeb.nDetect)<< "Web nDetect Check";
+	// getDetect()
+	ASSERT_EQ(GRIDNUMDETECT, testGridWeb.getDetect())<< "Web getDetect() Check";
 
-	// nNucleate
-	ASSERT_EQ(GRIDNUMNUCLEATE, testGridWeb.nNucleate)<< "Web nNucleate Check";
+	// getNucleate()
+	ASSERT_EQ(GRIDNUMNUCLEATE, testGridWeb.getNucleate())<<
+			"Web getNucleate() Check";
 
-	// dResolution
-	ASSERT_EQ(GRIDRESOLUTION, testGridWeb.dResolution)<< "Web dResolution "
-	"Check";
+	// getResolution()
+	ASSERT_EQ(GRIDRESOLUTION, testGridWeb.getResolution())<<
+			"Web getResolution() Check";
 
-	// nRow
-	ASSERT_EQ(GRIDNUMROWS, testGridWeb.nRow)<< "Web nRow Check";
+	// getRow()
+	ASSERT_EQ(GRIDNUMROWS, testGridWeb.getRow())<< "Web getRow() Check";
 
-	// nCol
-	ASSERT_EQ(GRIDNUMROWS, testGridWeb.nCol)<< "Web nCol Check";
+	// getCol()
+	ASSERT_EQ(GRIDNUMROWS, testGridWeb.getCol())<< "Web getCol() Check";
 
-	// nCol
-	ASSERT_EQ(GRIDNUMZ, testGridWeb.nZ)<< "Web nZ Check";
+	// getCol()
+	ASSERT_EQ(GRIDNUMZ, testGridWeb.getZ())<< "Web getZ() Check";
 
-	// bUpdate
-	ASSERT_EQ(UPDATE, testGridWeb.bUpdate)<< "Web bUpdate Check";
+	// getUpdate()
+	ASSERT_EQ(UPDATE, testGridWeb.getUpdate())<< "Web getUpdate() Check";
 
 	// lists
-	ASSERT_EQ(GRIDNUMNODES, (int)testGridWeb.vNode.size())<< "node list";
-	ASSERT_EQ(0, (int)testGridWeb.vSitesFilter.size())<<
+	ASSERT_EQ(GRIDNUMNODES, (int)testGridWeb.getVNodeSize())<< "node list";
+	ASSERT_EQ(0, (int)testGridWeb.getVSitesFilterSize())<<
 	"site filter list empty";
-	ASSERT_EQ(0, (int)testGridWeb.vNetFilter.size())<<
+	ASSERT_EQ(0, (int)testGridWeb.getVNetFilterSize())<<
 	"net filter list empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testGridWeb.pGlass)<< "pGlass null";
-	ASSERT_TRUE(NULL != testGridWeb.pTrv1)<< "pTrv1 not null";
-	ASSERT_TRUE(NULL != testGridWeb.pTrv2)<< "pTrv2 not null";
+	ASSERT_EQ(NULL, testGridWeb.getGlass())<< "getGlass() null";
+	ASSERT_TRUE(NULL != testGridWeb.getTrv1())<< "getTrv1() not null";
+	ASSERT_TRUE(NULL != testGridWeb.getTrv2())<< "getTrv2() not null";
 
 	// phase name
-	ASSERT_STREQ(testGridWeb.pTrv1->sPhase.c_str(), phasename1.c_str());
+	ASSERT_STREQ(testGridWeb.getTrv1()->sPhase.c_str(), phasename1.c_str());
 
 	// phase name
-	ASSERT_STREQ(testGridWeb.pTrv2->sPhase.c_str(), phasename2.c_str());
+	ASSERT_STREQ(testGridWeb.getTrv2()->sPhase.c_str(), phasename2.c_str());
 
 	// cleanup
 	delete (testSiteList);
@@ -454,55 +459,55 @@ TEST(WebTest, GridExplicitTest) {
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
-	testGridWeb.pSiteList = testSiteList;
+	testGridWeb.setSiteList(testSiteList);
 	testGridWeb.dispatch(&gridConfig);
 
 	// name
 	ASSERT_STREQ(std::string(GRIDEXPLICITNAME).c_str(),
-			testGridWeb.sName.c_str())<< "Web sName Matches";
+			testGridWeb.getName().c_str())<< "Web getName() Matches";
 
 	// threshold
 	ASSERT_EQ(GRIDEXPLICITTHRESH,
-			testGridWeb.dThresh)<< "Web dThresh Check";
+			testGridWeb.getThresh())<< "Web getThresh() Check";
 
-	// nDetect
+	// getDetect()
 	ASSERT_EQ(GRIDEXPLICITNUMDETECT,
-			testGridWeb.nDetect)<< "Web nDetect Check";
+			testGridWeb.getDetect())<< "Web getDetect() Check";
 
-	// nNucleate
+	// getNucleate()
 	ASSERT_EQ(GRIDEXPLICITNUMNUCLEATE,
-			testGridWeb.nNucleate)<< "Web nNucleate Check";
+			testGridWeb.getNucleate())<< "Web getNucleate() Check";
 
-	// dResolution
+	// getResolution()
 	ASSERT_EQ(GRIDEXPLICITRESOLUTION,
-			testGridWeb.dResolution)<< "Web dResolution Check";
+			testGridWeb.getResolution())<< "Web getResolution() Check";
 
-	// nRow
-	ASSERT_EQ(0, testGridWeb.nRow)<< "Web nRow Check";
+	// getRow()
+	ASSERT_EQ(0, testGridWeb.getRow())<< "Web getRow() Check";
 
-	// nCol
-	ASSERT_EQ(0, testGridWeb.nCol)<< "Web nCol Check";
+	// getCol()
+	ASSERT_EQ(0, testGridWeb.getCol())<< "Web getCol() Check";
 
-	// nCol
-	ASSERT_EQ(0, testGridWeb.nZ)<< "Web nZ Check";
+	// getCol()
+	ASSERT_EQ(0, testGridWeb.getZ())<< "Web getZ() Check";
 
-	// bUpdate
-	ASSERT_EQ(NOUPDATE, testGridWeb.bUpdate)<< "Web bUpdate Check";
+	// getUpdate()
+	ASSERT_EQ(NOUPDATE, testGridWeb.getUpdate())<< "Web getUpdate() Check";
 
 	// lists
-	ASSERT_EQ(GRIDEXPLICITNUMNODES, (int)testGridWeb.vNode.size())<< "node list";
-	ASSERT_EQ(0, (int)testGridWeb.vSitesFilter.size())<<
+	ASSERT_EQ(GRIDEXPLICITNUMNODES, (int)testGridWeb.getVNodeSize())<< "node list";
+	ASSERT_EQ(0, (int)testGridWeb.getVSitesFilterSize())<<
 	"site filter list empty";
-	ASSERT_EQ(0, (int)testGridWeb.vNetFilter.size())<<
+	ASSERT_EQ(0, (int)testGridWeb.getVNetFilterSize())<<
 	"net filter list empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testGridWeb.pGlass)<< "pGlass null";
-	ASSERT_TRUE(NULL != testGridWeb.pTrv1)<< "pTrv1 not null";
-	ASSERT_TRUE(NULL == testGridWeb.pTrv2)<< "pTrv2 null";
+	ASSERT_EQ(NULL, testGridWeb.getGlass())<< "getGlass() null";
+	ASSERT_TRUE(NULL != testGridWeb.getTrv1())<< "getTrv1() not null";
+	ASSERT_TRUE(NULL == testGridWeb.getTrv2())<< "getTrv2() null";
 
 	// phase name
-	ASSERT_STREQ(testGridWeb.pTrv1->sPhase.c_str(), phasename1.c_str());
+	ASSERT_STREQ(testGridWeb.getTrv1()->sPhase.c_str(), phasename1.c_str());
 
 	// cleanup
 	delete (testSiteList);
@@ -540,7 +545,7 @@ TEST(WebTest, AddTest) {
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
-	testGridWeb.pSiteList = testSiteList;
+	testGridWeb.setSiteList(testSiteList);
 	testGridWeb.dispatch(&gridConfig);
 
 	// create site to add
@@ -596,7 +601,7 @@ TEST(WebTest, RemoveTest) {
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
-	testGridWeb.pSiteList = testSiteList;
+	testGridWeb.setSiteList(testSiteList);
 	testGridWeb.dispatch(&gridConfig);
 
 	// create site to remove

--- a/glasscore/tests/web_unittest.cpp
+++ b/glasscore/tests/web_unittest.cpp
@@ -280,24 +280,24 @@ TEST(WebTest, GlobalTest) {
 
 	// name
 	ASSERT_STREQ(std::string(GLOBALNAME).c_str(),
-				 testGlobalWeb.getName().c_str())<<
-						 "Web getName() Matches";
+			testGlobalWeb.getName().c_str())<<
+	"Web getName() Matches";
 
 	// threshold
 	ASSERT_EQ(GLOBALTHRESH, testGlobalWeb.getThresh())<<
-			"Web getThresh() Check";
+	"Web getThresh() Check";
 
 	// getDetect()
 	ASSERT_EQ(GLOBALNUMDETECT, testGlobalWeb.getDetect())<<
-			"Web getDetect() Check";
+	"Web getDetect() Check";
 
 	// getNucleate()
 	ASSERT_EQ(GLOBALNUMNUCLEATE, testGlobalWeb.getNucleate())<<
-			"Web getNucleate() Check";
+	"Web getNucleate() Check";
 
 	// getResolution()
 	ASSERT_EQ(GLOBALRESOLUTION, testGlobalWeb.getResolution())<<
-			"Web getResolution() Check";
+	"Web getResolution() Check";
 
 	// getRow()
 	ASSERT_EQ(0, testGlobalWeb.getRow())<< "Web getRow() Check";
@@ -384,11 +384,11 @@ TEST(WebTest, GridTest) {
 
 	// getNucleate()
 	ASSERT_EQ(GRIDNUMNUCLEATE, testGridWeb.getNucleate())<<
-			"Web getNucleate() Check";
+	"Web getNucleate() Check";
 
 	// getResolution()
 	ASSERT_EQ(GRIDRESOLUTION, testGridWeb.getResolution())<<
-			"Web getResolution() Check";
+	"Web getResolution() Check";
 
 	// getRow()
 	ASSERT_EQ(GRIDNUMROWS, testGridWeb.getRow())<< "Web getRow() Check";
@@ -549,8 +549,9 @@ TEST(WebTest, AddTest) {
 	testGridWeb.dispatch(&gridConfig);
 
 	// create site to add
-	json::Object siteJSON = json::Deserialize(std::string(ADDSITE));
-	glasscore::CSite * addSite = new glasscore::CSite(&siteJSON, NULL);
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(ADDSITE)));
+	glasscore::CSite * addSite = new glasscore::CSite(siteJSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedAddSite(addSite);
 
 	// add to site list
@@ -605,8 +606,9 @@ TEST(WebTest, RemoveTest) {
 	testGridWeb.dispatch(&gridConfig);
 
 	// create site to remove
-	json::Object siteJSON = json::Deserialize(std::string(REMOVESITE));
-	glasscore::CSite * removeSite = new glasscore::CSite(&siteJSON, NULL);
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(REMOVESITE)));
+	glasscore::CSite * removeSite = new glasscore::CSite(siteJSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedRemoveSite(removeSite);
 
 	// update in site list

--- a/glasscore/tests/web_unittest.cpp
+++ b/glasscore/tests/web_unittest.cpp
@@ -266,17 +266,19 @@ TEST(WebTest, GlobalTest) {
 	std::getline(globalFile, globalLine);
 	globalFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object globalConfig = json::Deserialize(globalLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+			json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> globalConfig = std::make_shared<json::Object>(
+			json::Deserialize(globalLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a web
 	glasscore::CWeb testGlobalWeb(UPDATE);
 	testGlobalWeb.setSiteList(testSiteList);
-	testGlobalWeb.dispatch(&globalConfig);
+	testGlobalWeb.dispatch(globalConfig);
 
 	// name
 	ASSERT_STREQ(std::string(GLOBALNAME).c_str(),
@@ -360,17 +362,19 @@ TEST(WebTest, GridTest) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+				json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+					json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
 	testGridWeb.setSiteList(testSiteList);
-	testGridWeb.dispatch(&gridConfig);
+	testGridWeb.dispatch(gridConfig);
 
 	// name
 	ASSERT_STREQ(std::string(GRIDNAME).c_str(), testGridWeb.getName().c_str())<<
@@ -450,17 +454,19 @@ TEST(WebTest, GridExplicitTest) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+				json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+					json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
 	testGridWeb.setSiteList(testSiteList);
-	testGridWeb.dispatch(&gridConfig);
+	testGridWeb.dispatch(gridConfig);
 
 	// name
 	ASSERT_STREQ(std::string(GRIDEXPLICITNAME).c_str(),
@@ -536,21 +542,23 @@ TEST(WebTest, AddTest) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+				json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+					json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
 	testGridWeb.setSiteList(testSiteList);
-	testGridWeb.dispatch(&gridConfig);
+	testGridWeb.dispatch(gridConfig);
 
 	// create site to add
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(ADDSITE)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(ADDSITE))));
 	glasscore::CSite * addSite = new glasscore::CSite(siteJSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedAddSite(addSite);
 
@@ -593,21 +601,23 @@ TEST(WebTest, RemoveTest) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+				json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+				json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a web
 	glasscore::CWeb testGridWeb(UPDATE);
 	testGridWeb.setSiteList(testSiteList);
-	testGridWeb.dispatch(&gridConfig);
+	testGridWeb.dispatch(gridConfig);
 
 	// create site to remove
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(REMOVESITE)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+				json::Object(json::Deserialize(std::string(REMOVESITE))));
 	glasscore::CSite * removeSite = new glasscore::CSite(siteJSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedRemoveSite(removeSite);
 
@@ -651,7 +661,6 @@ TEST(WebTest, FailTests) {
 	// grid fails
 	std::ifstream badGridFile;
 	std::string badGridLine = "";
-	json::Object badGridConfig;
 
 	// global
 	// bad tt
@@ -662,8 +671,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad global1 false";
+	std::shared_ptr<json::Object> badGridConfig = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig))<< "bad global1 false";
 
 	// no resolution
 	badGridFile.open(
@@ -673,8 +683,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad global2 false";
+	std::shared_ptr<json::Object> badGridConfig2 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig2))<< "bad global2 false";
 
 	// no depths
 	badGridFile.open(
@@ -684,8 +695,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad global4 false";
+	std::shared_ptr<json::Object> badGridConfig3 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig3))<< "bad global4 false";
 
 	// grid
 	// bad tt
@@ -695,8 +707,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad grid1 false";
+	std::shared_ptr<json::Object> badGridConfig4 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig4))<< "bad grid1 false";
 
 	// no resolution
 	badGridFile.open(
@@ -705,8 +718,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad grid2 false";
+	std::shared_ptr<json::Object> badGridConfig5 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig5))<< "bad grid2 false";
 
 	// no depths
 	badGridFile.open(
@@ -715,8 +729,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad grid3 false";
+	std::shared_ptr<json::Object> badGridConfig6 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig6))<< "bad grid3 false";
 
 	// explicit
 	// bad tt
@@ -727,8 +742,9 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad grid1 false";
+	std::shared_ptr<json::Object> badGridConfig7 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig7))<< "bad grid1 false";
 
 	// no resolution
 	badGridFile.open(
@@ -738,6 +754,7 @@ TEST(WebTest, FailTests) {
 	std::getline(badGridFile, badGridLine);
 	badGridFile.close();
 
-	badGridConfig = json::Deserialize(badGridLine);
-	ASSERT_FALSE(aWeb.global(&badGridConfig))<< "bad grid2 false";
+	std::shared_ptr<json::Object> badGridConfig8 = std::make_shared<json::Object>(
+					json::Deserialize(badGridLine));
+	ASSERT_FALSE(aWeb.global(badGridConfig8))<< "bad grid2 false";
 }

--- a/glasscore/tests/weblist_unittest.cpp
+++ b/glasscore/tests/weblist_unittest.cpp
@@ -62,12 +62,14 @@ TEST(WebListTest, AddWeb) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+			json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+			json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a WebList
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
@@ -77,7 +79,7 @@ TEST(WebListTest, AddWeb) {
 	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// add a web
-	testWebList->dispatch(&gridConfig);
+	testWebList->dispatch(gridConfig);
 
 	// web list
 	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
@@ -111,12 +113,14 @@ TEST(WebListTest, RemWeb) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+			json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+			json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a WebList
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
@@ -126,15 +130,17 @@ TEST(WebListTest, RemWeb) {
 	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// add a web
-	testWebList->dispatch(&gridConfig);
+	testWebList->dispatch(gridConfig);
 
 	// web list
 	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
 
-	json::Object remGridConfig = json::Deserialize(std::string(REMWEB));
+	std::shared_ptr<json::Object> remGridConfig =
+			std::make_shared<json::Object>(
+					json::Deserialize(std::string(REMWEB)));
 
 	// remove a web
-	testWebList->dispatch(&remGridConfig);
+	testWebList->dispatch(remGridConfig);
 
 	// web list
 	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list removed";
@@ -166,12 +172,14 @@ TEST(WebListTest, SiteOperations) {
 	std::getline(gridFile, gridLine);
 	gridFile.close();
 
-	json::Object siteList = json::Deserialize(stationLine);
-	json::Object gridConfig = json::Deserialize(gridLine);
+	std::shared_ptr<json::Object> siteList = std::make_shared<json::Object>(
+			json::Deserialize(stationLine));
+	std::shared_ptr<json::Object> gridConfig = std::make_shared<json::Object>(
+			json::Deserialize(gridLine));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();
-	testSiteList->dispatch(&siteList);
+	testSiteList->dispatch(siteList);
 
 	// construct a WebList
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
@@ -181,14 +189,14 @@ TEST(WebListTest, SiteOperations) {
 	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// add a web
-	testWebList->dispatch(&gridConfig);
+	testWebList->dispatch(gridConfig);
 
 	// web list
 	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
 
 	// create site to add
-	json::Object * siteJSON = new json::Object(
-			json::Deserialize(std::string(ADDSITE)));
+	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(ADDSITE))));
 	glasscore::CSite * addSite = new glasscore::CSite(siteJSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedAddSite(addSite);
 
@@ -203,8 +211,8 @@ TEST(WebListTest, SiteOperations) {
 	ASSERT_TRUE(testWebList->hasSite(sharedAddSite))<< "site added";
 
 	// create site to remove
-	json::Object * siteJSON2 = new json::Object(
-			json::Deserialize(std::string(REMOVESITE)));
+	std::shared_ptr<json::Object> siteJSON2 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(std::string(REMOVESITE))));
 	glasscore::CSite * removeSite = new glasscore::CSite(siteJSON2, NULL);
 	std::shared_ptr<glasscore::CSite> sharedRemoveSite(removeSite);
 

--- a/glasscore/tests/weblist_unittest.cpp
+++ b/glasscore/tests/weblist_unittest.cpp
@@ -187,8 +187,9 @@ TEST(WebListTest, SiteOperations) {
 	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
 
 	// create site to add
-	json::Object siteJSON = json::Deserialize(std::string(ADDSITE));
-	glasscore::CSite * addSite = new glasscore::CSite(&siteJSON, NULL);
+	json::Object * siteJSON = new json::Object(
+			json::Deserialize(std::string(ADDSITE)));
+	glasscore::CSite * addSite = new glasscore::CSite(siteJSON, NULL);
 	std::shared_ptr<glasscore::CSite> sharedAddSite(addSite);
 
 	// add to site list
@@ -202,8 +203,9 @@ TEST(WebListTest, SiteOperations) {
 	ASSERT_TRUE(testWebList->hasSite(sharedAddSite))<< "site added";
 
 	// create site to remove
-	json::Object siteJSON2 = json::Deserialize(std::string(REMOVESITE));
-	glasscore::CSite * removeSite = new glasscore::CSite(&siteJSON2, NULL);
+	json::Object * siteJSON2 = new json::Object(
+			json::Deserialize(std::string(REMOVESITE)));
+	glasscore::CSite * removeSite = new glasscore::CSite(siteJSON2, NULL);
 	std::shared_ptr<glasscore::CSite> sharedRemoveSite(removeSite);
 
 	// update in site list

--- a/glasscore/tests/weblist_unittest.cpp
+++ b/glasscore/tests/weblist_unittest.cpp
@@ -29,10 +29,10 @@ TEST(WebListTest, Construction) {
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
 
 	// lists
-	ASSERT_EQ(0, (int)testWebList->vWeb.size())<< "web list empty";
+	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// pointers
-	ASSERT_EQ(NULL, testWebList->pGlass)<< "pGlass null";
+	ASSERT_EQ(NULL, testWebList->getGlass())<< "getGlass() null";
 
 	ASSERT_TRUE(testWebList->statusCheck())<< "status check";
 
@@ -71,16 +71,16 @@ TEST(WebListTest, AddWeb) {
 
 	// construct a WebList
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
-	testWebList->pSiteList = testSiteList;
+	testWebList->setSiteList(testSiteList);
 
 	// web list
-	ASSERT_EQ(0, (int)testWebList->vWeb.size())<< "web list empty";
+	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// add a web
 	testWebList->dispatch(&gridConfig);
 
 	// web list
-	ASSERT_EQ(1, (int)testWebList->vWeb.size())<< "web list added";
+	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
 
 	ASSERT_TRUE(testWebList->statusCheck())<< "status check";
 
@@ -120,16 +120,16 @@ TEST(WebListTest, RemWeb) {
 
 	// construct a WebList
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
-	testWebList->pSiteList = testSiteList;
+	testWebList->setSiteList(testSiteList);
 
 	// web list
-	ASSERT_EQ(0, (int)testWebList->vWeb.size())<< "web list empty";
+	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// add a web
 	testWebList->dispatch(&gridConfig);
 
 	// web list
-	ASSERT_EQ(1, (int)testWebList->vWeb.size())<< "web list added";
+	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
 
 	json::Object remGridConfig = json::Deserialize(std::string(REMWEB));
 
@@ -137,7 +137,7 @@ TEST(WebListTest, RemWeb) {
 	testWebList->dispatch(&remGridConfig);
 
 	// web list
-	ASSERT_EQ(0, (int)testWebList->vWeb.size())<< "web list removed";
+	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list removed";
 
 	delete (testSiteList);
 	delete (testWebList);
@@ -175,16 +175,16 @@ TEST(WebListTest, SiteOperations) {
 
 	// construct a WebList
 	glasscore::CWebList * testWebList = new glasscore::CWebList();
-	testWebList->pSiteList = testSiteList;
+	testWebList->setSiteList(testSiteList);
 
 	// web list
-	ASSERT_EQ(0, (int)testWebList->vWeb.size())<< "web list empty";
+	ASSERT_EQ(0, (int)testWebList->getVWebSize())<< "web list empty";
 
 	// add a web
 	testWebList->dispatch(&gridConfig);
 
 	// web list
-	ASSERT_EQ(1, (int)testWebList->vWeb.size())<< "web list added";
+	ASSERT_EQ(1, (int)testWebList->getVWebSize())<< "web list added";
 
 	// create site to add
 	json::Object siteJSON = json::Deserialize(std::string(ADDSITE));

--- a/output/include/output.h
+++ b/output/include/output.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <memory>
 
 namespace glass {
 /**
@@ -81,7 +82,7 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 *
 	 * \param message - A json::Object containing the message to send to output.
 	 */
-	void sendToOutput(json::Object* message) override;
+	void sendToOutput(std::shared_ptr<json::Object> message) override;
 
 	/**
 	 * \brief thread pool check function
@@ -144,9 +145,9 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 * \param data - A pointer to a json::Object containing the detection data.
 	 * \return Returns true if successful, false otherwise
 	 */
-	bool addTrackingData(json::Object* data);
+	bool addTrackingData(std::shared_ptr<json::Object> data);
 
-	json::Object * getTrackingData(std::string id);
+	std::shared_ptr<json::Object> getTrackingData(std::string id);
 
 	/**
 	 * \brief get data from the output tracking cache
@@ -157,7 +158,7 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 * \return Returns a pointer to the json::Object containing the detection
 	 * data ready for output, NULL if no data found that is ready.
 	 */
-	json::Object * getNextTrackingData();
+	std::shared_ptr<json::Object> getNextTrackingData();
 
 	/**
 	 * \brief check if data is in output tracking cache
@@ -168,7 +169,7 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 * \param data - A pointer to a json::Object containing the detection data.
 	 * \return Returns true if the data is in the cache, false otherwise
 	 */
-	bool haveTrackingData(json::Object* data);
+	bool haveTrackingData(std::shared_ptr<json::Object> data);
 	bool haveTrackingData(std::string ID);
 
 	/**
@@ -179,7 +180,7 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 * \param data - A pointer to a json::Object containing the detection data.
 	 * \return Returns true if successful, false otherwise
 	 */
-	bool removeTrackingData(json::Object* data);
+	bool removeTrackingData(std::shared_ptr<json::Object> data);
 	bool removeTrackingData(std::string ID);
 
 	/**
@@ -198,9 +199,10 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 * data to check
 	 * \return Returns true if the data is ready, false if not.
 	 */
-	bool isDataReady(json::Object *data);
-	bool isDataChanged(json::Object *data);
-	bool isDataPublished(json::Object *data, bool ignoreVersion = true);
+	bool isDataReady(std::shared_ptr<json::Object> data);
+	bool isDataChanged(std::shared_ptr<json::Object> data);
+	bool isDataPublished(std::shared_ptr<json::Object> data,
+							bool ignoreVersion = true);
 
  protected:
 	/**
@@ -220,7 +222,7 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 * \param data - A pointer to a json::Object containing the data to be
 	 * output.
 	 */
-	void writeOutput(json::Object *data);
+	void writeOutput(std::shared_ptr<json::Object> data);
 
 	virtual void sendOutput(const std::string &type, const std::string &id,
 							const std::string &message) = 0;

--- a/output/include/output.h
+++ b/output/include/output.h
@@ -82,7 +82,7 @@ class output : public util::iOutput, public util::ThreadBaseClass {
 	 *
 	 * \param message - A json::Object containing the message to send to output.
 	 */
-	void sendToOutput(std::shared_ptr<json::Object> message) override;
+	void sendToOutput(std::shared_ptr<json::Object> &message) override;
 
 	/**
 	 * \brief thread pool check function

--- a/output/src/output.cpp
+++ b/output/src/output.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <iostream>
 #include <fstream>
+#include <memory>
 
 namespace glass {
 
@@ -212,7 +213,7 @@ void output::clear() {
 	util::BaseClass::clear();
 }
 
-void output::sendToOutput(json::Object* message) {
+void output::sendToOutput(std::shared_ptr<json::Object> message) {
 	if (message == NULL) {
 		return;
 	}
@@ -236,7 +237,7 @@ bool output::check() {
 }
 
 // add data to output cache
-bool output::addTrackingData(json::Object* data) {
+bool output::addTrackingData(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log("error",
 					"output::addtrackingdata(): Bad json object passed in.");
@@ -262,20 +263,14 @@ bool output::addTrackingData(json::Object* data) {
 		return (false);
 	}
 
-	// make a new copy to add
-	json::Object * newData = new json::Object(*data);
-
-	// cleanup
-	delete (data);
-	data = NULL;
-
 	logger::log(
 			"debug",
 			"output::addTrackingData(): New tracking data: "
-					+ json::Serialize(*newData));
+					+ json::Serialize(*data));
 
 	// check to see if this event is already being tracked
-	json::Object* existingdata = m_TrackingCache->getFromCache(id);
+	std::shared_ptr<json::Object> existingdata = m_TrackingCache->getFromCache(
+			id);
 	if (existingdata != NULL) {
 		// it is, copy the pub log for an existing event
 		if (!(*existingdata).HasKey("PubLog")) {
@@ -284,11 +279,10 @@ bool output::addTrackingData(json::Object* data) {
 					"output::addtrackingdata(): existing event missing pub log! :"
 							+ json::Serialize(*existingdata));
 
-			delete (newData);
 			return (false);
 		} else {
 			json::Array pubLog = (*existingdata)["PubLog"].ToArray();
-			(*newData)["PubLog"] = pubLog;
+			(*data)["PubLog"] = pubLog;
 		}
 	} else {
 		// it isn't generate the pub log for a new event
@@ -299,15 +293,15 @@ bool output::addTrackingData(json::Object* data) {
 			// generate a pub log entry
 			pubLog.push_back(0);
 		}
-		(*newData)["PubLog"] = pubLog;
+		(*data)["PubLog"] = pubLog;
 	}
 
 	// add, cache handles updates
-	return (m_TrackingCache->addToCache(newData, id));
+	return (m_TrackingCache->addToCache(data, id));
 }
 
 // remove data from output cache
-bool output::removeTrackingData(json::Object* data) {
+bool output::removeTrackingData(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log("error",
 					"output::removetrackingdata(): Bad json object passed in.");
@@ -324,16 +318,8 @@ bool output::removeTrackingData(json::Object* data) {
 				"error",
 				"output::removetrackingdata(): Bad json hypo object passed in.");
 
-		// cleanup
-		delete (data);
-		data = NULL;
-
 		return (false);
 	}
-
-	// cleanup
-	delete (data);
-	data = NULL;
 
 	return (removeTrackingData(ID));
 }
@@ -352,14 +338,15 @@ bool output::removeTrackingData(std::string ID) {
 		return (false);
 }
 
-json::Object * output::getTrackingData(std::string id) {
+std::shared_ptr<json::Object> output::getTrackingData(std::string id) {
 	// return the value
 	return (m_TrackingCache->getFromCache(id));
 }
 
-json::Object * output::getNextTrackingData() {
+std::shared_ptr<json::Object> output::getNextTrackingData() {
 	// get the data
-	json::Object* data = m_TrackingCache->getNextFromCache(true);
+	std::shared_ptr<json::Object> data = m_TrackingCache->getNextFromCache(
+			true);
 
 	// loop until we hit the end of the list
 	while (data != NULL) {
@@ -378,7 +365,7 @@ json::Object * output::getNextTrackingData() {
 }
 
 // check if data in output cache
-bool output::haveTrackingData(json::Object* data) {
+bool output::haveTrackingData(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log("error",
 					"output::havetrackingdata(): Bad json object passed in.");
@@ -429,7 +416,7 @@ bool output::work() {
 
 	// first see what we're supposed to do with a new message
 	// see if there's anything in the message queue
-	json::Object* message = m_MessageQueue->getDataFromQueue();
+	std::shared_ptr<json::Object> message = m_MessageQueue->getDataFromQueue();
 
 	// if we got something
 	if (message != NULL) {
@@ -464,7 +451,8 @@ bool output::work() {
 
 		// glass has a hypo it wants us to send
 		if (messagetype == "Hypo") {
-			json::Object * trackingData = getTrackingData(messageid);
+			std::shared_ptr<json::Object> trackingData = getTrackingData(
+					messageid);
 
 			if (trackingData == NULL) {
 				return (false);
@@ -508,7 +496,8 @@ bool output::work() {
 
 			m_iEventCounter++;
 		} else if (messagetype == "Cancel") {
-			json::Object * trackingData = getTrackingData(messageid);
+			std::shared_ptr<json::Object> trackingData = getTrackingData(
+					messageid);
 			// see if we've tracked this event
 			if (trackingData != NULL) {
 				// we have
@@ -538,7 +527,8 @@ bool output::work() {
 			}
 			m_iCancelCounter++;
 		} else if (messagetype == "Expire") {
-			json::Object * trackingData = getTrackingData(messageid);
+			std::shared_ptr<json::Object> trackingData = getTrackingData(
+					messageid);
 			// see if we've tracked this event
 			if (trackingData != NULL) {
 				// we have
@@ -566,9 +556,6 @@ bool output::work() {
 					"warning",
 					"output::work(): Unknown message from glasslib: "
 							+ json::Serialize(*message) + ".");
-
-			// cleanup
-			delete (message);
 		}
 
 		// reporting
@@ -621,7 +608,7 @@ bool output::work() {
 	}
 
 	// see if there's anything in the tracking cache
-	json::Object * data = getNextTrackingData();
+	std::shared_ptr<json::Object> data = getNextTrackingData();
 
 	// got something
 	if (data != NULL) {
@@ -664,7 +651,8 @@ bool output::work() {
 			// Request the hypo from associator
 			if (Associator != NULL) {
 				// build the request
-				json::Object * datarequest = new json::Object();
+				std::shared_ptr<json::Object> datarequest = std::make_shared<
+						json::Object>(json::Object());
 				(*datarequest)["Cmd"] = "ReqHypo";
 				(*datarequest)["Pid"] = id;
 
@@ -685,7 +673,8 @@ bool output::work() {
 			// Request the sitelist from associator
 			if (Associator != NULL) {
 				// build the request
-				json::Object * datarequest = new json::Object();
+				std::shared_ptr<json::Object> datarequest = std::make_shared<
+						json::Object>(json::Object());
 				(*datarequest)["Cmd"] = "ReqSiteList";
 
 				// send the request
@@ -702,7 +691,7 @@ bool output::work() {
 }
 
 // handle output
-void output::writeOutput(json::Object *data) {
+void output::writeOutput(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log("error",
 					"output::writeoutput(): Null json object passed in.");
@@ -757,7 +746,7 @@ void output::writeOutput(json::Object *data) {
 }
 
 // filter
-bool output::isDataReady(json::Object *data) {
+bool output::isDataReady(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log("error",
 					"output::isdataready(): Null tracking object passed in.");
@@ -859,7 +848,7 @@ bool output::isDataReady(json::Object *data) {
 	return (false);
 }
 
-bool output::isDataChanged(json::Object *data) {
+bool output::isDataChanged(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log("error",
 					"output::isDataChanged(): Null tracking object passed in.");
@@ -900,7 +889,8 @@ bool output::isDataChanged(json::Object *data) {
 	return (true);
 }
 
-bool output::isDataPublished(json::Object *data, bool ignoreVersion) {
+bool output::isDataPublished(std::shared_ptr<json::Object> data,
+								bool ignoreVersion) {
 	if (data == NULL) {
 		logger::log(
 				"error",

--- a/output/src/output.cpp
+++ b/output/src/output.cpp
@@ -213,6 +213,10 @@ void output::clear() {
 }
 
 void output::sendToOutput(json::Object* message) {
+	if (message == NULL) {
+		return;
+	}
+
 	if (m_MessageQueue != NULL) {
 		m_MessageQueue->addDataToQueue(message);
 	}
@@ -260,6 +264,10 @@ bool output::addTrackingData(json::Object* data) {
 
 	// make a new copy to add
 	json::Object * newData = new json::Object(*data);
+
+	// cleanup
+	delete (data);
+	data = NULL;
 
 	logger::log(
 			"debug",
@@ -315,8 +323,17 @@ bool output::removeTrackingData(json::Object* data) {
 		logger::log(
 				"error",
 				"output::removetrackingdata(): Bad json hypo object passed in.");
+
+		// cleanup
+		delete (data);
+		data = NULL;
+
 		return (false);
 	}
+
+	// cleanup
+	delete (data);
+	data = NULL;
 
 	return (removeTrackingData(ID));
 }
@@ -489,11 +506,6 @@ bool output::work() {
 			// add the event to the tracking cache
 			addTrackingData(message);
 
-			// cleanup
-			// cppcheck-suppress nullPointerRedundantCheck
-			if (message != NULL) {
-				delete (message);
-			}
 			m_iEventCounter++;
 		} else if (messagetype == "Cancel") {
 			json::Object * trackingData = getTrackingData(messageid);

--- a/output/src/output.cpp
+++ b/output/src/output.cpp
@@ -213,7 +213,7 @@ void output::clear() {
 	util::BaseClass::clear();
 }
 
-void output::sendToOutput(std::shared_ptr<json::Object> message) {
+void output::sendToOutput(std::shared_ptr<json::Object> &message) {
 	if (message == NULL) {
 		return;
 	}

--- a/output/tests/output_unittest.cpp
+++ b/output/tests/output_unittest.cpp
@@ -77,6 +77,9 @@ TEST(Output, TrackingTests) {
 	ASSERT_FALSE(
 			outputThread.addTrackingData(new json::Object(json::Deserialize(BADTRACKING2))));  // NOLINT
 
+	tracking1 = new json::Object(json::Deserialize(TRACKING1));
+	tracking2 = new json::Object(json::Deserialize(TRACKING2));
+
 	// have successes
 	ASSERT_TRUE(outputThread.haveTrackingData(tracking1));
 	ASSERT_TRUE(outputThread.haveTrackingData(tracking2));
@@ -88,6 +91,9 @@ TEST(Output, TrackingTests) {
 
 	// remove successes
 	ASSERT_TRUE(outputThread.removeTrackingData(tracking1));
+
+	tracking1 = new json::Object(json::Deserialize(TRACKING1));
+
 	ASSERT_FALSE(outputThread.haveTrackingData(tracking1));
 
 	// remove fail

--- a/output/tests/output_unittest.cpp
+++ b/output/tests/output_unittest.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <ctime>
+#include <memory>
 
 #define EMPTYCONFIG "{\"Cmd\":\"GlassOutput\"}"
 #define CONFIGFAIL1 "{\"PublicationTimes\":[3, 6]}"
@@ -39,6 +40,7 @@ class OutputStub : public glass::output {
 TEST(Output, TrackingTests) {
 	// create output stub
 	OutputStub outputThread;
+	std::shared_ptr<json::Object> nullTrack;
 
 	time_t tNow;
 	std::time(&tNow);
@@ -50,17 +52,20 @@ TEST(Output, TrackingTests) {
 	ASSERT_TRUE(
 			outputThread.setup(new json::Object(json::Deserialize(EMPTYCONFIG))));  // NOLINT
 
-	json::Object *tracking1 = new json::Object(json::Deserialize(TRACKING1));
+	std::shared_ptr<json::Object> tracking1 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(TRACKING1)));
 
 	(*tracking1)["CreateTime"] = util::convertEpochTimeToISO8601(tNow);
 	(*tracking1)["ReportTime"] = util::convertEpochTimeToISO8601(tNow);
 
-	json::Object *tracking2 = new json::Object(json::Deserialize(TRACKING2));
+	std::shared_ptr<json::Object> tracking2 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(TRACKING2)));
 
 	(*tracking2)["CreateTime"] = util::convertEpochTimeToISO8601(tNow);
 	(*tracking2)["ReportTime"] = util::convertEpochTimeToISO8601(tNow);
 
-	json::Object *tracking3 = new json::Object(json::Deserialize(TRACKING3));
+	std::shared_ptr<json::Object> tracking3 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(TRACKING3)));
 
 	(*tracking3)["CreateTime"] = util::convertEpochTimeToISO8601(tNow);
 	(*tracking3)["ReportTime"] = util::convertEpochTimeToISO8601(tNow);
@@ -73,31 +78,34 @@ TEST(Output, TrackingTests) {
 	// add fails
 	ASSERT_FALSE(outputThread.addTrackingData(NULL));
 	ASSERT_FALSE(
-			outputThread.addTrackingData(new json::Object(json::Deserialize(BADTRACKING1))));  // NOLINT
+			outputThread.addTrackingData(std::make_shared<json::Object>(json::Object(json::Deserialize(BADTRACKING1)))));  // NOLINT
 	ASSERT_FALSE(
-			outputThread.addTrackingData(new json::Object(json::Deserialize(BADTRACKING2))));  // NOLINT
+			outputThread.addTrackingData(std::make_shared<json::Object>(json::Object(json::Deserialize(BADTRACKING2)))));  // NOLINT
 
-	tracking1 = new json::Object(json::Deserialize(TRACKING1));
-	tracking2 = new json::Object(json::Deserialize(TRACKING2));
+	std::shared_ptr<json::Object> tracking4 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(TRACKING1)));
+	std::shared_ptr<json::Object> tracking5 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(TRACKING2)));
 
 	// have successes
-	ASSERT_TRUE(outputThread.haveTrackingData(tracking1));
-	ASSERT_TRUE(outputThread.haveTrackingData(tracking2));
+	ASSERT_TRUE(outputThread.haveTrackingData(tracking4));
+	ASSERT_TRUE(outputThread.haveTrackingData(tracking5));
 	ASSERT_TRUE(outputThread.haveTrackingData(std::string(ID1)));
 
 	// have fails
-	ASSERT_FALSE(outputThread.haveTrackingData(NULL));
+	ASSERT_FALSE(outputThread.haveTrackingData(nullTrack));
 	ASSERT_FALSE(outputThread.haveTrackingData(""));
 
 	// remove successes
-	ASSERT_TRUE(outputThread.removeTrackingData(tracking1));
+	ASSERT_TRUE(outputThread.removeTrackingData(tracking4));
 
-	tracking1 = new json::Object(json::Deserialize(TRACKING1));
+	std::shared_ptr<json::Object> tracking6 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(TRACKING1)));
 
-	ASSERT_FALSE(outputThread.haveTrackingData(tracking1));
+	ASSERT_FALSE(outputThread.haveTrackingData(tracking6));
 
 	// remove fail
-	ASSERT_FALSE(outputThread.removeTrackingData(NULL));
+	ASSERT_FALSE(outputThread.removeTrackingData(nullTrack));
 	ASSERT_FALSE(outputThread.removeTrackingData(""));
 
 	// clear

--- a/parse/include/ccparser.h
+++ b/parse/include/ccparser.h
@@ -10,6 +10,7 @@
 #include <json.h>
 #include <parser.h>
 #include <string>
+#include <memory>
 
 namespace parse {
 /**
@@ -52,7 +53,7 @@ class CCParser : public Parser {
 	 * \return Returns a pointer to the json::Object containing
 	 * the data.
 	 */
-	json::Object* parse(const std::string &input) override;
+	std::shared_ptr<json::Object> parse(const std::string &input) override;
 
 	/**
 	 * \brief cross correlation validation function
@@ -63,7 +64,7 @@ class CCParser : public Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	bool validate(json::Object* input) override;
+	bool validate(std::shared_ptr<json::Object> input) override;
 };
 }  // namespace parse
 #endif  // CCPARSER_H

--- a/parse/include/ccparser.h
+++ b/parse/include/ccparser.h
@@ -64,7 +64,7 @@ class CCParser : public Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	bool validate(std::shared_ptr<json::Object> input) override;
+	bool validate(std::shared_ptr<json::Object> &input) override;
 };
 }  // namespace parse
 #endif  // CCPARSER_H

--- a/parse/include/convert.h
+++ b/parse/include/convert.h
@@ -9,6 +9,7 @@
 
 #include <json.h>
 #include <string>
+#include <memory>
 
 namespace parse {
 
@@ -25,7 +26,7 @@ namespace parse {
  * \return Returns a string containing the converted json detection, empty
  * string otherwise
  */
-std::string hypoToJSONDetection(json::Object *data,
+std::string hypoToJSONDetection(std::shared_ptr<json::Object>,
 								const std::string &outputAgencyID,
 								const std::string &outputAuthor);
 
@@ -43,7 +44,7 @@ std::string hypoToJSONDetection(json::Object *data,
  * \return Returns a string containing the converted json detection, empty
  * string otherwise
  */
-std::string cancelToJSONRetract(json::Object *data,
+std::string cancelToJSONRetract(std::shared_ptr<json::Object>,
 								const std::string &outputAgencyID,
 								const std::string &outputAuthor);
 
@@ -58,7 +59,7 @@ std::string cancelToJSONRetract(json::Object *data,
  * \return Returns a string containing the converted json detection, empty
  * string otherwise
  */
-std::string siteListToStationList(json::Object *data);
+std::string siteListToStationList(std::shared_ptr<json::Object>);
 
 /**
  * \brief json station list conversion function
@@ -74,7 +75,7 @@ std::string siteListToStationList(json::Object *data);
  * \return Returns a string containing the converted json detection, empty
  * string otherwise
  */
-std::string siteLookupToStationInfoRequest(json::Object *data,
+std::string siteLookupToStationInfoRequest(std::shared_ptr<json::Object>,
 											const std::string &outputAgencyID,
 											const std::string &outputAuthor);
 

--- a/parse/include/gpickparser.h
+++ b/parse/include/gpickparser.h
@@ -64,7 +64,7 @@ class GPickParser : public Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	bool validate(std::shared_ptr<json::Object> input) override;
+	bool validate(std::shared_ptr<json::Object> &input) override;
 };
 }  // namespace parse
 #endif  // GPICKPARSER_H

--- a/parse/include/gpickparser.h
+++ b/parse/include/gpickparser.h
@@ -10,6 +10,7 @@
 #include <json.h>
 #include <parser.h>
 #include <string>
+#include <memory>
 
 namespace parse {
 /**
@@ -52,7 +53,7 @@ class GPickParser : public Parser {
 	 * \return Returns a pointer to the json::Object containing
 	 * the data.
 	 */
-	json::Object* parse(const std::string &input) override;
+	std::shared_ptr<json::Object> parse(const std::string &input) override;
 
 	/**
 	 * \brief pick validation function
@@ -63,7 +64,7 @@ class GPickParser : public Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	bool validate(json::Object* input) override;
+	bool validate(std::shared_ptr<json::Object> input) override;
 };
 }  // namespace parse
 #endif  // GPICKPARSER_H

--- a/parse/include/jsonparser.h
+++ b/parse/include/jsonparser.h
@@ -53,7 +53,7 @@ class JSONParser : public Parser {
 	 * \return Returns a pointer to the json::Object containing
 	 * the data.
 	 */
-	std::shared_ptr<json::Object> parse(const std::string &input) override;
+	std::shared_ptr<json::Object> parse(const std::string &input) override; // NOLINT
 
 	/**
 	 * \brief json validation function
@@ -64,7 +64,7 @@ class JSONParser : public Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	bool validate(std::shared_ptr<json::Object> input) override;
+	bool validate(std::shared_ptr<json::Object> &input) override;
 };
 }  // namespace parse
 #endif  // JSONPARSER_H

--- a/parse/include/jsonparser.h
+++ b/parse/include/jsonparser.h
@@ -10,6 +10,7 @@
 #include <json.h>
 #include <parser.h>
 #include <string>
+#include <memory>
 
 namespace parse {
 /**
@@ -52,7 +53,7 @@ class JSONParser : public Parser {
 	 * \return Returns a pointer to the json::Object containing
 	 * the data.
 	 */
-	json::Object* parse(const std::string &input) override;
+	std::shared_ptr<json::Object> parse(const std::string &input) override;
 
 	/**
 	 * \brief json validation function
@@ -63,7 +64,7 @@ class JSONParser : public Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	bool validate(json::Object* input) override;
+	bool validate(std::shared_ptr<json::Object> input) override;
 };
 }  // namespace parse
 #endif  // JSONPARSER_H

--- a/parse/include/parser.h
+++ b/parse/include/parser.h
@@ -62,7 +62,7 @@ class Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	virtual bool validate(std::shared_ptr<json::Object> input) = 0;
+	virtual bool validate(std::shared_ptr<json::Object> &input) = 0; // NOLINT
 
 	/**
 	 * \brief getter for the agencyid configuration variable

--- a/parse/include/parser.h
+++ b/parse/include/parser.h
@@ -9,6 +9,7 @@
 
 #include <json.h>
 #include <string>
+#include <memory>
 
 namespace parse {
 /**
@@ -50,7 +51,7 @@ class Parser {
 	 * \return Returns a pointer to the json::Object containing
 	 * the data.
 	 */
-	virtual json::Object* parse(const std::string &input) = 0;
+	virtual std::shared_ptr<json::Object> parse(const std::string &input) = 0;
 
 	/**
 	 * \brief validation function
@@ -61,7 +62,7 @@ class Parser {
 	 * validate.
 	 * \return Returns true if valid, false otherwise.
 	 */
-	virtual bool validate(json::Object* input) = 0;
+	virtual bool validate(std::shared_ptr<json::Object> input) = 0;
 
 	/**
 	 * \brief getter for the agencyid configuration variable

--- a/parse/src/ccparser.cpp
+++ b/parse/src/ccparser.cpp
@@ -138,7 +138,7 @@ std::shared_ptr<json::Object> CCParser::parse(const std::string &input) {
 }
 
 // validate a json object
-bool CCParser::validate(std::shared_ptr<json::Object> input) {
+bool CCParser::validate(std::shared_ptr<json::Object> &input) {
 	// nullcheck
 	if (input == NULL) {
 		return (false);

--- a/parse/src/ccparser.cpp
+++ b/parse/src/ccparser.cpp
@@ -6,6 +6,7 @@
 #include <detection-formats.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace parse {
 CCParser::CCParser(const std::string &newAgencyID, const std::string &newAuthor)
@@ -15,7 +16,7 @@ CCParser::~CCParser() {
 }
 
 // parse a json object from an input string
-json::Object* CCParser::parse(const std::string &input) {
+std::shared_ptr<json::Object> CCParser::parse(const std::string &input) {
 	// make sure we got something
 	if (input.length() == 0)
 		return (NULL);
@@ -119,8 +120,9 @@ json::Object* CCParser::parse(const std::string &input) {
 
 		// make sure we got valid json
 		if (deserializedJSON.GetType() != json::ValueType::NULLVal) {
-			json::Object* newjsoncorrelation = new json::Object(
-					deserializedJSON.ToObject());
+			std::shared_ptr<json::Object> newjsoncorrelation = std::make_shared<
+								json::Object>(json::Object(deserializedJSON.ToObject()));
+
 			logger::log(
 					"trace",
 					"ccparser::parse: Output JSON: "
@@ -136,7 +138,7 @@ json::Object* CCParser::parse(const std::string &input) {
 }
 
 // validate a json object
-bool CCParser::validate(json::Object* input) {
+bool CCParser::validate(std::shared_ptr<json::Object> input) {
 	// nullcheck
 	if (input == NULL) {
 		return (false);

--- a/parse/src/convert.cpp
+++ b/parse/src/convert.cpp
@@ -7,10 +7,11 @@
 #include <string>
 #include <ctime>
 #include <vector>
+#include <memory>
 
 namespace parse {
 
-std::string hypoToJSONDetection(json::Object *data,
+std::string hypoToJSONDetection(std::shared_ptr<json::Object> data,
 								const std::string &outputAgencyID,
 								const std::string &outputAuthor) {
 	if (data == NULL) {
@@ -384,14 +385,11 @@ std::string hypoToJSONDetection(json::Object *data,
 			detection.tojson(detectiondocument,
 								detectiondocument.GetAllocator()));
 
-	// cleanup
-	delete (data);
-
 	// done
 	return (OutputData);
 }
 
-std::string cancelToJSONRetract(json::Object *data,
+std::string cancelToJSONRetract(std::shared_ptr<json::Object> data,
 								const std::string &outputAgencyID,
 								const std::string &outputAuthor) {
 	if (data == NULL) {
@@ -452,14 +450,11 @@ std::string cancelToJSONRetract(json::Object *data,
 	OutputData = detectionformats::ToJSONString(
 			retract.tojson(retractdocument, retractdocument.GetAllocator()));
 
-	// cleanup
-	delete (data);
-
 	// done
 	return (OutputData);
 }
 
-std::string siteListToStationList(json::Object *data) {
+std::string siteListToStationList(std::shared_ptr<json::Object> data) {
 	if (data == NULL) {
 		logger::log(
 				"error",
@@ -543,14 +538,11 @@ std::string siteListToStationList(json::Object *data) {
 
 	OutputData = json::Serialize(stationListObj);
 
-	// cleanup
-	delete (data);
-
 	// done
 	return (OutputData);
 }
 
-std::string siteLookupToStationInfoRequest(json::Object *data,
+std::string siteLookupToStationInfoRequest(std::shared_ptr<json::Object> data,
 											const std::string &outputAgencyID,
 											const std::string &outputAuthor) {
 	if (data == NULL) {
@@ -650,9 +642,6 @@ std::string siteLookupToStationInfoRequest(json::Object *data,
 				"siteLookupToStationInfoRequest: Invalid station info request "
 						"message: " + errorstring);
 	}
-
-	// cleanup
-	delete (data);
 
 	// done
 	return (OutputString);

--- a/parse/src/gpickparser.cpp
+++ b/parse/src/gpickparser.cpp
@@ -196,7 +196,7 @@ std::shared_ptr<json::Object> GPickParser::parse(const std::string &input) {
 }
 
 // validate a json object
-bool GPickParser::validate(std::shared_ptr<json::Object> input) {
+bool GPickParser::validate(std::shared_ptr<json::Object> &input) {
 	// nullcheck
 	if (input == NULL) {
 		return (false);

--- a/parse/src/gpickparser.cpp
+++ b/parse/src/gpickparser.cpp
@@ -6,6 +6,7 @@
 #include <detection-formats.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace parse {
 GPickParser::GPickParser(const std::string &newAgencyID,
@@ -16,7 +17,7 @@ GPickParser::~GPickParser() {
 }
 
 // parse a json object from an input string
-json::Object* GPickParser::parse(const std::string &input) {
+std::shared_ptr<json::Object> GPickParser::parse(const std::string &input) {
 	// make sure we got something
 	if (input.length() == 0)
 		return (NULL);
@@ -174,8 +175,9 @@ json::Object* GPickParser::parse(const std::string &input) {
 
 		// make sure we got valid json
 		if (deserializedJSON.GetType() != json::ValueType::NULLVal) {
-			json::Object* newjsonpick = new json::Object(
-					deserializedJSON.ToObject());
+			std::shared_ptr<json::Object> newjsonpick = std::make_shared<
+					json::Object>(json::Object(deserializedJSON.ToObject()));
+
 			logger::log(
 					"trace",
 					"gpickparser::parse: Output JSON: "
@@ -194,7 +196,7 @@ json::Object* GPickParser::parse(const std::string &input) {
 }
 
 // validate a json object
-bool GPickParser::validate(json::Object* input) {
+bool GPickParser::validate(std::shared_ptr<json::Object> input) {
 	// nullcheck
 	if (input == NULL) {
 		return (false);

--- a/parse/src/jsonparser.cpp
+++ b/parse/src/jsonparser.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<json::Object> JSONParser::parse(const std::string &input) {
 }
 
 // validate a json object
-bool JSONParser::validate(std::shared_ptr<json::Object> input) {
+bool JSONParser::validate(std::shared_ptr<json::Object> &input) {
 	// nullcheck
 	if (input == NULL) {
 		return (false);

--- a/parse/src/jsonparser.cpp
+++ b/parse/src/jsonparser.cpp
@@ -5,6 +5,7 @@
 #include <detection-formats.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace parse {
 JSONParser::JSONParser(const std::string &newAgencyID,
@@ -15,7 +16,7 @@ JSONParser::~JSONParser() {
 }
 
 // parse a json object from an input string
-json::Object* JSONParser::parse(const std::string &input) {
+std::shared_ptr<json::Object> JSONParser::parse(const std::string &input) {
 	// make sure we got something
 	if (input.length() == 0) {
 		return (NULL);
@@ -26,7 +27,7 @@ json::Object* JSONParser::parse(const std::string &input) {
 	// JSON format
 	// JSON doesn't have a fixed format
 	// try to convert the string to a json object
-	json::Object *newobject = NULL;
+	std::shared_ptr<json::Object> newobject;
 	try {
 		json::Value deserializedvalue = json::Deserialize(input);
 
@@ -39,7 +40,8 @@ json::Object* JSONParser::parse(const std::string &input) {
 		}
 
 		// convert our resulting value to a json object
-		newobject = new json::Object(deserializedvalue.ToObject());
+		newobject = std::make_shared<json::Object>(
+				json::Object(deserializedvalue.ToObject()));
 	} catch (const std::runtime_error &e) {
 		// oopse
 		std::string exceptionstring = e.what();
@@ -67,7 +69,7 @@ json::Object* JSONParser::parse(const std::string &input) {
 }
 
 // validate a json object
-bool JSONParser::validate(json::Object* input) {
+bool JSONParser::validate(std::shared_ptr<json::Object> input) {
 	// nullcheck
 	if (input == NULL) {
 		return (false);

--- a/parse/tests/ccparser_unittest.cpp
+++ b/parse/tests/ccparser_unittest.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <memory>
 
 #define TESTCCSTRING "2015/03/23 23:53:47.630 36.769 -98.019 5.0 1.2677417 mblg GS OK032 HHZ 00 P 2015/03/23 23:53:50.850 0.7663822 0.65" // NOLINT
 #define TESTFAILSTRING "2015/03/23 -98.019 5.0 1.2677417 mblg GS OK032 HHZ 00 P 2015/03/23 23:53:50.850 0.7663822 0.65" // NOLINT
@@ -31,7 +32,7 @@ class CCParser : public ::testing::Test {
 TEST_F(CCParser, Construction) {
 	// assert that agencyid is ok
 	ASSERT_STREQ(Parser->getAgencyid().c_str(), agencyid.c_str())<<
-			"AgencyID check";
+	"AgencyID check";
 
 	// assert that author is ok
 	ASSERT_STREQ(Parser->getAuthor().c_str(), author.c_str())
@@ -42,28 +43,28 @@ TEST_F(CCParser, Construction) {
 TEST_F(CCParser, CorrelationParsing) {
 	std::string ccstring = std::string(TESTCCSTRING);
 
-	json::Object * CCObject = Parser->parse(ccstring);
+	std::shared_ptr<json::Object> CCObject = Parser->parse(ccstring);
 
 	// parse the origin
 	ASSERT_FALSE(CCObject == NULL)<< "Parsed cross correlation not null.";
 
 	// validate the origin
 	ASSERT_TRUE(Parser->validate(CCObject))<<
-			"Parsed cross correlation is valid";
+	"Parsed cross correlation is valid";
 }
 
 // test failure
 TEST_F(CCParser, FailTest) {
 	std::string failstring = std::string(TESTFAILSTRING);
 
-	json::Object * FailObject = Parser->parse(failstring);
+	std::shared_ptr<json::Object> FailObject = Parser->parse(failstring);
 
 	// parse the bad data
 	ASSERT_TRUE(FailObject == NULL)<< "Parsed fail string is null.";
 
 	// validate the bad data
 	ASSERT_FALSE(Parser->validate(FailObject))<<
-			"Parsed failstring is not valid";
+	"Parsed failstring is not valid";
 
 	// parse empty string
 	FailObject = Parser->parse("");
@@ -73,5 +74,5 @@ TEST_F(CCParser, FailTest) {
 
 	// validate the bad data
 	ASSERT_FALSE(Parser->validate(FailObject))<<
-			"Parsed empty string is not valid";
+	"Parsed empty string is not valid";
 }

--- a/parse/tests/convert_unittest.cpp
+++ b/parse/tests/convert_unittest.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <string>
+#include <memory>
 
 #define HYPOSTRING "{\"Bayes\":2.087726,\"Cmd\":\"Hypo\",\"Data\":[{\"Type\":\"Correlation\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Phase\":\"P\",\"Time\":\"2015-12-28T21:32:24.017Z\",\"Correlation\":2.65,\"Hypocenter\":{\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44,\"Time\":\"2015-12-28T21:30:44.039Z\"},\"EventType\":\"earthquake\",\"Magnitude\":2.14,\"SNR\":3.8,\"ZScore\":33.67,\"DetectionThreshold\":1.5,\"ThresholdType\":\"minimum\",\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}},{\"Amplitude\":{\"Amplitude\":0.000000,\"Period\":0.000000,\"SNR\":3.410000},\"AssociationInfo\":{\"Azimuth\":146.725914,\"Distance\":0.114828,\"Phase\":\"P\",\"Residual\":0.000904,\"Sigma\":1.000000},\"Filter\":[{\"HighPass\":1.050000,\"LowPass\":2.650000}],\"ID\":\"100725\",\"Phase\":\"P\",\"Picker\":\"raypicker\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"BHZ\",\"Location\":\"--\",\"Network\":\"AK\",\"Station\":\"SSN\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"228041013\"},\"Time\":\"2015-08-14T03:35:25.947Z\",\"Type\":\"Pick\"}],\"Depth\":24.717898,\"Gap\":110.554774,\"ID\":\"20311B8E10AF5649BDC52ED099CF173E\",\"IsUpdate\":false,\"Latitude\":61.559315,\"Longitude\":-150.877897,\"MinimumDistance\":0.110850,\"Source\":{\"AgencyID\":\"US\",\"Author\":\"glass\"},\"T\":\"20150814033521.219\",\"Time\":\"2015-08-14T03:35:21.219Z\",\"Type\":\"Hypo\"}" // NOLINT
 #define BADHYPOSTRING1 "{\"Bayes\":2.087726,\"Cmd\":\"Hypo\",\"Data\":[{\"Amplitude\":{\"Amplitude\":0.000000,\"Period\":0.000000,\"SNR\":3.410000},\"AssociationInfo\":{\"Azimuth\":146.725914,\"Distance\":0.114828,\"Phase\":\"P\",\"Residual\":0.000904,\"Sigma\":1.000000},\"Filter\":[{\"HighPass\":1.050000,\"LowPass\":2.650000}],\"ID\":\"100725\",\"Phase\":\"P\",\"Picker\":\"raypicker\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"BHZ\",\"Location\":\"--\",\"Network\":\"AK\",\"Station\":\"SSN\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"228041013\"},\"Time\":\"2015-08-14T03:35:25.947Z\",\"Type\":\"Pick\"}],\"Depth\":24.717898,\"Gap\":110.554774,\"ID\":\"20311B8E10AF5649BDC52ED099CF173E\",\"IsUpdate\":false,\"Latitude\":61.559315,\"Longitude\":-150.877897,\"MinimumDistance\":0.110850,\"Source\":{\"AgencyID\":\"US\",\"Author\":\"glass\"},\"T\":\"20150814033521.219\",\"Time\":\"2015-08-14T03:35:21.219Z\"}" // NOLINT
@@ -35,18 +36,20 @@ TEST(Convert, HypoTest) {
 	ASSERT_STREQ(parse::hypoToJSONDetection(NULL, agencyid, author).c_str(),
 					"");
 	ASSERT_STREQ(
-			parse::hypoToJSONDetection(new json::Object(json::Deserialize(BADHYPOSTRING1)), agencyid, author).c_str(),  // NOLINT
+			parse::hypoToJSONDetection(std::make_shared<json::Object>(json::Object(json::Deserialize(BADHYPOSTRING1))), agencyid, author).c_str(),  // NOLINT
 			"");
 	ASSERT_STREQ(
-			parse::hypoToJSONDetection(new json::Object( json::Deserialize(BADHYPOSTRING2)), agencyid, author).c_str(),  // NOLINT
+			parse::hypoToJSONDetection(std::make_shared<json::Object>(json::Object(json::Deserialize(BADHYPOSTRING2))), agencyid, author).c_str(),  // NOLINT
 			"");
 	ASSERT_STREQ(
-			parse::hypoToJSONDetection(new json::Object( json::Deserialize(CANCELSTRING)), agencyid, author).c_str(),  // NOLINT
+			parse::hypoToJSONDetection(std::make_shared<json::Object>(json::Object(json::Deserialize(CANCELSTRING))), agencyid, author).c_str(),  // NOLINT
 			"");
 
 	// Hypo
 	std::string detectionoutput = parse::hypoToJSONDetection(
-			new json::Object(json::Deserialize(HYPOSTRING)), agencyid, author);
+			std::make_shared<json::Object>(
+					json::Object(json::Deserialize(HYPOSTRING))),
+			agencyid, author);
 	// build detection object
 	rapidjson::Document detectiondocument;
 	detectionformats::detection detectionobject(
@@ -121,19 +124,20 @@ TEST(Convert, CancelTest) {
 	ASSERT_STREQ(parse::cancelToJSONRetract(NULL, agencyid, author).c_str(),
 					"");
 	ASSERT_STREQ(
-			parse::cancelToJSONRetract(new json::Object(json::Deserialize(BADCANCELSTRING1)), agencyid, author).c_str(),  // NOLINT
+			parse::cancelToJSONRetract(std::make_shared<json::Object>(json::Object(json::Deserialize(BADCANCELSTRING1))), agencyid, author).c_str(),  // NOLINT
 			"");
 	ASSERT_STREQ(
-			parse::cancelToJSONRetract(new json::Object( json::Deserialize(BADCANCELSTRING2)), agencyid, author).c_str(),  // NOLINT
+			parse::cancelToJSONRetract(std::make_shared<json::Object>(json::Object(json::Deserialize(BADCANCELSTRING2))), agencyid, author).c_str(),  // NOLINT
 			"");
 	ASSERT_STREQ(
-			parse::cancelToJSONRetract(new json::Object( json::Deserialize(HYPOSTRING)), agencyid, author).c_str(),  // NOLINT
+			parse::cancelToJSONRetract(std::make_shared<json::Object>(json::Object(json::Deserialize(HYPOSTRING))), agencyid, author).c_str(),  // NOLINT
 			"");
 
 	// Cancel
 	std::string retractoutput = parse::cancelToJSONRetract(
-			new json::Object(json::Deserialize(CANCELSTRING)), agencyid,
-			author);
+			std::make_shared<json::Object>(
+					json::Object(json::Deserialize(CANCELSTRING))),
+			agencyid, author);
 	// build detection object
 	rapidjson::Document retractdocument;
 	detectionformats::retract retractobject(
@@ -163,10 +167,10 @@ TEST(Convert, SiteListTest) {
 	// failure cases
 	ASSERT_STREQ(parse::siteListToStationList(NULL).c_str(), "");
 	ASSERT_STREQ(
-			parse::siteListToStationList(new json::Object( json::Deserialize(BADSITELISTSTRING1))).c_str(), // NOLINT
+			parse::siteListToStationList(std::make_shared<json::Object>(json::Object( json::Deserialize(BADSITELISTSTRING1)))).c_str(),  // NOLINT
 			"");
 	ASSERT_STREQ(
-			parse::siteListToStationList(new json::Object( json::Deserialize(BADSITELISTSTRING2))).c_str(), // NOLINT
+			parse::siteListToStationList(std::make_shared<json::Object>(json::Object( json::Deserialize(BADSITELISTSTRING2)))).c_str(),  // NOLINT
 			"");
 
 	std::string sitelistfile = "./" + std::string(TESTPATH) + "/"
@@ -182,14 +186,15 @@ TEST(Convert, SiteListTest) {
 
 	inFile.close();
 
-	json::Object* sitelistobject = new json::Object(
-			json::Deserialize(sitelist));
+	std::shared_ptr<json::Object> sitelistobject =
+			std::make_shared<json::Object>(
+					json::Object(json::Deserialize(sitelist)));
 	int numsites = (*sitelistobject)["SiteList"].ToArray().size();
 
 	std::string stationlist = parse::siteListToStationList(sitelistobject);
 
-	json::Object* stationlistobject = new json::Object(
-			json::Deserialize(stationlist));
+	std::shared_ptr<json::Object> stationlistobject = std::make_shared<
+			json::Object>(json::Object(json::Deserialize(stationlist)));
 
 	ASSERT_TRUE(stationlistobject->HasKey("Type"));
 	ASSERT_STREQ((*stationlistobject)["Type"].ToString().c_str(),
@@ -209,16 +214,17 @@ TEST(Convert, SiteLookupTest) {
 			parse::siteLookupToStationInfoRequest(NULL, agencyid, author).c_str(),
 			"");
 	ASSERT_STREQ(
-			parse::siteLookupToStationInfoRequest(new json::Object(json::Deserialize(BADSITELOOKUPSTRING1)), agencyid, author).c_str(),  // NOLINT
+			parse::siteLookupToStationInfoRequest(std::make_shared<json::Object>( json::Object(json::Deserialize(BADSITELOOKUPSTRING1))), agencyid, author).c_str(),  // NOLINT
 			"");
 	ASSERT_STREQ(
-			parse::siteLookupToStationInfoRequest(new json::Object( json::Deserialize(CANCELSTRING)), agencyid, author).c_str(),  // NOLINT
+			parse::siteLookupToStationInfoRequest(std::make_shared<json::Object>( json::Object( json::Deserialize(CANCELSTRING))), agencyid, author).c_str(),  // NOLINT
 			"");
 
 	// sitelookup
 	std::string stationinforequestoutput =
 			parse::siteLookupToStationInfoRequest(
-					new json::Object(json::Deserialize(SITELOOKUPSTRING)),
+					std::make_shared<json::Object>(
+							json::Object(json::Deserialize(SITELOOKUPSTRING))),
 					agencyid, author);
 	// build detection object
 	rapidjson::Document stationdocument;

--- a/parse/tests/gpickparser_unittest.cpp
+++ b/parse/tests/gpickparser_unittest.cpp
@@ -2,13 +2,13 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <memory>
 
 #define TESTGPICKSTRING1 "228041013 22637648 1 BOZ BHZ US 00 20150303000044.175 P -1.0000 U  ? m 1.050 2.650 0.0 0.000000 3.49 0.000000 0.000000" // NOLINT
 #define TESTGPICKSTRING2 "228041013 22637649 1 BOZ BHZ US 00 20150303000045.175 P -1.0000 D  i r 1.050 2.650 0.0 0.000000 3.49 0.000000 0.000000" // NOLINT
 #define TESTGPICKSTRING3 "228041013 22637650 1 BOZ BHZ US 00 20150303000046.175 P -1.0000 U  e l 1.050 2.650 0.0 0.000000 3.49 0.000000 0.000000" // NOLINT
 #define TESTGPICKSTRING4 "228041013 22637651 1 BOZ BHZ US 00 20150303000047.175 P -1.0000 U  q e 1.050 2.650 0.0 0.000000 3.49 0.000000 0.000000" // NOLINT
 #define TESTGPICKSTRING5 "228041013 22637652 1 BOZ BHZ US 00 20150303000048.175 P -1.0000 U  q U 1.050 2.650 0.0 0.000000 3.49 0.000000 0.000000" // NOLINT
-
 
 #define TESTFAILSTRING "228041013 22637648 1 BOZ BHZ US 00 P -1.0000 U  ? r 1.050 2.650 0.0 0.000000 3.49 0.000000 0.000000" // NOLINT
 #define TESTAGENCYID "US"
@@ -37,7 +37,7 @@ class GPickParser : public ::testing::Test {
 TEST_F(GPickParser, Construction) {
 	// assert that agencyid is ok
 	ASSERT_STREQ(Parser->getAgencyid().c_str(), agencyid.c_str())<<
-			"AgencyID check";
+	"AgencyID check";
 
 	// assert that author is ok
 	ASSERT_STREQ(Parser->getAuthor().c_str(), author.c_str())
@@ -53,7 +53,7 @@ TEST_F(GPickParser, PickParsing) {
 	std::string pickstring5 = std::string(TESTGPICKSTRING5);
 
 	// pick 1
-	json::Object * PickObject = Parser->parse(pickstring1);
+	std::shared_ptr<json::Object> PickObject = Parser->parse(pickstring1);
 
 	// parse the origin
 	ASSERT_FALSE(PickObject == NULL)<< "Parsed pick 1 not null.";
@@ -62,54 +62,54 @@ TEST_F(GPickParser, PickParsing) {
 	ASSERT_TRUE(Parser->validate(PickObject))<< "Parsed pick 1 is valid";
 
 	// pick 2
-	PickObject = Parser->parse(pickstring2);
+	std::shared_ptr<json::Object> PickObject2 = Parser->parse(pickstring2);
 
 	// parse the origin
-	ASSERT_FALSE(PickObject == NULL)<< "Parsed pick 2 not null.";
+	ASSERT_FALSE(PickObject2 == NULL)<< "Parsed pick 2 not null.";
 
 	// validate the pick
-	ASSERT_TRUE(Parser->validate(PickObject))<< "Parsed pick 2 is valid";
+	ASSERT_TRUE(Parser->validate(PickObject2))<< "Parsed pick 2 is valid";
 
 	// pick 3
-	PickObject = Parser->parse(pickstring3);
+	std::shared_ptr<json::Object> PickObject3 = Parser->parse(pickstring3);
 
 	// parse the origin
-	ASSERT_FALSE(PickObject == NULL)<< "Parsed pick 3 not null.";
+	ASSERT_FALSE(PickObject3 == NULL)<< "Parsed pick 3 not null.";
 
 	// validate the pick
-	ASSERT_TRUE(Parser->validate(PickObject))<< "Parsed pick 3 is valid";
+	ASSERT_TRUE(Parser->validate(PickObject3))<< "Parsed pick 3 is valid";
 
 	// pick 4
-	PickObject = Parser->parse(pickstring4);
+	std::shared_ptr<json::Object> PickObject4 = Parser->parse(pickstring4);
 
 	// parse the origin
-	ASSERT_FALSE(PickObject == NULL)<< "Parsed pick 4 not null.";
+	ASSERT_FALSE(PickObject4 == NULL)<< "Parsed pick 4 not null.";
 
 	// validate the pick
-	ASSERT_TRUE(Parser->validate(PickObject))<< "Parsed pick 4 is valid";
+	ASSERT_TRUE(Parser->validate(PickObject4))<< "Parsed pick 4 is valid";
 
 	// pick 5
-	PickObject = Parser->parse(pickstring5);
+	std::shared_ptr<json::Object> PickObject5 = Parser->parse(pickstring5);
 
 	// parse the origin
-	ASSERT_FALSE(PickObject == NULL)<< "Parsed pick 2 not null.";
+	ASSERT_FALSE(PickObject5 == NULL)<< "Parsed pick 2 not null.";
 
 	// validate the pick
-	ASSERT_TRUE(Parser->validate(PickObject))<< "Parsed pick 2 is valid";
+	ASSERT_TRUE(Parser->validate(PickObject5))<< "Parsed pick 2 is valid";
 }
 
 // test failure
 TEST_F(GPickParser, FailTest) {
 	std::string failstring = std::string(TESTFAILSTRING);
 
-	json::Object * FailObject = Parser->parse(failstring);
+	std::shared_ptr<json::Object> FailObject = Parser->parse(failstring);
 
 	// parse the bad data
 	ASSERT_TRUE(FailObject == NULL)<< "Parsed fail string is null.";
 
 	// validate the bad data
 	ASSERT_FALSE(Parser->validate(FailObject))<<
-			"Parsed failstring is not valid";
+	"Parsed failstring is not valid";
 
 	// parse empty string
 	FailObject = Parser->parse("");
@@ -119,5 +119,5 @@ TEST_F(GPickParser, FailTest) {
 
 	// validate the bad data
 	ASSERT_FALSE(Parser->validate(FailObject))<<
-			"Parsed empty string is not valid";
+	"Parsed empty string is not valid";
 }

--- a/parse/tests/jsonparser_unittest.cpp
+++ b/parse/tests/jsonparser_unittest.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <memory>
 
 #define TESTDETECTIONSTRING "{\"Type\":\"Detection\",\"ID\":\"12GFH48776857\",\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Hypocenter\":{\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44,\"Time\":\"2015-12-28T21:32:24.017Z\"},\"DetectionType\":\"New\",\"EventType\":\"earthquake\",\"Bayes\":2.65,\"MinimumDistance\":2.14,\"RMS\":3.8,\"Gap\":33.67,\"Data\":[{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}},{\"Type\":\"Correlation\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Phase\":\"P\",\"Time\":\"2015-12-28T21:32:24.017Z\",\"Correlation\":2.65,\"Hypocenter\":{\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44,\"Time\":\"2015-12-28T21:30:44.039Z\"},\"EventType\":\"earthquake\",\"Magnitude\":2.14,\"SNR\":3.8,\"ZScore\":33.67,\"DetectionThreshold\":1.5,\"ThresholdType\":\"minimum\",\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}]}" // NOLINT
 #define TESTCORRELATIONSTRING "{\"Type\":\"Correlation\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Phase\":\"P\",\"Time\":\"2015-12-28T21:32:24.017Z\",\"Correlation\":2.65,\"Hypocenter\":{\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44,\"Time\":\"2015-12-28T21:30:44.039Z\"},\"EventType\":\"earthquake\",\"Magnitude\":2.14,\"SNR\":3.8,\"ZScore\":33.67,\"DetectionThreshold\":1.5,\"ThresholdType\":\"minimum\",\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}" // NOLINT
@@ -53,7 +54,8 @@ TEST_F(JSONParser, Construction) {
 TEST_F(JSONParser, DetectionParsing) {
 	std::string detectionstring = std::string(TESTDETECTIONSTRING);
 
-	json::Object * DetectionObject = Parser->parse(detectionstring);
+	std::shared_ptr<json::Object> DetectionObject = Parser->parse(
+			detectionstring);
 
 	// parse the detection
 	ASSERT_FALSE(DetectionObject == NULL)<< "Parsed detection not null.";
@@ -67,7 +69,8 @@ TEST_F(JSONParser, DetectionParsing) {
 TEST_F(JSONParser, CorrelationParsing) {
 	std::string correlationstring = std::string(TESTCORRELATIONSTRING);
 
-	json::Object * CorrelationObject = Parser->parse(correlationstring);
+	std::shared_ptr<json::Object> CorrelationObject = Parser->parse(
+			correlationstring);
 
 	// parse the corrleation
 	ASSERT_FALSE(CorrelationObject == NULL)<< "Parsed correlation not null.";
@@ -81,7 +84,7 @@ TEST_F(JSONParser, CorrelationParsing) {
 TEST_F(JSONParser, PickParsing) {
 	std::string pickstring = std::string(TESTPICKSTRING);
 
-	json::Object * PickObject = Parser->parse(pickstring);
+	std::shared_ptr<json::Object> PickObject = Parser->parse(pickstring);
 
 	// parse the pick
 	ASSERT_FALSE(PickObject == NULL)<< "Parsed pick not null.";
@@ -94,7 +97,7 @@ TEST_F(JSONParser, PickParsing) {
 TEST_F(JSONParser, StationParsing) {
 	std::string stationstring = std::string(TESTSTATIONSTRING);
 
-	json::Object * StationObject = Parser->parse(stationstring);
+	std::shared_ptr<json::Object> StationObject = Parser->parse(stationstring);
 
 	// parse the pick
 	ASSERT_FALSE(StationObject == NULL)<< "Parsed station not null.";
@@ -111,7 +114,8 @@ TEST_F(JSONParser, FailTests) {
 	std::string stationfailstring = std::string(TESTFAILSTATIONSTRING);
 
 	// detection failure
-	json::Object * FailObject = Parser->parse(detectionfailstring);
+	std::shared_ptr<json::Object> FailObject = Parser->parse(
+			detectionfailstring);
 
 	// parse the bad data
 	ASSERT_FALSE(FailObject == NULL)<< "Parsed detection fail object not null.";

--- a/parse/tests/parser_unittest.cpp
+++ b/parse/tests/parser_unittest.cpp
@@ -20,7 +20,7 @@ class parserstub : public parse::Parser {
 		return (NULL);
 	}
 
-	bool validate(std::shared_ptr<json::Object> input) override {
+	bool validate(std::shared_ptr<json::Object> &input) override {
 		return (true);
 	}
 };

--- a/parse/tests/parser_unittest.cpp
+++ b/parse/tests/parser_unittest.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <memory>
 
 #define TESTAGENCYID "US"
 #define TESTAUTHOR "glasstest"
@@ -15,11 +16,11 @@ class parserstub : public parse::Parser {
 	~parserstub() {
 	}
 
-	json::Object* parse(const std::string &input) override {
+	std::shared_ptr<json::Object> parse(const std::string &input) override {
 		return (NULL);
 	}
 
-	bool validate(json::Object* input) override {
+	bool validate(std::shared_ptr<json::Object> input) override {
 		return (true);
 	}
 };
@@ -33,7 +34,7 @@ TEST(ParserTest, Construction) {
 
 	// assert that agencyid is ok
 	ASSERT_STREQ(Parser->getAgencyid().c_str(), agencyid.c_str())<<
-			"AgencyID check";
+	"AgencyID check";
 
 	// assert that author is ok
 	ASSERT_STREQ(Parser->getAuthor().c_str(), author.c_str())<< "Author check";

--- a/process/include/associator.h
+++ b/process/include/associator.h
@@ -114,7 +114,7 @@ class Associator : public glasscore::IGlassSend, public util::iAssociator,
 	 * \param message - A json::Object containing the message to send to
 	 * glasscore.
 	 */
-	void sendToAssociator(std::shared_ptr<json::Object> message) override;
+	void sendToAssociator(std::shared_ptr<json::Object> &message) override;
 
 	/**
 	 * \brief thread pool check function

--- a/process/include/associator.h
+++ b/process/include/associator.h
@@ -192,9 +192,20 @@ class Associator : public glasscore::IGlassSend, public util::iAssociator,
 	int m_iWorkCounter;
 
 	/**
-	 * \brief The duration of time spent getting data from the input queue.
+	 * \brief Integer holding the count of input data sent to glasscore overall
 	 */
-	std::chrono::duration<double> tQueueDuration;
+	int m_iTotalWorkCounter;
+
+	/**
+	 * \brief Integer holding the count of used to compute the running average
+	 * of data per second
+	 */
+	int m_iRunningAverageCounter;
+
+	/**
+	 * \brief Integer holding the the running average of data per second
+	 */
+	double m_dRunningAverage;
 
 	/**
 	 * \brief The duration of time spent sending data to the glasscore.

--- a/process/include/associator.h
+++ b/process/include/associator.h
@@ -17,6 +17,7 @@
 #include <threadbaseclass.h>
 #include <queue.h>
 #include <ctime>
+#include <memory>
 
 /**
  * \namespace glass
@@ -103,7 +104,7 @@ class Associator : public glasscore::IGlassSend, public util::iAssociator,
 	 * \param communication - A json::Object containing the message from
 	 * glasscore.
 	 */
-	void Send(json::Object *communication) override;
+	void Send(std::shared_ptr<json::Object> communication) override;
 
 	/**
 	 * \brief glasscore message sending function
@@ -113,7 +114,7 @@ class Associator : public glasscore::IGlassSend, public util::iAssociator,
 	 * \param message - A json::Object containing the message to send to
 	 * glasscore.
 	 */
-	void sendToAssociator(json::Object* message) override;
+	void sendToAssociator(std::shared_ptr<json::Object> message) override;
 
 	/**
 	 * \brief thread pool check function
@@ -166,7 +167,7 @@ class Associator : public glasscore::IGlassSend, public util::iAssociator,
 	 * glasscore.
 	 * \return returns true if the dispatch was successful, false otherwise.
 	 */
-	bool dispatch(json::Object *communication);
+	bool dispatch(std::shared_ptr<json::Object> communication);
 
 	/**
 	 * \brief glasscore logging function

--- a/process/src/associator.cpp
+++ b/process/src/associator.cpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <Logit.h>
 #include <Glass.h>
+#include <HypoList.h>
+#include <PickList.h>
 
 namespace glass {
 // Construction/Destruction
@@ -211,6 +213,15 @@ bool Associator::work() {
 									static_cast<int>(tNow - tLastWorkReport))
 							+ " seconds.");
 		} else {
+			int hypoListSize = 0;
+			int pickListSize = 0;
+			if (m_pGlass->getHypoList()) {
+				hypoListSize = m_pGlass->getHypoList()->getVHypoSize();
+			}
+			if (m_pGlass->getPickList()) {
+				pickListSize = m_pGlass->getPickList()->getVPickSize();
+			}
+
 			m_iTotalWorkCounter += m_iWorkCounter;
 
 			// calculate data per second average
@@ -231,16 +242,17 @@ bool Associator::work() {
 					"info",
 					"Associator::work(): Sent " + std::to_string(m_iWorkCounter)
 							+ " data to glass (" + std::to_string(pendingdata)
-							+ " pending, " + std::to_string(m_iTotalWorkCounter)
-							+ " total) in the last "
+							+ " in queue, " + std::to_string(m_iTotalWorkCounter)
+							+ " total) in "
 							+ std::to_string(
 									static_cast<int>(tNow - tLastWorkReport))
 							+ " seconds. (" + std::to_string(dataAverage)
-							+ " data per second) ("
-							+ std::to_string(m_dRunningAverage)
-							+ " running average data per second) ("
+							+ " dps) (" + std::to_string(m_dRunningAverage)
+							+ " avg dps) ("
 							+ std::to_string(averageglasstime)
-							+ " average per pick time).");
+							+ " avg glass time) (" + "vPickSize: "
+							+ std::to_string(pickListSize) + " vHypoSize: "
+							+ std::to_string(hypoListSize) + ").");
 		}
 
 		tLastWorkReport = tNow;

--- a/process/src/associator.cpp
+++ b/process/src/associator.cpp
@@ -172,9 +172,6 @@ bool Associator::work() {
 	if (message != NULL) {
 		// send the message into glass
 		m_pGlass->dispatch(message);
-
-		// done with message
-		delete (message);
 	}
 
 	std::time_t tNow;

--- a/process/src/associator.cpp
+++ b/process/src/associator.cpp
@@ -151,7 +151,7 @@ void Associator::Send(std::shared_ptr<json::Object> communication) {
 	dispatch(communication);
 }
 
-void Associator::sendToAssociator(std::shared_ptr<json::Object> message) {
+void Associator::sendToAssociator(std::shared_ptr<json::Object> &message) {
 	if (m_MessageQueue != NULL) {
 		m_MessageQueue->addDataToQueue(message);
 	}

--- a/util/include/associatorinterface.h
+++ b/util/include/associatorinterface.h
@@ -41,7 +41,7 @@ class iAssociator {
 	 * \param message - A pointer to a json::object containing the data
 	 * to send to the associator library.
 	 */
-	virtual void sendToAssociator(std::shared_ptr<json::Object> message) = 0;
+	virtual void sendToAssociator(std::shared_ptr<json::Object> &message) = 0; // NOLINT
 };
 }  // namespace util
 #endif  // ASSOCINTERFACE_H

--- a/util/include/associatorinterface.h
+++ b/util/include/associatorinterface.h
@@ -8,6 +8,7 @@
 #define ASSOCINTERFACE_H
 
 #include <json.h>
+#include <memory>
 
 /**
  * \namespace util
@@ -40,7 +41,7 @@ class iAssociator {
 	 * \param message - A pointer to a json::object containing the data
 	 * to send to the associator library.
 	 */
-	virtual void sendToAssociator(json::Object* message) = 0;
+	virtual void sendToAssociator(std::shared_ptr<json::Object> message) = 0;
 };
 }  // namespace util
 #endif  // ASSOCINTERFACE_H

--- a/util/include/cache.h
+++ b/util/include/cache.h
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <string>
 #include <map>
+#include <memory>
 
 namespace util {
 /**
@@ -81,8 +82,8 @@ class Cache : public util::BaseClass {
 	 * Defaults to true
 	 * \return returns true if successful, false otherwise.
 	 */
-	virtual bool addToCache(json::Object * data, std::string id, bool lock =
-									true);
+	virtual bool addToCache(std::shared_ptr<json::Object> data, std::string id,
+							bool lock = true);
 
 	/**
 	 *\brief remove data from cache
@@ -123,8 +124,8 @@ class Cache : public util::BaseClass {
 	 * if the data
 	 * was not found
 	 */
-	virtual json::Object * getFromCache(std::string id, bool lock = true,
-										bool copy = false);
+	virtual std::shared_ptr<json::Object> getFromCache(std::string id,
+														bool lock = true);
 
 	/**
 	 * \brief get next data from cache
@@ -138,8 +139,8 @@ class Cache : public util::BaseClass {
 	 * NULL if there is no
 	 * more data available.
 	 */
-	virtual json::Object * getNextFromCache(bool restart = false, bool lock =
-													true);
+	virtual std::shared_ptr<json::Object> getNextFromCache(bool restart = false,
+															bool lock = true);
 
 	/**
 	 *\brief clear data from cache
@@ -216,7 +217,7 @@ class Cache : public util::BaseClass {
 	/**
 	 * \brief the std::map used to store the cache
 	 */
-	std::map<std::string, json::Object *> m_Cache;
+	std::map<std::string, std::shared_ptr<json::Object>> m_Cache;
 
 	/**
 	 * \brief a boolean flag indicating whether the cache has
@@ -227,7 +228,7 @@ class Cache : public util::BaseClass {
 	/**
 	 * \brief a std::map iterator used to output the cache
 	 */
-	std::map<std::string, json::Object *>::iterator m_CacheDumpItr;
+	std::map<std::string, std::shared_ptr<json::Object>>::iterator m_CacheDumpItr;
 
 	/**
 	 * \brief the mutex for the cache

--- a/util/include/inputinterface.h
+++ b/util/include/inputinterface.h
@@ -8,6 +8,7 @@
 #define INPUTINTERFACE_H
 
 #include <json.h>
+#include <memory>
 
 namespace util {
 
@@ -31,7 +32,7 @@ class iInput {
 	 * \return Returns a pointer to a json::object containing the input
 	 * data.
 	 */
-	virtual json::Object* getData() = 0;
+	virtual std::shared_ptr<json::Object> getData() = 0;
 
 	/**
 	 * \brief Get count of remaining input data

--- a/util/include/outputinterface.h
+++ b/util/include/outputinterface.h
@@ -25,7 +25,7 @@ struct iOutput {
 	 * \param data - A pointer to a json::object containing the output
 	 * data.
 	 */
-	virtual void sendToOutput(std::shared_ptr<json::Object> data) = 0;
+	virtual void sendToOutput(std::shared_ptr<json::Object> &data) = 0; // NOLINT
 };
 }  // namespace util
 #endif  // OUTPUTINTERFACE_H

--- a/util/include/outputinterface.h
+++ b/util/include/outputinterface.h
@@ -2,6 +2,7 @@
 #define OUTPUTINTERFACE_H
 
 #include <json.h>
+#include <memory>
 
 namespace util {
 
@@ -24,7 +25,7 @@ struct iOutput {
 	 * \param data - A pointer to a json::object containing the output
 	 * data.
 	 */
-	virtual void sendToOutput(json::Object* data) = 0;
+	virtual void sendToOutput(std::shared_ptr<json::Object> data) = 0;
 };
 }  // namespace util
 #endif  // OUTPUTINTERFACE_H

--- a/util/include/queue.h
+++ b/util/include/queue.h
@@ -9,6 +9,7 @@
 
 #include <json.h>
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <queue>
@@ -45,7 +46,7 @@ class Queue {
 	 * Defaults to true
 	 * \return returns true if successful, false otherwise.
 	 */
-	bool addDataToQueue(json::Object * data, bool lock = true);
+	bool addDataToQueue(std::shared_ptr<json::Object> data, bool lock = true);
 
 	/**
 	 *\brief get data from queue
@@ -60,7 +61,7 @@ class Queue {
 	 * there was no
 	 * data in the queue
 	 */
-	json::Object * getDataFromQueue(bool lock = true, bool copy = false);
+	std::shared_ptr<json::Object> getDataFromQueue(bool lock = true);
 
 	/**
 	 *\brief clear data from queue
@@ -86,7 +87,7 @@ class Queue {
 	/**
 	 * \brief the std::queue used to store the queue
 	 */
-	std::queue<json::Object *> m_DataQueue;
+	std::queue<std::shared_ptr<json::Object>> m_DataQueue;
 
 	/**
 	 * \brief the mutex for the queue

--- a/util/src/queue.cpp
+++ b/util/src/queue.cpp
@@ -3,6 +3,7 @@
 #include <logger.h>
 #include <stringutil.h>
 #include <timeutil.h>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <queue>
@@ -21,7 +22,7 @@ Queue::~Queue() {
 	clearQueue();
 }
 
-bool Queue::addDataToQueue(json::Object * data, bool lock) {
+bool Queue::addDataToQueue(std::shared_ptr<json::Object> data, bool lock) {
 	if (lock) {
 		m_QueueMutex.lock();
 	}
@@ -36,7 +37,7 @@ bool Queue::addDataToQueue(json::Object * data, bool lock) {
 	return (true);
 }
 
-json::Object * Queue::getDataFromQueue(bool lock, bool copy) {
+std::shared_ptr<json::Object> Queue::getDataFromQueue(bool lock) {
 	if (lock) {
 		m_QueueMutex.lock();
 	}
@@ -50,12 +51,8 @@ json::Object * Queue::getDataFromQueue(bool lock, bool copy) {
 	}
 
 	// get the next element
-	json::Object *data;
-	if (copy) {
-		data = new json::Object(*m_DataQueue.front());
-	} else {
-		data = m_DataQueue.front();
-	}
+	std::shared_ptr<json::Object> data;
+	data = m_DataQueue.front();
 
 	// remove that element now that we got it
 	m_DataQueue.pop();

--- a/util/tests/cache_unittest.cpp
+++ b/util/tests/cache_unittest.cpp
@@ -2,6 +2,7 @@
 #include <json.h>
 #include <cache.h>
 #include <string>
+#include <memory>
 
 #define TESTDATA1 "{\"HighPass\":1.000000,\"LowPass\":1.000000,\"cacheid\":\"test1\"}" // NOLINT
 #define TESTDATA1ID "test1"
@@ -59,18 +60,18 @@ TEST(CacheTest, CombinedTest) {
 
 	// create input data
 	std::string inputstring1 = std::string(TESTDATA1);
-	json::Object* inputdata1 = new json::Object(
-			json::Deserialize(inputstring1));
+	std::shared_ptr<json::Object> inputdata1 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(inputstring1)));
 	std::string inputid1 = std::string(TESTDATA1ID);
 
 	std::string inputstring2 = std::string(TESTDATA2);
-	json::Object* inputdata2 = new json::Object(
-			json::Deserialize(inputstring2));
+	std::shared_ptr<json::Object> inputdata2 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(inputstring2)));
 	std::string inputid2 = std::string(TESTDATA2ID);
 
 	std::string inputstring3 = std::string(TESTDATA3);
-	json::Object* inputdata3 = new json::Object(
-			json::Deserialize(inputstring3));
+	std::shared_ptr<json::Object> inputdata3 = std::make_shared<json::Object>(
+			json::Object(json::Deserialize(inputstring3)));
 	std::string inputid3 = std::string(TESTDATA3ID);
 
 	// add data to cache
@@ -93,9 +94,12 @@ TEST(CacheTest, CombinedTest) {
 
 	// get data from cache
 	ASSERT_TRUE(NULL == TestCache->getFromCache(""));
-	json::Object* outputobject1 = TestCache->getFromCache(inputid1);
-	json::Object* outputobject2 = TestCache->getFromCache(inputid2);
-	json::Object* outputobject3 = TestCache->getFromCache(inputid3);
+	std::shared_ptr<json::Object> outputobject1 = TestCache->getFromCache(
+			inputid1);
+	std::shared_ptr<json::Object> outputobject2 = TestCache->getFromCache(
+			inputid2);
+	std::shared_ptr<json::Object> outputobject3 = TestCache->getFromCache(
+			inputid3);
 
 	// assert that we got something
 	ASSERT_TRUE(outputobject1 != NULL)<< "non-null cache data 1 (getfromcache)";

--- a/util/tests/queue_unittest.cpp
+++ b/util/tests/queue_unittest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <queue.h>
 #include <string>
+#include <memory>
 
 #define TESTDATA1 "{\"HighPass\":1.000000,\"LowPass\":1.000000}"
 #define TESTDATA2 "{\"HighPass\":2.000000,\"LowPass\":2.000000}"
@@ -16,24 +17,27 @@ TEST(QueueTest, CombinedTest) {
 
 	// create input data
 	std::string inputstring1 = std::string(TESTDATA1);
-	json::Object inputdata1 = json::Deserialize(inputstring1);
+	std::shared_ptr<json::Object> inputdata1 = std::make_shared<json::Object>(
+			json::Deserialize(inputstring1));
 
 	std::string inputstring2 = std::string(TESTDATA2);
-	json::Object inputdata2 = json::Deserialize(inputstring2);
+	std::shared_ptr<json::Object> inputdata2 = std::make_shared<json::Object>(
+			json::Deserialize(inputstring2));
 
 	std::string inputstring3 = std::string(TESTDATA3);
-	json::Object inputdata3 = json::Deserialize(inputstring3);
+	std::shared_ptr<json::Object> inputdata3 = std::make_shared<json::Object>(
+			json::Deserialize(inputstring3));
 
 	// add data to queue
-	TestQueue->addDataToQueue(&inputdata1);
-	TestQueue->addDataToQueue(&inputdata2);
-	TestQueue->addDataToQueue(&inputdata3);
+	TestQueue->addDataToQueue(inputdata1);
+	TestQueue->addDataToQueue(inputdata2);
+	TestQueue->addDataToQueue(inputdata3);
 
 	// assert three items in the queue
 	ASSERT_EQ(TestQueue->size(), 3)<< "3 items in queue";
 
 	// get data from queue
-	json::Object* outputobject = TestQueue->getDataFromQueue();
+	std::shared_ptr<json::Object> outputobject = TestQueue->getDataFromQueue();
 
 	// assert that we got something
 	ASSERT_TRUE(outputobject != NULL)<< "non-null queue data";


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added 
- [X] Docs have been added / updated 

* **What kind of change does this PR introduce?**
This PR corrects a number of bugs involving program crashes, memory deallocation, and minor algorithmic bugs.

* **What is the current behavior?**
Glass would eventually crash (segmentation fault) or run out of memory on the server after processing between 1 and 7 days of picks using the global example configuration.

* **What is the new behavior?**
  - Glass is much less likely to crash, because the glass classes have been converted to use setters/getters for member access, to avoid incorrect access between threads. A change was also made to ensure that a hypo could only be processed by a single thread at a time.
  - Glass is memory stable during long runs, once the grids are generated and the pick list and hypo list have reached their limits, because the input json object pointers were converted to shared_ptr to ensure proper cleanup when the input data is no longer needed.  Additionally, some shared_ptr links between classes (mainly between hypo and pick) were changed to weak_ptr to avoid cyclical references (preventing some picks and/or hypos from ever cleaning up).
  - Glass is also somewhat faster (computationally) in processing data when multiple threads are used.
  - Trigger tracking was split from Node into the new CTrigger class.
  - A bug when nDetect is greater than the available number of stations (preventing nodes from being linked to stations) was fixed.
  - A bug preventing 2-phase nucleation from working (try secondary phase if primary phase was unsuccessful) was fixed.
  - A bug preventing nucleation phases from being used during initial nucleation location (anneal) was fixed. Nucleation locations also now use the same phase weighting as the hypo locations.
  - Logging was somewhat simplified and reduced (less logging per pick processed, less logging of the site list).
  - Some performance logging was added to track how long it takes to run evolve for a hypo, and to give a better understanding of how far glass has progressed during the processing of a dataset.

* **Does this PR introduce a breaking change?**
No