### PR TITLE
Performance change for small grids

### DIFF
--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -222,7 +222,9 @@ class CPick {
 	/**
 	 * \brief A std::weak_ptr to a CSite object
 	 * representing the link between this pick and the site it was
-	 * picked at
+	 * picked at. A weak_ptr is used here instead of a shared_ptr to prevent
+	 * a cyclical reference between CPick and CSite. The weak_ptr is here
+	 * instead of in site due to performance reasons.
 	 */
 	std::weak_ptr<CSite> wpSite;
 

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -186,7 +186,7 @@ class CPick {
 	 * \brief Site getter
 	 * \return the site
 	 */
-	const std::shared_ptr<CSite>& getSite() const;
+	const std::shared_ptr<CSite> getSite() const;
 
 	/**
 	 * \brief Association string getter

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -220,11 +220,11 @@ class CPick {
 
  private:
 	/**
-	 * \brief A std::shared_ptr to a CSite object
+	 * \brief A std::weak_ptr to a CSite object
 	 * representing the link between this pick and the site it was
 	 * picked at
 	 */
-	std::shared_ptr<CSite> pSite;
+	std::weak_ptr<CSite> wpSite;
 
 	/**
 	 * \brief A std::weak_ptr to a CHypo object

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -320,9 +320,9 @@ class CSite {
 	mutable std::mutex vPickMutex;
 
 	/**
-	 * \brief A std::vector of std::weak_ptr's to the picks made at this this
-	 * CSite. A weak_ptr is used here instead of a shared_ptr to prevent a
-	 * cyclical reference between CPick and CSite.
+	 * \brief A std::vector of std::shared_ptr to the picks made at this this
+	 * CSite. A shared_ptr is used here instead of a weak_ptr (to prevent a
+	 * cyclical reference between CPick and CSite) to improve performance
 	 */
 	std::vector<std::shared_ptr<CPick>> vPick;
 

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -324,7 +324,7 @@ class CSite {
 	 * CSite. A weak_ptr is used here instead of a shared_ptr to prevent a
 	 * cyclical reference between CPick and CSite.
 	 */
-	std::vector<std::weak_ptr<CPick>> vPick;
+	std::vector<std::shared_ptr<CPick>> vPick;
 
 	/**
 	 * \brief A pointer to the main CGlass class used encode/decode time and

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -283,6 +283,10 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 
 		// search through each pick at this site
 		for (const auto &pick : vSitePicks) {
+			if (pick == NULL) {
+				continue;
+			}
+
 			// get the pick's arrival time
 			double tPick = pick->getTPick();
 

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -269,12 +269,12 @@ bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	clear();
-
+	
 	// nullcheck
 	if (pickSite == NULL) {
 		return (false);
 	}
-
+	
 	wpSite = pickSite;
 	tPick = pickTime;
 	idPick = pickId;
@@ -546,7 +546,7 @@ const std::shared_ptr<CHypo> CPick::getHypo() const {
 	return (wpHypo.lock());
 }
 
-const std::shared_ptr<CSite>& CPick::getSite() const {
+const std::shared_ptr<CSite> CPick::getSite() const {
 	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
 	return (wpSite.lock());
 }

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -269,12 +269,12 @@ bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 	std::lock_guard<std::recursive_mutex> guard(pickMutex);
 
 	clear();
-	
+
 	// nullcheck
 	if (pickSite == NULL) {
 		return (false);
 	}
-	
+
 	wpSite = pickSite;
 	tPick = pickTime;
 	idPick = pickId;

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -430,8 +430,7 @@ void CSite::addPick(std::shared_ptr<CPick> pck) {
 
 	// add pick to site pick vector
 	// NOTE: Need to add duplicate pick protection
-	std::weak_ptr<CPick> wpPck = pck;
-	vPick.push_back(wpPck);
+	vPick.push_back(pck);
 }
 
 // ---------------------------------------------------------remPick
@@ -448,16 +447,11 @@ void CSite::remPick(std::shared_ptr<CPick> pck) {
 
 	// remove pick from site pick vector
 	for (auto it = vPick.begin(); it != vPick.end();) {
-		if ((*it).expired() == true) {
-			// clean up expired pointers
+		auto aPck = (*it);
+
+		// erase target pick
+		if (aPck->getPid() == pck->getPid()) {
 			it = vPick.erase(it);
-		} else if (auto aPck = (*it).lock()) {
-			// erase target pick
-			if (aPck->getPid() == pck->getPid()) {
-				it = vPick.erase(it);
-			} else {
-				++it;
-			}
 		} else {
 			++it;
 		}
@@ -708,16 +702,6 @@ const std::string& CSite::getSite() const {
 
 const std::vector<std::shared_ptr<CPick> > CSite::getVPick() const {
 	std::lock_guard<std::mutex> guard(vPickMutex);
-
-	std::vector<std::shared_ptr<CPick>> picks;
-	for (auto awpPck : vPick) {
-		std::shared_ptr<CPick> aPck = awpPck.lock();
-
-		if (aPck != NULL) {
-			picks.push_back(aPck);
-		}
-	}
-
-	return (picks);
+	return (vPick);
 }
 }  // namespace glasscore

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -80,7 +80,7 @@ void checkdata(glasscore::CPick * pickobject, const std::string &testinfo) {
 
 // test to see if the pick can be constructed
 TEST(PickTest, Construction) {
-	glassutil::CLogit::disable();
+	glassutil::CLogit::enable();
 
 	// construct a pick
 	glasscore::CPick * testPick = new glasscore::CPick();
@@ -93,7 +93,7 @@ TEST(PickTest, Construction) {
 	ASSERT_STREQ("", testPick->getAss().c_str());
 	ASSERT_STREQ("", testPick->getPhs().c_str());
 	ASSERT_STREQ("", testPick->getPid().c_str());
-
+	
 	// pointers
 	ASSERT_TRUE(testPick->getSite() == NULL)<< "pSite null";
 	ASSERT_TRUE(testPick->getHypo() == NULL)<< "pHypo null";
@@ -104,7 +104,7 @@ TEST(PickTest, Construction) {
 			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
 			new glasscore::CSite(siteJSON, NULL));
-
+	
 	// now init
 	testPick->initialize(sharedTestSite, PICKTIME, PICKID,
 							std::string(PICKIDSTRING), BACKAZIMUTH, SLOWNESS);

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -93,7 +93,7 @@ TEST(PickTest, Construction) {
 	ASSERT_STREQ("", testPick->getAss().c_str());
 	ASSERT_STREQ("", testPick->getPhs().c_str());
 	ASSERT_STREQ("", testPick->getPid().c_str());
-	
+
 	// pointers
 	ASSERT_TRUE(testPick->getSite() == NULL)<< "pSite null";
 	ASSERT_TRUE(testPick->getHypo() == NULL)<< "pHypo null";

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -104,7 +104,7 @@ TEST(PickTest, Construction) {
 			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
 			new glasscore::CSite(siteJSON, NULL));
-	
+
 	// now init
 	testPick->initialize(sharedTestSite, PICKTIME, PICKID,
 							std::string(PICKIDSTRING), BACKAZIMUTH, SLOWNESS);
@@ -148,7 +148,7 @@ TEST(PickTest, HypoOperations) {
 	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
 			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<glasscore::CSite> sharedTestSite(
-					new glasscore::CSite(siteJSON, NULL));
+			new glasscore::CSite(siteJSON, NULL));
 
 	// create pick
 	glasscore::CPick * testPick = new glasscore::CPick(

--- a/glasscore/tests/picklist_unittest.cpp
+++ b/glasscore/tests/picklist_unittest.cpp
@@ -60,24 +60,24 @@ TEST(PickListTest, PickOperations) {
 
 	// create json objects from the strings
 	std::shared_ptr<json::Object> siteJSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(SITEJSON))));
+			json::Object(json::Deserialize(std::string(SITEJSON))));
 	std::shared_ptr<json::Object> site2JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(SITE2JSON))));
+			json::Object(json::Deserialize(std::string(SITE2JSON))));
 	std::shared_ptr<json::Object> site3JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(SITE3JSON))));
+			json::Object(json::Deserialize(std::string(SITE3JSON))));
 
 	std::shared_ptr<json::Object> pickJSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(PICKJSON))));
+			json::Object(json::Deserialize(std::string(PICKJSON))));
 	std::shared_ptr<json::Object> pick2JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(PICK2JSON))));
+			json::Object(json::Deserialize(std::string(PICK2JSON))));
 	std::shared_ptr<json::Object> pick3JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(PICK3JSON))));
+			json::Object(json::Deserialize(std::string(PICK3JSON))));
 	std::shared_ptr<json::Object> pick4JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(PICK4JSON))));
+			json::Object(json::Deserialize(std::string(PICK4JSON))));
 	std::shared_ptr<json::Object> pick5JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(PICK5JSON))));
+			json::Object(json::Deserialize(std::string(PICK5JSON))));
 	std::shared_ptr<json::Object> pick6JSON = std::make_shared<json::Object>(
-				json::Object(json::Deserialize(std::string(PICK6JSON))));
+			json::Object(json::Deserialize(std::string(PICK6JSON))));
 
 	// construct a sitelist
 	glasscore::CSiteList * testSiteList = new glasscore::CSiteList();


### PR DESCRIPTION
**Performance change for small grids**

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added

* **What kind of change does this PR introduce?**
This PR addresses slow performance observed when using small grids, (fixes #18).

* **What is the current behavior?**
Glass had a performance slowdown when converting the vector of weak_ptr's to picks in each site to a vector of shared_ptr's for use in nucleation. This slowdown was especially noticeable with small grids and few nucleation threads.

* **What is the new behavior?**
The "weak" side of the site-pick references (made to avoid memory issues due to the cyclical reference) was moved from site (vector of weak_ptr's to picks) to pick (weak_ptr to site). This was done because the site is accessed much less often from a pick during nucleation than the pick list, is accessed from a site, and there is only ever a single site reference per pick, as opposed to many references to picks in the vector in each site.

* **Does this PR introduce a breaking change?** 
No

* **Other information**:
Overall glass performance was evaluated using the global test dataset, with a resulting percentage of PDE events found of 47.95%, which is within the normal range for that dataset (previous run found 45.95%)
