### PR TITLE
Detection and Classification updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,22 +141,24 @@ if (BUILD_GLASS-APP OR BUILD_GLASS-BROKER-APP)
     if (GIT_CLONE_PUBLIC)
       ExternalProject_Add(DetectionFormats
           GIT_REPOSITORY https://github.com/usgs/earthquake-detection-formats.git
-          #GIT_TAG working
+          GIT_TAG v0.9.7
           TIMEOUT 10
           CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DRAPIDJSON_PATH=${RAPIDJSON_PATH}
+            -DRUN_TESTS=${RUN_TESTS}
             -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
             -DSUPPORT_COVERAGE=${SUPPORT_COVERAGE}
       )
     else()
       ExternalProject_Add(DetectionFormats
           GIT_REPOSITORY git@github.com:usgs/earthquake-detection-formats.git
-          #GIT_TAG working
+          GIT_TAG v0.9.7
           TIMEOUT 10
           CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DRAPIDJSON_PATH=${RAPIDJSON_PATH}
+            -DRUN_TESTS=${RUN_TESTS}
             -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
             -DSUPPORT_COVERAGE=${SUPPORT_COVERAGE}
       )
@@ -179,7 +181,7 @@ if (BUILD_GLASS-BROKER-APP)
     if (GIT_CLONE_PUBLIC)
       ExternalProject_Add(HazdevBroker
           GIT_REPOSITORY https://github.com/usgs/hazdev-broker.git
-          GIT_TAG v0.2.1
+          GIT_TAG v0.2.2
           TIMEOUT 10
           CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -191,7 +193,7 @@ if (BUILD_GLASS-BROKER-APP)
     else()
       ExternalProject_Add(HazdevBroker
           GIT_REPOSITORY git@github.com:usgs/hazdev-broker.git
-          GIT_TAG v0.2.1
+          GIT_TAG v0.2.2
           TIMEOUT 10
           CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -250,6 +252,7 @@ if (BUILD_GLASS-APP OR BUILD_GLASS-BROKER-APP)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+          -DRAPIDJSON_PATH=${RAPIDJSON_PATH}
           -DRUN_TESTS=${RUN_TESTS}
           -DRUN_CPPCHECK=${RUN_CPPCHECK}
           -DRUN_CPPLINT=${RUN_CPPLINT}
@@ -286,6 +289,7 @@ if (BUILD_GLASS-APP OR BUILD_GLASS-BROKER-APP)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+          -DRAPIDJSON_PATH=${RAPIDJSON_PATH}
           -DRUN_TESTS=${RUN_TESTS}
           -DRUN_CPPCHECK=${RUN_CPPCHECK}
           -DRUN_CPPLINT=${RUN_CPPLINT}
@@ -305,6 +309,7 @@ if (BUILD_GLASS-APP OR BUILD_GLASS-BROKER-APP)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+          -DRAPIDJSON_PATH=${RAPIDJSON_PATH}
           -DRUN_TESTS=${RUN_TESTS}
           -DRUN_CPPCHECK=${RUN_CPPCHECK}
           -DRUN_CPPLINT=${RUN_CPPLINT}
@@ -329,6 +334,7 @@ if (BUILD_GLASS-APP)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+          -DRAPIDJSON_PATH=${RAPIDJSON_PATH}
           -DRUN_TESTS=${RUN_TESTS}
           -DRUN_CPPCHECK=${RUN_CPPCHECK}
           -DRUN_CPPLINT=${RUN_CPPLINT}

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
 # version.cmake - a CMake script that defines the overall project version
 set (PROJECT_VERSION_MAJOR 1)
 set (PROJECT_VERSION_MINOR 0)
-set (PROJECT_VERSION_PATCH 2)
+set (PROJECT_VERSION_PATCH 3)

--- a/doc/GlassConfiguration.md
+++ b/doc/GlassConfiguration.md
@@ -31,11 +31,15 @@ An example `glass_init.d` configuration file:
       "CorrelationCancelAge": 900,
       "BeamMatchingAzimuthWindow" : 22.5,
       "HypocenterTimeWindow": 30.0,
-      "HypocenterDistanceWindow": 3.0,      
+      "HypocenterDistanceWindow": 3.0,
       "ReportingStackThreshold": 0.5,
       "ReportingDataThreshold": 5,
       "EventFragmentDepthThreshold": 550.0,
-      "EventFragmentAzimuthThreshold": 270.0      
+      "EventFragmentAzimuthThreshold": 270.0
+  },
+  "PickClassification":{
+      "NoiseThreshold": 0.75,
+      "PhaseThreshold": 0.75
   },
   "DefaultNucleationPhase": {
       "PhaseName": "P",
@@ -168,6 +172,16 @@ a hypocenter. Defaults to **NucleationDataCountThreshold**.
 event fragment, in combination with  **EventFragmentAzimuthThreshold**.
 * **EventFragmentAzimuthThreshold** The azimuth threshold for declaring a hypo an
 event fragment, in combination with **EventFragmentDepthThreshold**.
+
+## Pick Classification Configuration
+These configuration parameters define the thresholds to use when glass processes
+picks with optional classification information from external algorithms
+
+* **NoiseThreshold** - The threshold used by glass when determining whether it
+accepts the classification of a new pick as "noise". Noise picks are not processed
+* **PhaseThreshold** - The threshold used by glass when determining whether it
+accepts the classification of the phase of a new pick. Classified picks are
+nucleated/associated according to the given phase.
 
 ### DefaultNucleationPhase
 This parameter defines the default nucleation phase for glass. This value can be

--- a/glass-app/CMakeLists.txt
+++ b/glass-app/CMakeLists.txt
@@ -21,6 +21,9 @@ include(${CMAKE_DIR}/base.cmake)
 # SuperEasyJSON
 include(${CMAKE_DIR}/include_SuperEasyJSON.cmake)
 
+# rapidjson
+include(${CMAKE_DIR}/include_rapidjson.cmake)
+
 # detection-formats
 include(${CMAKE_DIR}/include_DetectionFormats.cmake)
 

--- a/glass-app/params/initialize.d
+++ b/glass-app/params/initialize.d
@@ -33,6 +33,10 @@
       "HypocenterTimeWindow": 30,
       "HypocenterDistanceWindow": 3
   },
+  "PickClassification":{
+      "NoiseThreshold": 0.75,
+      "PhaseThreshold": 0.75
+  },
   "DefaultNucleationPhase": {
       "PhaseName": "P",
       "TravFile": "./P.trv"

--- a/glass-broker-app/params/initialize.d
+++ b/glass-broker-app/params/initialize.d
@@ -33,6 +33,10 @@
       "HypocenterTimeWindow": 30,
       "HypocenterDistanceWindow": 3
   },
+  "PickClassification": {
+      "NoiseThreshold": 0.75,
+      "PhaseThreshold": 0.75
+  },
   "DefaultNucleationPhase": {
       "PhaseName": "P",
       "TravFile": "./P.trv"

--- a/glasscore/glasslib/include/Glass.h
+++ b/glasscore/glasslib/include/Glass.h
@@ -407,6 +407,20 @@ class CGlass {
 	static bool getAllowPickUpdates();
 
 	/**
+	 * \brief Gets the optional threshold used for accepting the classification
+	 * of a pick as noise by an external algorithm. -1 indicates this feature is 
+	 * disabled
+	 */
+	static double getPickNoiseClassificationThreshold();
+
+	/**
+	 * \brief Gets the optional threshold used for accepting the classification 
+	 * of a pick phase by an external algorithm. -1 indicates this feature is 
+	 * disabled
+	 */
+	static double getPickPhaseClassificationThreshold();
+
+	/**
 	 * \brief Gets a pointer to the Correlation list
 	 * \return Returns a pointer to the correlation list
 	 */
@@ -680,6 +694,19 @@ class CGlass {
 	 * pick list to be updated
 	 */
 	static std::atomic<bool> m_bAllowPickUpdates;
+
+	/**
+	 * \brief The probability threshold for accepting the pick noise 
+	 * classification, phases that meet this threshold will be rejected
+	 */
+	static std::atomic<double> m_dPickNoiseClassificationThreshold;
+
+	/**
+	 * \brief The probability threshold for accepting the pick phase
+	 * classification, phases that meet this threshold will be assumed to be
+	 * the classified phase for nucleation/association
+	 */
+	static std::atomic<double> m_dPickPhaseClassificationThreshold;
 
 	/**
 	 * \brief An IGlassSend interface pointer used to send communication

--- a/glasscore/glasslib/include/Link.h
+++ b/glasscore/glasslib/include/Link.h
@@ -17,10 +17,12 @@ class CNode;
 class CSite;
 
 // defines indexes for links
-#define LINK_PTR 0  // Node or site pointer
-#define LINK_TT1 1  // First travel time in seconds
-#define LINK_TT2 2  // Second travel time in seconds
-#define LINK_DIST 3  // Distance in degrees between Node and Site
+#define LINK_PTR 0   // Node or site pointer
+#define LINK_TT1 1   // First travel time in seconds
+#define LINK_PHS1 2  // First travel time phase code
+#define LINK_TT2 3   // Second travel time in seconds
+#define LINK_PHS2 4  // Second travel time phase code
+#define LINK_DIST 5  // Distance in degrees between Node and Site
 
 /**
  * \brief Typedef to simplify use of a site-node link.  Contains a CNode
@@ -29,7 +31,7 @@ class CSite;
  * and Distance (between Node and Site) in Deg.  Uses weak_ptr to
  * prevent a cyclical reference
  */
-typedef std::tuple<std::weak_ptr<CNode>, double, double, double> NodeLink;
+typedef std::tuple<std::weak_ptr<CNode>, double, std::string, double, std::string, double> NodeLink; // NOLINT
 
 /**
  * \brief Typedef to simplify use of a node-site link.  Contains a CSite
@@ -37,6 +39,6 @@ typedef std::tuple<std::weak_ptr<CNode>, double, double, double> NodeLink;
  * Nucleation Traveltime 1 (sec), Nucleation Traveltime 2 (sec),
  * and Distance (between Node and Site) in Deg
  */
-typedef std::tuple<std::shared_ptr<CSite>, double, double, double> SiteLink;
+typedef std::tuple<std::shared_ptr<CSite>, double, std::string, double, std::string, double> SiteLink; // NOLINT
 }  // namespace glasscore
 #endif  // LINK_H

--- a/glasscore/glasslib/include/Node.h
+++ b/glasscore/glasslib/include/Node.h
@@ -121,15 +121,18 @@ class CNode {
 	 * between the node and the site.
 	 * \param travelTime1 - A double value containing the first travel time to
 	 * use for the link
+	 * \param phase1 - A std::string containing the first travel time phase code
 	 * \param travelTime2 - A double value containing the optional second travel
 	 * time to use for the link, defaults to -1 (no travel time)
+	 * \param phase2 - A std::string containing the second travel time phase 
+	 * code, defaults to "" (no travel time)
 	 * \param site - A shared_ptr<CSite> to the site to link
 	 * \param node - A shared_ptr<CNode> to the node to link (should be itself)
 	 * \return - Returns true if successful, false otherwise
 	 */
 	bool linkSite(std::shared_ptr<CSite> site, std::shared_ptr<CNode> node,
-					double distDeg, double travelTime1,
-					double travelTime2 = -1);
+					double distDeg, double travelTime1, std::string phase1,
+					double travelTime2 = -1, std::string phase2 = "");
 
 	/**
 	 * \brief CNode node-site and site-node unlinker

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -61,12 +61,56 @@ class CPick {
 	 * made at
 	 * \param pickTime - A double containing the pick arrival time
 	 * \param pickIdString - A std::string containing the external pick id.
-	 * \param backAzimuth - A double containing the optional back azimuth, -1
-	 * to omit
-	 * \param slowness - A double containing the optional slowness, -1 to omit
+	 * \param backAzimuth - A double containing the optional back azimuth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param slowness - A double containing the optional slowness, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
 	 */
 	CPick(std::shared_ptr<CSite> pickSite, double pickTime,
-			std::string pickIdString, double backAzimuth, double slowness);
+					std::string pickIdString, double backAzimuth,
+					double slowness);
+
+	/**
+	 * \brief CPick advanced constructor
+	 *
+	 * An advanced constructor for the CPick class. This function
+	 * initializes members to the provided values.
+	 *
+	 * \param pickSite - A shared pointer to a CSite object that the pick was
+	 * made at
+	 * \param pickTime - A double containing the pick arrival time
+	 * \param pickIdString - A std::string containing the external pick id.
+	 * \param backAzimuth - A double containing the optional back azimuth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param slowness - A double containing the optional slowness, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param phase - A std::string containing the optional classified phase,
+	 * empty string to omit.
+	 * \param phaseProb - A double containing the optional classified phase 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param distance - A double containing the optional classified distance, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param distanceProb - A double containing the optional classified distance 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param azimuth - A double containing the optional classified azimuth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param azimuthProb - A double containing the optional classified azimuth 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param depth - A double containing the optional classified depth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param depthProb - A double containing the optional classified depth 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param magnitude - A double containing the optional classified magnitude, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param magnitudeProb - A double containing the optional classified 
+	 * magnitude probability, std::numeric_limits<double>::quiet_NaN() to omit
+	 */
+	CPick(std::shared_ptr<CSite> pickSite, double pickTime,
+					std::string pickIdString, double backAzimuth,
+					double slowness, std::string phase, double phaseProb,
+					double distance, double distanceProb, double azimuth,
+					double azimuthProb, double depth, double depthProb,
+					double magnitude, double magnitudeProb);
 
 	/**
 	 * \brief CPick advanced constructor
@@ -102,14 +146,38 @@ class CPick {
 	 * made at
 	 * \param pickTime - A double containing the pick arrival time
 	 * \param pickIdString - A std::string containing the external pick id.
-	 * \param backAzimuth - A double containing the optional back azimuth, -1
-	 * to omit
-	 * \param slowness - A double containing the optional slowness, -1 to omit
+	 * \param backAzimuth - A double containing the optional back azimuth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param slowness - A double containing the optional slowness, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param phase - A std::string containing the optional classified phase,
+	 * empty string to omit.
+	 * \param phaseProb - A double containing the optional classified phase 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param distance - A double containing the optional classified distance, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param distanceProb - A double containing the optional classified distance 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param azimuth - A double containing the optional classified azimuth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param azimuthProb - A double containing the optional classified azimuth 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param depth - A double containing the optional classified depth, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param depthProb - A double containing the optional classified depth 
+	 * probability,  std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param magnitude - A double containing the optional classified magnitude, 
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param magnitudeProb - A double containing the optional classified 
+	 * magnitude probability, std::numeric_limits<double>::quiet_NaN() to omit
 	 * \return Returns true if successful, false otherwise.
 	 */
 	bool initialize(std::shared_ptr<CSite> pickSite, double pickTime,
 					std::string pickIdString, double backAzimuth,
-					double slowness);
+					double slowness, std::string phase, double phaseProb,
+					double distance, double distanceProb, double azimuth,
+					double azimuthProb, double depth, double depthProb,
+					double magnitude, double magnitudeProb);
 
 	/**
 	 * \brief Add hypo reference to this pick
@@ -246,22 +314,88 @@ class CPick {
 
 	/**
 	 * \brief Get the insertion time for this pick
-	 * \return Returns a double containing the pick inserrtion time into Glass
+	 * \return Returns a double containing the pick insertion time into Glass
 	 * in Gregorian seconds
 	 */
 	double getTInsertion() const;
+
 	/**
 	 * \brief Get the first assoc time for this pick
 	 * \return Returns a double containing the time in Gregorian seconds when
 	 * the pick was first associated with an event.
 	 */
 	double getTFirstAssociation() const;
+
 	/**
 	 * \brief Get the nucleation time for this pick
 	 * \return Returns a double containing the time in Gregorian seconds when
 	 * this pick was used as keystone for nucleation
 	 */
 	double getTNucleation() const;
+
+	/**
+	 * \brief Get the classified phase for this pick
+	 * \return Return a std::string containing the pick phase
+	 */
+	const std::string& getClassifiedPhase() const;
+
+	/**
+	 * \brief Get the classified phase probability for this pick
+	 * \return Returns a double containing the pick classified phase probability 
+	 */
+	double getClassifiedPhaseProbability() const;
+
+	/**
+	 * \brief Get the classified distance for this pick
+	 * \return Returns a double containing the pick classified distance 
+	 */
+	double getClassifiedDistance() const;
+
+	/**
+	 * \brief Get the classified distance probability for this pick
+	 * \return Returns a double containing the pick classified distance 
+	 * probability 
+	 */
+	double getClassifiedDistanceProbability() const;
+
+	/**
+	 * \brief Get the classified azimuth for this pick
+	 * \return Returns a double containing the pick classified azimuth 
+	 */
+	double getClassifiedAzimuth() const;
+
+	/**
+	 * \brief Get the classified azimuth probability for this pick
+	 * \return Returns a double containing the pick classified azimuth 
+	 * probability 
+	 */
+	double getClassifiedAzimuthProbability() const;
+
+	/**
+	 * \brief Get the classified depth for this pick
+	 * \return Returns a double containing the pick classified depth 
+	 */
+	double getClassifiedDepth() const;
+
+	/**
+	 * \brief Get the classified depth probability for this pick
+	 * \return Returns a double containing the pick classified depth 
+	 * probability 
+	 */
+	double getClassifiedDepthProbability() const;
+
+	/**
+	 * \brief Get the classified magnitude for this pick
+	 * \return Returns a double containing the pick classified magnitude 
+	 */
+	double getClassifiedMagnitude() const;
+
+	/**
+	 * \brief Get the classified magnitude probability for this pick
+	 * \return Returns a double containing the pick classified magnitude 
+	 * probability 
+	 */
+	double getClassifiedMagnitudeProbability() const;
 
  protected:
 	/**
@@ -327,6 +461,61 @@ class CPick {
 	 * \brief A double value containing the arrival time of the pick
 	 */
 	std::atomic<double> m_tPick;
+
+	/**
+	 * \brief A string containing the classified phase for the pick
+	 */
+	std::string m_sClassifiedPhase;
+
+	/**
+	 * \brief A double value containing the probability of the classified 
+	 * phase
+	 */
+	std::atomic<double> m_dClassifiedPhaseProbability;
+
+	/**
+	 * \brief A double value containing the classified distance for the pick
+	 */
+	std::atomic<double> m_dClassifiedDistance;
+
+	/**
+	 * \brief A double value containing the probability of the classified 
+	 * distance
+	 */
+	std::atomic<double> m_dClassifiedDistanceProbability;
+
+	/**
+	 * \brief A double value containing the classified azimuth for the pick
+	 */
+	std::atomic<double> m_dClassifiedAzimuth;
+
+	/**
+	 * \brief A double value containing the probability of the classified 
+	 * azimuth
+	 */
+	std::atomic<double> m_dClassifiedAzimuthProbability;
+
+	/**
+	 * \brief A double value containing the classified depth for the pick
+	 */
+	std::atomic<double> m_dClassifiedDepth;
+
+	/**
+	 * \brief A double value containing the probability of the classified 
+	 * depth
+	 */
+	std::atomic<double> m_dClassifiedDepthProbability;
+
+	/**
+	 * \brief A double value containing the classified magnitude for the pick
+	 */
+	std::atomic<double> m_dClassifiedMagnitude;
+
+	/**
+	 * \brief A double value containing the probability of the classified 
+	 * magnitude
+	 */
+	std::atomic<double> m_dClassifiedMagnitudeProbability;
 
 	/**
 	 * \brief A std::shared_ptr to a json object

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -232,11 +232,15 @@ class CSite {
 	 * and this site in degrees
 	 * \param travelTime1 - A double value containing the first travel time
 	 * to use
+	 * \param phase1 - A std::string containing the first travel time phase code
 	 * \param travelTime2 - A double value containing the optional second travel
+	 * \param phase2 - A std::string containing the second travel time phase 
+	 * code, defaults to "" (no travel time)
 	 * time to use for the link, defaults to -1 (no travel time)
 	 */
 	void addNode(std::shared_ptr<CNode> node, double distDeg,
-					double travelTime1, double travelTime2 = -1);
+					double travelTime1, std::string phase1,
+					double travelTime2 = -1, std::string phase2 = "");
 
 	/**
 	 * \brief Remove pick from this site

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -392,7 +392,7 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 						m_dLatitude, m_dLongitude,
 						glass3::util::Geo::k_EarthRadiusKm - m_dDepth);
 
-				// compute azimith from the site to the node
+				// compute azimuth from the site to the node
 				double siteAzimuth = pick->getSite()->getGeo().azimuth(
 						&nodeGeo);
 
@@ -427,7 +427,7 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 
 			// get the best significance from the observed time and the
 			// link hmmm... at this point we don't know which TT got us here,
-			// or wich one
+			// or which one
 			double dSig = getBestSignificance(tObs, travelTime1, travelTime2,
 												distDeg);
 

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -119,8 +119,8 @@ bool CNode::initialize(std::string name, double lat, double lon, double z,
 
 // ---------------------------------------------------------linkSite
 bool CNode::linkSite(std::shared_ptr<CSite> site, std::shared_ptr<CNode> node,
-						double distDeg, double travelTime1,
-						double travelTime2) {
+						double distDeg, double travelTime1, std::string phase1,
+						double travelTime2, std::string phase2) {
 	// nullchecks
 	// check site
 	if (site == NULL) {
@@ -140,13 +140,14 @@ bool CNode::linkSite(std::shared_ptr<CSite> site, std::shared_ptr<CNode> node,
 
 	// Link node to site using traveltime
 	// NOTE: No validation on travel times or distance
-	SiteLink link = std::make_tuple(site, travelTime1, travelTime2, distDeg);
+	SiteLink link = std::make_tuple(site, travelTime1, phase1, travelTime2,
+		phase2, distDeg);
 	m_vSiteLinkList.push_back(link);
 
 	// link site to node, again using the traveltime
 	// NOTE: this used to be site->addNode(shared_ptr<CNode>(this), tt);
 	// but that caused problems when deleting site-node links.
-	site->addNode(node, distDeg, travelTime1, travelTime2);
+	site->addNode(node, distDeg, travelTime1, phase1, travelTime2, phase2);
 
 	// successfully linked site
 	return (true);
@@ -292,7 +293,9 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 
 		// get traveltime(s) to site
 		double travelTime1 = std::get < LINK_TT1 > (link);
+		std::string phase1 = std::get < LINK_PHS1 > (link);
 		double travelTime2 = std::get < LINK_TT2 > (link);
+		std::string phase2 = std::get < LINK_PHS2 > (link);
 		double distDeg = std::get < LINK_DIST > (link);
 
 		// the minimum and maximum time windows for picks
@@ -424,6 +427,31 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 			 }
 			 }
 			 */
+
+			// check pick classification
+			// are we configured to check pick phase classification
+			if (CGlass::getPickPhaseClassificationThreshold() > 0) {
+				// check to see if the phase classification is valid and above
+				// our threshold
+				if ((std::isnan(pick->getClassifiedPhaseProbability()) != true)
+					&& (pick->getClassifiedPhaseProbability() >
+					CGlass::getPickPhaseClassificationThreshold())) {
+					// check to see if the phase is classified as one of our
+					// nucleation phases
+					if (pick->getClassifiedPhase() == phase1) {
+						// match, we only consider traveltime1, disable
+						// traveltime2
+						travelTime2 =
+							traveltime::CTravelTime::k_dTravelTimeInvalid;
+					} else if (pick->getClassifiedPhase() == phase2) {
+						// match, we only consider traveltime2, disable
+						// traveltime1
+						travelTime1 =
+							traveltime::CTravelTime::k_dTravelTimeInvalid;
+					}
+					// otherwise there is no match and it's business as usual
+				}
+			}
 
 			// get the best significance from the observed time and the
 			// link hmmm... at this point we don't know which TT got us here,

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -463,7 +463,17 @@ glass3::util::WorkState CPickList::work() {
 			existingPick->initialize(existingPick->getSite(),
 										newPick->getTPick(), newPick->getID(),
 										newPick->getBackAzimuth(),
-										newPick->getSlowness());
+										newPick->getSlowness(),
+										newPick->getClassifiedPhase(),
+										newPick->getClassifiedPhaseProbability(),
+										newPick->getClassifiedDistance(),
+										newPick->getClassifiedDistanceProbability(),
+										newPick->getClassifiedAzimuth(),
+										newPick->getClassifiedAzimuthProbability(),
+										newPick->getClassifiedDepth(),
+										newPick->getClassifiedDepthProbability(),
+										newPick->getClassifiedMagnitude(),
+										newPick->getClassifiedMagnitudeProbability());
 
 			// update the position of the pick in the sort
 			updatePosition(existingPick);

--- a/glasscore/glasslib/src/PickList.cpp
+++ b/glasscore/glasslib/src/PickList.cpp
@@ -499,24 +499,26 @@ glass3::util::WorkState CPickList::work() {
 		// cleanup
 		delete (newPick);
 
-		// we're done
+		// message was processed
 		return (glass3::util::WorkState::OK);
 	}
 
 	// are we configured to check pick noise classification
 	if (CGlass::getPickNoiseClassificationThreshold() > 0) {
-		// check to see if the phase is classified as noise
-		// and it's probability is above our threshold
-		if ((newPick->getClassifiedPhase() == "Noise") &&
+		// check to see if the phase classification is valid and above
+		// our threshold
+		if ((std::isnan(newPick->getClassifiedPhaseProbability()) != true) &&
 			(newPick->getClassifiedPhaseProbability() >
 			CGlass::getPickNoiseClassificationThreshold())) {
-			// this pick is noise, ignore new pick
+			// check to see if the phase is classified as noise
+			if (newPick->getClassifiedPhase() == "Noise") {
+				// this pick is noise, ignore new pick
+				// cleanup
+				delete (newPick);
 
-			// cleanup
-			delete (newPick);
-
-			// message was processed
-			return (glass3::util::WorkState::OK);
+				// message was processed (rejected)
+				return (glass3::util::WorkState::OK);
+			}
 		}
 	}
 

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -547,7 +547,8 @@ std::mutex & CSite::getPickMutex() {
 
 // ---------------------------------------------------------addNode
 void CSite::addNode(std::shared_ptr<CNode> node, double distDeg,
-					double travelTime1, double travelTime2) {
+						double travelTime1, std::string phase1,
+						double travelTime2, std::string phase2) {
 	// lock for editing
 	std::lock_guard<std::mutex> guard(m_vNodeMutex);
 
@@ -569,7 +570,8 @@ void CSite::addNode(std::shared_ptr<CNode> node, double distDeg,
 	// add node link to vector of nodes linked to this site
 	// NOTE: no duplication check, but multiple nodes from the
 	// same web can exist at the same site (travel times would be different)
-	NodeLink link = std::make_tuple(node, travelTime1, travelTime2, distDeg);
+	NodeLink link = std::make_tuple(node, travelTime1, phase1, travelTime2,
+		phase2, distDeg);
 	m_vNode.push_back(link);
 }
 

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -1422,13 +1422,17 @@ std::shared_ptr<CNode> CWeb::generateNodeSites(std::shared_ptr<CNode> node) {
 
 		// compute traveltimes between site and node
 		double travelTime1 = traveltime::CTravelTime::k_dTravelTimeInvalid;
+		std::string phase1 = traveltime::CTravelTime::k_dPhaseInvalid;
 		if (m_pNucleationTravelTime1 != NULL) {
 			travelTime1 = m_pNucleationTravelTime1->T(delta);
+			phase1 = m_pNucleationTravelTime1->m_sPhase;
 		}
 
 		double travelTime2 = traveltime::CTravelTime::k_dTravelTimeInvalid;
+		std::string phase2 = traveltime::CTravelTime::k_dPhaseInvalid;
 		if (m_pNucleationTravelTime2 != NULL) {
 			travelTime2 = m_pNucleationTravelTime2->T(delta);
+			phase2 = m_pNucleationTravelTime2->m_sPhase;
 		}
 
 		// skip site if there are no valid times
@@ -1437,7 +1441,8 @@ std::shared_ptr<CNode> CWeb::generateNodeSites(std::shared_ptr<CNode> node) {
 		}
 
 		// Link node to site using traveltimes
-		node->linkSite(site, node, delta, travelTime1, travelTime2);
+		node->linkSite(site, node, delta, travelTime1, phase1, travelTime2,
+			phase2);
 	}
 
 	// sort the site links
@@ -1552,19 +1557,24 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 		}
 
 		// compute traveltimes between site and node
-		double travelTime1 = -1;
+		double travelTime1 = traveltime::CTravelTime::k_dTravelTimeInvalid;
+		std::string phase1 = traveltime::CTravelTime::k_dPhaseInvalid;
 		if (m_pNucleationTravelTime1 != NULL) {
 			travelTime1 = m_pNucleationTravelTime1->T(newDistance);
+			phase1 = m_pNucleationTravelTime1->m_sPhase;
 		}
-		double travelTime2 = -1;
+		double travelTime2 = traveltime::CTravelTime::k_dTravelTimeInvalid;
+		std::string phase2 = traveltime::CTravelTime::k_dPhaseInvalid;
 		if (m_pNucleationTravelTime2 != NULL) {
 			travelTime2 = m_pNucleationTravelTime2->T(newDistance);
+			phase2 = m_pNucleationTravelTime2->m_sPhase;
 		}
 
 		// check to see if we're at the limit
 		if (node->getSiteLinksCount() < m_iNumStationsPerNode) {
 			// Link node to site using traveltimes
-			node->linkSite(site, node, newDistance, travelTime1, travelTime2);
+			node->linkSite(site, node, newDistance, travelTime1, phase1,
+				travelTime2, phase2);
 
 		} else {
 			// remove last site
@@ -1573,7 +1583,8 @@ void CWeb::addSite(std::shared_ptr<CSite> site) {
 			node->unlinkLastSite();
 
 			// Link node to site using traveltimes
-			node->linkSite(site, node, newDistance, travelTime1, travelTime2);
+			node->linkSite(site, node, newDistance, travelTime1, phase1,
+				travelTime2, phase2);
 		}
 
 		// resort site links
@@ -1693,17 +1704,21 @@ void CWeb::removeSite(std::shared_ptr<CSite> site) {
 
 			// compute traveltimes between site and node
 			double travelTime1 = traveltime::CTravelTime::k_dTravelTimeInvalid;
+			std::string phase1 = traveltime::CTravelTime::k_dPhaseInvalid;
 			if (m_pNucleationTravelTime1 != NULL) {
 				travelTime1 = m_pNucleationTravelTime1->T(newDistance);
+				phase1 = m_pNucleationTravelTime1->m_sPhase;
 			}
 			double travelTime2 = traveltime::CTravelTime::k_dTravelTimeInvalid;
+			std::string phase2 = traveltime::CTravelTime::k_dPhaseInvalid;
 			if (m_pNucleationTravelTime2 != NULL) {
 				travelTime2 = m_pNucleationTravelTime2->T(newDistance);
+				phase2 = m_pNucleationTravelTime2->m_sPhase;
 			}
 
 			// Link node to new site using traveltimes
-			if (node->linkSite(newSite, node, newDistance, travelTime1,
-								travelTime2) == false) {
+			if (node->linkSite(newSite, node, newDistance, travelTime1, phase1,
+								travelTime2, phase2) == false) {
 				glass3::util::Logger::log(
 						"error",
 						"CWeb::remSite: Failed to add station "

--- a/glasscore/tests/node_unittest.cpp
+++ b/glasscore/tests/node_unittest.cpp
@@ -18,6 +18,7 @@
 
 #define SITEJSON "{\"Cmd\":\"Site\",\"Elv\":2326.000000,\"Lat\":45.822170,\"Lon\":-112.451000,\"Site\":\"LRM.EHZ.MB.--\",\"Use\":true}"  // NOLINT
 #define TRAVELTIME 122
+#define PHASE "P"
 #define DISTANCE_FOR_TT 8.5
 
 // NOTE: Need to consider testing nucleate, but that would need a much more
@@ -97,8 +98,8 @@ TEST(NodeTest, SiteOperations) {
 	std::shared_ptr<glasscore::CSite> sharedTestSite(testSite);
 
 	// add the site to the node
-	ASSERT_TRUE(
-			testNode->linkSite(sharedTestSite, sharedTestNode, DISTANCE_FOR_TT, TRAVELTIME));  // NOLINT
+	ASSERT_TRUE(testNode->linkSite(sharedTestSite, sharedTestNode,
+		DISTANCE_FOR_TT, TRAVELTIME, PHASE));  // NOLINT
 
 	// check to see if the site was added
 	int expectedSize = 1;
@@ -140,9 +141,9 @@ TEST(NodeTest, FailTests) {
 
 	// link fails
 	ASSERT_FALSE(
-			testNode->linkSite(nullSite, sharedTestNode, DISTANCE_FOR_TT, TRAVELTIME));  // NOLINT
+			testNode->linkSite(nullSite, sharedTestNode, DISTANCE_FOR_TT, TRAVELTIME, PHASE));  // NOLINT
 	ASSERT_FALSE(
-			testNode->linkSite(sharedTestSite, nullNode, DISTANCE_FOR_TT, TRAVELTIME));  // NOLINT
+			testNode->linkSite(sharedTestSite, nullNode, DISTANCE_FOR_TT, TRAVELTIME, PHASE));  // NOLINT
 
 	// unlink fails
 	ASSERT_FALSE(testNode->unlinkSite(nullSite));

--- a/glasscore/tests/pick_unittest.cpp
+++ b/glasscore/tests/pick_unittest.cpp
@@ -11,10 +11,11 @@
 #include "Pick.h"
 
 #define SITEJSON "{\"Type\":\"StationInfo\",\"Elevation\":2326.000000,\"Latitude\":45.822170,\"Longitude\":-112.451000,\"Site\":{\"Station\":\"LRM\",\"Channel\":\"EHZ\",\"Network\":\"MB\",\"Location\":\"\"},\"Enable\":true,\"Quality\":1.0,\"UseForTeleseismic\":true}"  // NOLINT
-#define PICKJSON "{\"ID\":\"20682837\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"EHZ\",\"Location\":\"\",\"Network\":\"MB\",\"Station\":\"LRM\"},\"Source\":{\"AgencyID\":\"228041013\",\"Author\":\"228041013\"},\"Time\":\"2014-12-23T00:01:43.599Z\",\"Type\":\"Pick\",\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44}}"  // NOLINT
+#define PICKJSON "{\"ID\":\"20682837\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"EHZ\",\"Location\":\"\",\"Network\":\"MB\",\"Station\":\"LRM\"},\"Source\":{\"AgencyID\":\"228041013\",\"Author\":\"228041013\"},\"Time\":\"2014-12-23T00:01:43.599Z\",\"Type\":\"Pick\",\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44},\"ClassificationInfo\":{\"Phase\":\"P\",\"PhaseProbability\":0.22,\"Distance\":0.442559,\"DistanceProbability\":22.5,\"Azimuth\":0.418479,\"AzimuthProbability\":0.16,\"Magnitude\":2.14,\"MagnitudeType\":\"Mb\",\"MagnitudeProbability\":0.55,\"Depth\":32.44,\"DepthProbability\":11.2,\"EventType\":{\"Type\":\"Earthquake\",\"Certainty\":\"Suspected\"},\"EventTypeProbability\":1.1,\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"}}}"  // NOLINT
 #define BADPICK "{\"ID\":\"20682837\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"EHZ\",\"Location\":\"\",\"Network\":\"MB\",\"Station\":\"LRM\"},\"Source\":{\"AgencyID\":\"228041013\",\"Author\":\"228041013\"},\"Time\":\"2014-12-23T00:01:43.599Z\",\"Type\":\"FEH\",\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44}}"  // NOLINT
 #define BADPICK2 "{\"ID\":\"20682837\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Site\":{\"Channel\":\"EHZ\",\"Location\":\"\",\"Network\":\"MB\",\"Station\":\"LRM\"},\"Source\":{\"AgencyID\":\"228041013\",\"Author\":\"228041013\"},\"Time\":\"2014-12-23T00:01:43.599Z\",\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44}}"  // NOLINT
 
+#define PICKIDSTRING "20682837"
 #define SCNL "LRM.EHZ.MB"
 #define SITE "LRM"
 #define COMP "EHZ"
@@ -23,7 +24,17 @@
 #define PICKTIME 3628281703.599
 #define BACKAZIMUTH 2.65
 #define SLOWNESS 1.44
-#define PICKIDSTRING "20682837"
+#define PHASE "P"
+
+#define PHASEPROB 0.22
+#define DISTANCE 0.442559
+#define DISTANCEPROB 22.5
+#define AZIMUTH 0.418479
+#define AZIMUTHPROB 0.16
+#define MAGNITUDE 2.14
+#define MAGNITUDEPROB 0.55
+#define DEPTH 32.44
+#define DEPTHPROB 11.2
 
 // NOTE: Need to consider testing nucleate function, but that would need a
 // much more involved set of real nodes and data, not these dummy nodes.
@@ -75,6 +86,61 @@ void checkdata(glasscore::CPick * pickobject, const std::string &testinfo) {
 	std::string pickstringid = pickobject->getID();
 	std::string expectedstringid = std::string(PICKIDSTRING);
 	ASSERT_STREQ(pickstringid.c_str(), expectedstringid.c_str());
+
+	// check phase
+	std::string classificationphase = pickobject->getClassifiedPhase();
+	std::string expectedphase = PHASE;
+	ASSERT_STREQ(classificationphase.c_str(), expectedphase.c_str());
+
+	// check phase probability
+	double classificationphaseprobability =
+		pickobject->getClassifiedPhaseProbability();
+	double expectedphaseprobability = PHASEPROB;
+	ASSERT_EQ(classificationphaseprobability, expectedphaseprobability);
+
+	// check distance
+	double classificationdistance = pickobject->getClassifiedDistance();
+	double expecteddistance = DISTANCE;
+	ASSERT_EQ(classificationdistance, expecteddistance);
+
+	// check distance probability
+	double classificationdistanceprobability =
+		pickobject->getClassifiedDistanceProbability();
+	double expecteddistanceprobability = DISTANCEPROB;
+	ASSERT_EQ(classificationdistanceprobability, expecteddistanceprobability);
+
+	// check azimuth
+	double classificationazimuth = pickobject->getClassifiedAzimuth();
+	double expectedazimuth = AZIMUTH;
+	ASSERT_EQ(classificationazimuth, expectedazimuth);
+
+	// check azimuth probability
+	double classificationazimuthprobability =
+		pickobject->getClassifiedAzimuthProbability();
+	double expectedazimuthprobability = AZIMUTHPROB;
+	ASSERT_EQ(classificationazimuthprobability, expectedazimuthprobability);
+
+	// check depth
+	double classificationdepth = pickobject->getClassifiedDepth();
+	double expecteddepth = DEPTH;
+	ASSERT_EQ(classificationdepth, expecteddepth);
+
+	// check depth probability
+	double classificationdepthprobability =
+		pickobject->getClassifiedDepthProbability();
+	double expecteddepthprobability = DEPTHPROB;
+	ASSERT_EQ(classificationdepthprobability, expecteddepthprobability);
+
+	// check magnitude
+	double classificationmagnitude = pickobject->getClassifiedMagnitude();
+	double expectedmagnitude = MAGNITUDE;
+	ASSERT_EQ(classificationmagnitude, expectedmagnitude);
+
+	// check magnitude probability
+	double classificationmagnitudeprobability =
+		pickobject->getClassifiedMagnitudeProbability();
+	double expectedmagnitudeprobability = MAGNITUDEPROB;
+	ASSERT_EQ(classificationmagnitudeprobability, expectedmagnitudeprobability);
 }
 
 // test to see if the pick can be constructed
@@ -111,8 +177,8 @@ TEST(PickTest, Construction) {
 
 	// now init
 	testPick->initialize(sharedTestSite, PICKTIME, std::string(PICKIDSTRING),
-	BACKAZIMUTH,
-							SLOWNESS);
+		BACKAZIMUTH, SLOWNESS, PHASE, PHASEPROB, DISTANCE, DISTANCEPROB,
+		AZIMUTH, AZIMUTHPROB, DEPTH, DEPTHPROB, MAGNITUDE, MAGNITUDEPROB);
 
 	// check results
 	checkdata(testPick, "initialize check");

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -296,8 +296,8 @@ TEST(SiteTest, NodeOperations) {
 	std::shared_ptr<glasscore::CNode> sharedNode2(testNode2);
 
 	// test adding nodes to site
-	testSite->addNode(sharedNode, 5.0, 10.0);
-	testSite->addNode(sharedNode2, 6.0, 12.0);
+	testSite->addNode(sharedNode, 5.0, 10.0, "P");
+	testSite->addNode(sharedNode2, 6.0, 12.0, "P");
 	int expectedSize = 2;
 	ASSERT_EQ(expectedSize, testSite->getNodeLinksCount())<< "Added Nodes";
 

--- a/glasscore/traveltime/include/TravelTime.h
+++ b/glasscore/traveltime/include/TravelTime.h
@@ -224,6 +224,11 @@ class CTravelTime {
 	 * \brief the value for an invalid travel time
 	 */
 	static constexpr double k_dTravelTimeInvalid = -1.0;
+
+	/**
+	 * \brief the string for an invalid phase name
+	 */
+	static const std::string k_dPhaseInvalid;
 };
 }  // namespace traveltime
 #endif  // TRAVELTIME_H

--- a/glasscore/traveltime/src/TravelTime.cpp
+++ b/glasscore/traveltime/src/TravelTime.cpp
@@ -11,6 +11,7 @@ namespace traveltime {
 
 // constants
 constexpr double CTravelTime::k_dTravelTimeInvalid;
+const std::string CTravelTime::k_dPhaseInvalid = ""; // NOLINT
 
 // ---------------------------------------------------------CTravelTime
 CTravelTime::CTravelTime() {
@@ -65,6 +66,7 @@ void CTravelTime::clear() {
 	m_iNumDepthWarp = 0;
 	m_dDepth = 0;
 	m_dDelta = 0;
+	m_sPhase = CTravelTime::k_dPhaseInvalid;
 
 	if (m_pDistanceWarp) {
 		delete (m_pDistanceWarp);
@@ -95,7 +97,7 @@ void CTravelTime::clear() {
 // ---------------------------------------------------------Setup
 bool CTravelTime::setup(std::string phase, std::string file) {
 	// nullcheck
-	if (phase == "") {
+	if (phase == CTravelTime::k_dPhaseInvalid) {
 		glass3::util::Logger::log("error",
 									"CTravelTime::Setup: empty phase provided");
 		return (false);

--- a/input/CMakeLists.txt
+++ b/input/CMakeLists.txt
@@ -20,6 +20,9 @@ include(${CMAKE_DIR}/base.cmake)
 # SuperEasyJSON
 include(${CMAKE_DIR}/include_SuperEasyJSON.cmake)
 
+# rapid-json
+include(${CMAKE_DIR}/include_rapidjson.cmake)
+
 # detection-formats
 include(${CMAKE_DIR}/include_DetectionFormats.cmake)
 

--- a/output/CMakeLists.txt
+++ b/output/CMakeLists.txt
@@ -20,6 +20,9 @@ include(${CMAKE_DIR}/base.cmake)
 # SuperEasyJSON
 include(${CMAKE_DIR}/include_SuperEasyJSON.cmake)
 
+# rapid-json
+include(${CMAKE_DIR}/include_rapidjson.cmake)
+
 # detection-formats
 include(${CMAKE_DIR}/include_DetectionFormats.cmake)
 

--- a/parse/CMakeLists.txt
+++ b/parse/CMakeLists.txt
@@ -20,6 +20,9 @@ include(${CMAKE_DIR}/base.cmake)
 # SuperEasyJSON
 include(${CMAKE_DIR}/include_SuperEasyJSON.cmake)
 
+# rapid-json
+include(${CMAKE_DIR}/include_rapidjson.cmake)
+
 # detection-formats
 include(${CMAKE_DIR}/include_DetectionFormats.cmake)
 

--- a/parse/src/ccparser.cpp
+++ b/parse/src/ccparser.cpp
@@ -149,8 +149,9 @@ std::shared_ptr<json::Object> CCParser::parse(const std::string &input) {
 		// depth
 		newCorrelation.hypocenter.depth = std::stod(splitInput[DEPTH_INDEX]);
 
-		// event type is not specified, default to earthquake
-		newCorrelation.eventtype = "earthquake";
+		// event type is not specified, default to suspected earthquake
+		newCorrelation.eventtype = detectionformats::eventtype("Earthquake",
+			"Suspected");
 
 		// magnitude
 		newCorrelation.magnitude = std::stod(splitInput[MAGNITUDE_INDEX]);

--- a/parse/src/convert.cpp
+++ b/parse/src/convert.cpp
@@ -317,8 +317,10 @@ std::string hypoToJSONDetection(std::shared_ptr<json::Object> data,
 				// optional values
 				// type of event
 				if (dataobject.HasKey("EventType")) {
-					correlation.eventtype =
-							(dataobject)["EventType"].ToString();
+					json::Object typeobj = (dataobject)["EventType"].ToObject();
+					correlation.eventtype.type = (typeobj)["Type"].ToString();
+					correlation.eventtype.certainty =
+						(typeobj)["Certainty"].ToString();
 				}
 
 				// magnitude


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?**
Updates neic-glass3 to support changes in earthquake-detection-formats v0.9.7
Adds support for rejecting picks classified as "noise" above a configurable probability threshold
Adds support for utilizing classified pick phase identification in nucleation and association above a configurable probability threshold

* **What is the current behavior?**
neic-glass3 was not compatible with the latest version of earthquake-detection-formats
neic-glass3 did not support utilizing pick classification information

* **What is the new behavior?**
neic-glass3 will now parse selected classification information from input picks if present. If enabled, neic-glass3 will now utilize this classification information if the probability is above a configurable threshold. 

* **Does this PR introduce a breaking change?** 
neic-glass3 is not compatible with older versions of earthquake-detection-formats

