### PR TITLE
Residual Comparison Bug Fix

### DIFF
--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -1366,7 +1366,7 @@ double CHypo::getBayes(double xlat, double xlon, double xZ, double oT,
 				double resi2 = getWeightedResidual(pTrv2->sPhase, tobs, tcal2);
 
 				// use the smallest residual
-				if (resi1 < resi2) {
+				if (abs(resi1) < abs(resi2)) {
 					tcal = tcal1;
 					resi = resi1;
 				} else {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
This fixes a bug in the getBayes function in Hypo.cpp


* **What is the current behavior?** 
Residuals of two nucleation phases were compared without taking the absolute value. 


* **What is the new behavior ?**
The residuals are compared correctly. 

* **Does this PR introduce a breaking change?** 
No. 

* **Other information**:
