### PR TITLE
Working

### DIFF
--- a/glass-app/tests/input_unittest.cpp
+++ b/glass-app/tests/input_unittest.cpp
@@ -16,7 +16,7 @@
 #define ERRORDIRECTORY "error"
 #define ARCHIVEDIRECTORY "archive"
 
-#define SLEEPTIME 100
+#define SLEEPTIME 1
 #define FILESLEEPTIME 5
 #define QUEUEMAXSIZE 1000
 #define TESTAGENCYID "US"

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -2216,7 +2216,7 @@ double CHypo::localize() {
 
 	glassutil::CTaper taper;
 	taper = glassutil::CTaper(-0.0001, -0.0001, -0.0001, 30 + 0.0001);
-	double searchR = (dRes / 4. + taper.Val(vPick.size()) * .75 * dRes);
+	double searchR = (dRes / 4. + taper.Val(vPick.size()) * .75 * dRes) / 2.;
 
 	// This should be the default
 	if (pGlass->getMinimizeTtLocator() == false) {

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -650,6 +650,14 @@ bool CHypoList::evolve(std::shared_ptr<CHypo> hyp) {
 		hyp->localize();
 	}
 
+	// Iterate on pruning data
+	if (hyp->prune()) {
+		// we should report this hypo since it has changed
+		breport = true;
+		// relocate the hypo
+		hyp->localize();
+	}
+
 	std::chrono::high_resolution_clock::time_point tPruneEndTime =
 			std::chrono::high_resolution_clock::now();
 	double pruneTime =

--- a/glasscore/glasslib/src/HypoList.cpp
+++ b/glasscore/glasslib/src/HypoList.cpp
@@ -99,7 +99,7 @@ bool CHypoList::addHypo(std::shared_ptr<CHypo> hypo, bool scheduleProcessing) {
 	}
 
 	// lock for this scope
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 	// Add hypo to cache (mHypo) and time sorted
 	// index (vHypo). If vHypo has reached its
@@ -196,14 +196,14 @@ bool CHypoList::associate(std::shared_ptr<CPick> pk) {
 		return (false);
 	}
 
-	std::vector < std::shared_ptr < CHypo >> viper;
+	std::vector<std::shared_ptr<CHypo>> viper;
 
 	// compute the list of hypos to associate with
 	// (a potential hypo must be before the pick we're associating)
 	// use the pick time minus 2400 seconds to compute the starting index
 	// NOTE: Hard coded time delta
-	std::vector < std::weak_ptr < CHypo >> hypoList = getHypos(
-			pk->getTPick() - 2400, pk->getTPick());
+	std::vector<std::weak_ptr<CHypo>> hypoList = getHypos(pk->getTPick() - 2400,
+															pk->getTPick());
 
 	// make sure we got any hypos
 	if (hypoList.size() == 0) {
@@ -329,13 +329,13 @@ bool CHypoList::associate(std::shared_ptr<CCorrelation> corr) {
 	}
 
 	bool bass = false;
-	std::vector < std::shared_ptr < CHypo >> viper;
+	std::vector<std::shared_ptr<CHypo>> viper;
 
 	// compute the index range to search for hypos to associate with
 	// (a potential hypo must be before the pick we're associating)
 	// use the correlation time minus correlationMatchingTWindow to compute the
 	// starting index
-	std::vector < std::weak_ptr < CHypo >> hypoList = getHypos(
+	std::vector<std::weak_ptr<CHypo>> hypoList = getHypos(
 			corr->getTCorrelation() - pGlass->getCorrelationMatchingTWindow(),
 			corr->getTCorrelation() - pGlass->getCorrelationMatchingTWindow());
 
@@ -428,7 +428,7 @@ bool CHypoList::associate(std::shared_ptr<CCorrelation> corr) {
 
 // ---------------------------------------------------------clear
 void CHypoList::clear() {
-	std::lock_guard < std::recursive_mutex > hypoListGuard(m_HypoListMutex);
+	std::lock_guard<std::recursive_mutex> hypoListGuard(m_HypoListMutex);
 
 	clearHypos();
 	pGlass = NULL;
@@ -436,10 +436,10 @@ void CHypoList::clear() {
 
 // ---------------------------------------------------------clearHypos
 void CHypoList::clearHypos() {
-	std::lock_guard < std::mutex > queueGuard(m_QueueMutex);
+	std::lock_guard<std::mutex> queueGuard(m_QueueMutex);
 	qFifo.clear();
 
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 	vHypo.clear();
 	mHypo.clear();
 
@@ -475,7 +475,7 @@ void CHypoList::darwin() {
 		return;
 	}
 
-	std::lock_guard < std::mutex > hypoGuard(hyp->getProcessingMutex());
+	std::lock_guard<std::mutex> hypoGuard(hyp->getProcessingMutex());
 
 	try {
 		// log the hypo we're working on
@@ -815,7 +815,7 @@ bool CHypoList::evolve(std::shared_ptr<CHypo> hyp) {
 
 // ---------------------------------------------------------findHypo
 std::shared_ptr<CHypo> CHypoList::findHypo(double t1, double t2) {
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 	// don't bother if the list is empty
 	if (vHypo.size() == 0) {
@@ -862,7 +862,7 @@ std::shared_ptr<CHypo> CHypoList::findHypo(double t1, double t2) {
 
 // ---------------------------------------------------------getFifoSize
 int CHypoList::getFifoSize() {
-	std::lock_guard < std::mutex > queueGuard(m_QueueMutex);
+	std::lock_guard<std::mutex> queueGuard(m_QueueMutex);
 
 	// return the current size of the queue
 	int size = qFifo.size();
@@ -870,19 +870,19 @@ int CHypoList::getFifoSize() {
 }
 
 const CGlass* CHypoList::getGlass() const {
-	std::lock_guard < std::recursive_mutex > hypoListGuard(m_HypoListMutex);
+	std::lock_guard<std::recursive_mutex> hypoListGuard(m_HypoListMutex);
 	return (pGlass);
 }
 
 // ---------------------------------------------------------getHypos
 std::vector<std::weak_ptr<CHypo>> CHypoList::getHypos(double t1, double t2) {
-	std::vector < std::weak_ptr < CHypo >> hypos;
+	std::vector<std::weak_ptr<CHypo>> hypos;
 
 	if (t1 == t2) {
 		return (hypos);
 	}
 
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 	// don't bother if the list is empty
 	if (vHypo.size() == 0) {
@@ -936,31 +936,31 @@ std::vector<std::weak_ptr<CHypo>> CHypoList::getHypos(double t1, double t2) {
 
 // ---------------------------------------------------------getNHypo
 int CHypoList::getNHypo() const {
-	std::lock_guard < std::recursive_mutex > vHypoGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> vHypoGuard(m_vHypoMutex);
 	return (nHypo);
 }
 
 // ---------------------------------------------------------getNHypoMax
 int CHypoList::getNHypoMax() const {
-	std::lock_guard < std::recursive_mutex > hypoListGuard(m_HypoListMutex);
+	std::lock_guard<std::recursive_mutex> hypoListGuard(m_HypoListMutex);
 	return (nHypoMax);
 }
 
 // ---------------------------------------------------------getNHypoTotal
 int CHypoList::getNHypoTotal() const {
-	std::lock_guard < std::recursive_mutex > vHypoGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> vHypoGuard(m_vHypoMutex);
 	return (nHypoTotal);
 }
 
 // ---------------------------------------------------------getVHypoSize
 int CHypoList::getVHypoSize() const {
-	std::lock_guard < std::recursive_mutex > vHypoGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> vHypoGuard(m_vHypoMutex);
 	return (vHypo.size());
 }
 
 // ---------------------------------------------------------indexHypo
 int CHypoList::indexHypo(double tOrg) {
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 	// handle empty vector case
 	if (vHypo.size() == 0) {
@@ -1033,7 +1033,7 @@ bool CHypoList::mergeCloseEvents(std::shared_ptr<CHypo> hypo) {
 	// compute the list of hypos to try merging with with
 	// (a potential hypo must be within time cut to consider)
 	sort();
-	std::vector < std::weak_ptr < CHypo >> hypoList = getHypos(
+	std::vector<std::weak_ptr<CHypo>> hypoList = getHypos(
 			hypo->getTOrg() - timeCut, hypo->getTOrg() + timeCut);
 
 	// make sure we got hypos returned
@@ -1074,8 +1074,7 @@ bool CHypoList::mergeCloseEvents(std::shared_ptr<CHypo> hypo) {
 				continue;
 			}
 
-			std::lock_guard < std::mutex
-					> hypoGuard(hypo2->getProcessingMutex());
+			std::lock_guard<std::mutex> hypoGuard(hypo2->getProcessingMutex());
 
 			// check to make sure hypo2 is still good
 			if (hypo2->cancelCheck() == true) {
@@ -1121,16 +1120,15 @@ bool CHypoList::mergeCloseEvents(std::shared_ptr<CHypo> hypo) {
 					glassutil::CLogit::log(sLog);
 
 					// create a new merged event hypo3
-					std::shared_ptr<CHypo> hypo3 =
-							std::make_shared < CHypo
-									> ((hypo2->getLat() + hypo->getLat()) / 2., (hypo2
-											->getLon() + hypo->getLon()) / 2., (hypo2
-											->getZ() + hypo->getZ()) / 2., (hypo2
-											->getTOrg() + hypo->getTOrg()) / 2., glassutil::CPid::pid(), "Merged Hypo", 0.0, hypo
-											->getThresh(), hypo->getCut(), hypo
-											->getTrv1(), hypo->getTrv2(), pGlass
-											->getTTT(), hypo->getRes(), hypo
-											->getAziTaper(), hypo->getMaxDepth());
+					std::shared_ptr<CHypo> hypo3 = std::make_shared<CHypo>(
+							(hypo2->getLat() + hypo->getLat()) / 2.,
+							(hypo2->getLon() + hypo->getLon()) / 2.,
+							(hypo2->getZ() + hypo->getZ()) / 2.,
+							(hypo2->getTOrg() + hypo->getTOrg()) / 2.,
+							glassutil::CPid::pid(), "Merged Hypo", 0.0,
+							hypo->getThresh(), hypo->getCut(), hypo->getTrv1(),
+							hypo->getTrv2(), pGlass->getTTT(), hypo->getRes(),
+							hypo->getAziTaper(), hypo->getMaxDepth());
 
 					// set hypo glass pointer and such
 					hypo3->setGlass(pGlass);
@@ -1236,7 +1234,7 @@ void CHypoList::jobSleep() {
 
 // ---------------------------------------------------------listPicks
 void CHypoList::listHypos() {
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 	int n = 0;
 	char sLog[1024];
@@ -1371,7 +1369,7 @@ void CHypoList::remHypo(std::shared_ptr<CHypo> hypo, bool reportCancel) {
 		return;
 	}
 
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 // get the id
 	std::string pid = hypo->getPid();
@@ -1457,7 +1455,7 @@ bool CHypoList::reqHypo(std::shared_ptr<json::Object> com) {
 		return (false);
 	}
 
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 // get the hypo
 	std::shared_ptr<CHypo> hyp = mHypo[sPid];
@@ -1498,7 +1496,7 @@ bool CHypoList::resolve(std::shared_ptr<CHypo> hyp) {
 
 // this lock guard exists to avoid a deadlock that occurs
 // when it isn't present
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 
 // return whether we've changed the pick set
 	return (hyp->resolve(hyp));
@@ -1506,19 +1504,19 @@ bool CHypoList::resolve(std::shared_ptr<CHypo> hyp) {
 
 // ---------------------------------------------------------setGlass
 void CHypoList::setGlass(CGlass* glass) {
-	std::lock_guard < std::recursive_mutex > hypoListGuard(m_HypoListMutex);
+	std::lock_guard<std::recursive_mutex> hypoListGuard(m_HypoListMutex);
 	pGlass = glass;
 }
 
 // ---------------------------------------------------------setNHypoMax
 void CHypoList::setNHypoMax(int hypoMax) {
-	std::lock_guard < std::recursive_mutex > hypoListGuard(m_HypoListMutex);
+	std::lock_guard<std::recursive_mutex> hypoListGuard(m_HypoListMutex);
 	nHypoMax = hypoMax;
 }
 
 // ---------------------------------------------------------setStatus
 void CHypoList::setStatus(bool status) {
-	std::lock_guard < std::mutex > statusGuard(m_StatusMutex);
+	std::lock_guard<std::mutex> statusGuard(m_StatusMutex);
 // update thread status
 	if (m_ThreadStatusMap.find(std::this_thread::get_id())
 			!= m_ThreadStatusMap.end()) {
@@ -1528,7 +1526,7 @@ void CHypoList::setStatus(bool status) {
 
 // ---------------------------------------------------------sort
 void CHypoList::sort() {
-	std::lock_guard < std::recursive_mutex > listGuard(m_vHypoMutex);
+	std::lock_guard<std::recursive_mutex> listGuard(m_vHypoMutex);
 // sort hypos
 	std::sort(vHypo.begin(), vHypo.end(), sortHypo);
 }
@@ -1553,7 +1551,7 @@ bool CHypoList::statusCheck() {
 	std::time(&tNow);
 	if ((tNow - tLastStatusCheck) >= m_iStatusCheckInterval) {
 		// get the thread status
-		std::lock_guard < std::mutex > statusGuard(m_StatusMutex);
+		std::lock_guard<std::mutex> statusGuard(m_StatusMutex);
 
 		// check all the threads
 		std::map<std::thread::id, bool>::iterator StatusItr;

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -234,7 +234,7 @@ CPick::CPick(std::shared_ptr<json::Object> pick, int pickId,
 		return;
 	}
 
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	// remember input json for hypo message generation
 	// note, move to init?
@@ -248,7 +248,7 @@ CPick::~CPick() {
 
 // ---------------------------------------------------------~clear
 void CPick::clear() {
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	wpSite.reset();
 	wpHypo.reset();
@@ -266,7 +266,7 @@ void CPick::clear() {
 bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 						int pickId, std::string pickIdString,
 						double backAzimuth, double slowness) {
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	clear();
 
@@ -294,7 +294,7 @@ bool CPick::initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 
 // ---------------------------------------------------------addHypo
 void CPick::addHypo(std::shared_ptr<CHypo> hyp, std::string ass, bool force) {
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	// nullcheck
 	if (hyp == NULL) {
@@ -326,7 +326,7 @@ void CPick::remHypo(std::shared_ptr<CHypo> hyp) {
 }
 
 void CPick::remHypo(std::string pid) {
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	// is the pointer still valid
 	if (auto pHypo = wpHypo.lock()) {
@@ -341,12 +341,12 @@ void CPick::remHypo(std::string pid) {
 }
 
 void CPick::clearHypo() {
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 	wpHypo.reset();
 }
 
 void CPick::setAss(std::string ass) {
-	std::lock_guard<std::recursive_mutex> guard(pickMutex);
+	std::lock_guard < std::recursive_mutex > guard(pickMutex);
 
 	sAss = ass;
 }
@@ -396,7 +396,8 @@ bool CPick::nucleate() {
 	// linked to this pick's site and calculate
 	// the stacked agoric at each node.  If the threshold
 	// is exceeded, the node is added to the site's trigger list
-	std::vector<std::shared_ptr<CTrigger>> vTrigger = pickSite->nucleate(tPick);
+	std::vector < std::shared_ptr < CTrigger >> vTrigger = pickSite->nucleate(
+			tPick);
 
 	// if there were no triggers, we're done
 	if (vTrigger.size() == 0) {
@@ -441,8 +442,8 @@ bool CPick::nucleate() {
 		}
 
 		// create the hypo using the node
-		std::shared_ptr<CHypo> hypo = std::make_shared<CHypo>(
-				trigger, pGlass->getTTT());
+		std::shared_ptr<CHypo> hypo = std::make_shared < CHypo
+				> (trigger, pGlass->getTTT());
 
 		// set hypo glass pointer and such
 		hypo->setGlass(pGlass);
@@ -451,7 +452,8 @@ bool CPick::nucleate() {
 		hypo->setCutMin(pGlass->getCutMin());
 
 		// add links to all the picks that support the hypo
-		std::vector<std::shared_ptr<CPick>> vTriggerPicks = trigger->getVPick();
+		std::vector < std::shared_ptr < CPick >> vTriggerPicks = trigger
+				->getVPick();
 
 		for (auto pick : vTriggerPicks) {
 			// they're not associated yet, just potentially
@@ -474,9 +476,10 @@ bool CPick::nucleate() {
 			// far out the ot can change without losing the initial pick
 			// this all assumes that the closest grid triggers
 			// values derived from testing global event association
-			double bayes = hypo->anneal(10000, trigger->getResolution(),
-										trigger->getResolution() / 10.,
-										trigger->getResolution() / 10.0, .1);
+			double bayes = hypo->anneal(
+					10000, trigger->getResolution() / 2.,
+					trigger->getResolution() / 100.,
+					std::max(trigger->getResolution() / 10.0, 5.0), .1);
 
 			// get the number of picks we have now
 			int npick = hypo->getVPickSize();
@@ -567,12 +570,12 @@ const std::shared_ptr<json::Object>& CPick::getJPick() const {
 }
 
 const std::shared_ptr<CHypo> CPick::getHypo() const {
-	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
+	std::lock_guard < std::recursive_mutex > pickGuard(pickMutex);
 	return (wpHypo.lock());
 }
 
 const std::string CPick::getHypoPid() const {
-	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
+	std::lock_guard < std::recursive_mutex > pickGuard(pickMutex);
 	std::string hypoPid = "";
 
 	// make sure we have a hypo,
@@ -591,12 +594,12 @@ const std::string CPick::getHypoPid() const {
 }
 
 const std::shared_ptr<CSite> CPick::getSite() const {
-	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
+	std::lock_guard < std::recursive_mutex > pickGuard(pickMutex);
 	return (wpSite.lock());
 }
 
 const std::string& CPick::getAss() const {
-	std::lock_guard<std::recursive_mutex> pickGuard(pickMutex);
+	std::lock_guard < std::recursive_mutex > pickGuard(pickMutex);
 	return (sAss);
 }
 

--- a/glasscore/glasslib/src/Pick.cpp
+++ b/glasscore/glasslib/src/Pick.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include "Pid.h"
 #include "Web.h"
 #include "Trigger.h"

--- a/input/src/input.cpp
+++ b/input/src/input.cpp
@@ -21,7 +21,7 @@ namespace input {
 
 // ---------------------------------------------------------input
 input::input()
-		: glass3::util::ThreadBaseClass("input", 100) {
+		: glass3::util::ThreadBaseClass("input", 1) {
 	glass3::util::log("debug", "input::input(): Construction.");
 
 	m_GPickParser = NULL;
@@ -33,7 +33,7 @@ input::input()
 }
 
 input::input(std::shared_ptr<const json::Object> config)
-		: glass3::util::ThreadBaseClass("input", 100) {
+		: glass3::util::ThreadBaseClass("input", 1) {
 	m_GPickParser = NULL;
 	m_JSONParser = NULL;
 	m_CCParser = NULL;


### PR DESCRIPTION
I've made a couple of slight tweaks, specifically in the evolve function. Previously, evolve would scavenge, prune, and resolve. In the use case where sdPrune is lower than sdAssocaite, this would only compare picks that were not pruned. I've changed it so that the order is now scavenged, resolve, prune, prune. This allows resolve to compare a larger set of picks which can reduce the number of teleseismic false triggers. So a large earthquake can 'resolve' picks from a smaller event that fit within sdAssociate. Prune is then called twice, with localization occurring if picks are pruned. This ensures the best estimate of the event location. 

I also minorly tweaked the locator's search radius. 
