### PR TITLE
Elev bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if (BUILD_GLASS-APP OR BUILD_GLASS-BROKER-APP)
     if (GIT_CLONE_PUBLIC)
       ExternalProject_Add(DetectionFormats
           GIT_REPOSITORY https://github.com/usgs/earthquake-detection-formats.git
-          GIT_TAG v0.9.7
+          # GIT_TAG v0.9.7
           TIMEOUT 10
           CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -153,7 +153,7 @@ if (BUILD_GLASS-APP OR BUILD_GLASS-BROKER-APP)
     else()
       ExternalProject_Add(DetectionFormats
           GIT_REPOSITORY git@github.com:usgs/earthquake-detection-formats.git
-          GIT_TAG v0.9.7
+          # GIT_TAG v0.9.7
           TIMEOUT 10
           CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_LOCATION}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/glasscore/glasslib/include/Site.h
+++ b/glasscore/glasslib/include/Site.h
@@ -164,9 +164,9 @@ class CSite {
 	 * This function sets the geographic location of the site to
 	 * the provided latitude, longitude, and depth.
 	 *
-	 * \param lat - A double value containing the latitude to use.
-	 * \param lon - A double value containing the longitude to use.
-	 * \param z - A double value containing the depth to use.
+	 * \param lat - A double value containing the latitude in degrees to use.
+	 * \param lon - A double value containing the longitude in degrees to use.
+	 * \param z - A double value containing the surface depth in km to use.
 	 */
 	void setLocation(double lat, double lon, double z);
 
@@ -345,6 +345,27 @@ class CSite {
 	void setQuality(double qual);
 
 	/**
+	 * \brief Get the station raw latitude
+	 * \return Returns a double value containing the raw (original) latitude for
+	 * the station
+	 */
+	double getRawLatitude() const;
+
+	/**
+	 * \brief Get the station raw longitude
+	 * \return Returns a double value containing the raw (original) longitude for
+	 * the station
+	 */
+	double getRawLongitude() const;
+
+	/**
+	 * \brief Get the station raw elevation
+	 * \return Returns a double value containing the raw (original) elevation for
+	 * the station
+	 */
+	double getRawElevation() const;
+
+	/**
 	 * \brief Get the combined site location (latitude, longitude, elevation) as
 	 * a CGeo object
 	 * \return Returns a glass3::util::Geo object containing the combined location.
@@ -504,6 +525,24 @@ class CSite {
 	 * \brief A CGeo object containing the geographic location of this site
 	 */
 	glass3::util::Geo m_Geo;
+
+	/**
+	 * \brief A double value containing the raw (original) latitude of the station
+	 * in degrees.
+	 */
+	std::atomic<double> m_dRawLatitude;
+
+	/**
+	 * \brief A double value containing the raw (original) longitude of the station
+	 * in degrees.
+	 */
+	std::atomic<double> m_dRawLongitude;
+
+	/**
+	 * \brief A double value containing the raw (original) elevation of the station
+	 * in meters from the surface.
+	 */
+	std::atomic<double> m_dRawElevation;
 
 	/**
 	 * \brief A unit vector in Cartesian earth coordinates used to do a quick

--- a/glasscore/glasslib/src/Site.cpp
+++ b/glasscore/glasslib/src/Site.cpp
@@ -259,9 +259,9 @@ bool CSite::initialize(std::string sta, std::string comp, std::string net,
 
 	// check elevation, we assume that a station is not deeper than the Dead Sea
 	// and not higher than the Himalayas
-	if ((elv < -500.0) || (elv > 8000.0)) {
+	if ((elv < -5000.0) || (elv > 8000.0)) {
 		glass3::util::Logger::log("error", "CSite::initialize: Elevation not in the"
-			"valid range of -500 to 8000 meters.");
+			"valid range of -5000 to 8000 meters.");
 		return (false);
 	}
 	m_dRawElevation = elv;

--- a/glasscore/glasslib/src/SiteList.cpp
+++ b/glasscore/glasslib/src/SiteList.cpp
@@ -403,20 +403,11 @@ std::shared_ptr<json::Object> CSiteList::generateSiteListMessage(bool send) {
 	// move through whole vector
 	for (const auto &site : m_vSite) {
 		json::Object stationObj;
-		double lat;
-		double lon;
-		double z;
-
-		// convert to geographic coordinates
-		site->getGeo().getGeographic(&lat, &lon, &z);
-
-		// convert from earth radius to elevation
-		double elv = (z - 6317.0) * -1000.0;
 
 		// construct a json message containing our site info
-		stationObj["Lat"] = lat;
-		stationObj["Lon"] = lon;
-		stationObj["Z"] = elv;
+		stationObj["Lat"] = site->getRawLatitude();
+		stationObj["Lon"] = site->getRawLongitude();
+		stationObj["Z"] = site->getRawElevation();
 		stationObj["Qual"] = site->getQuality();
 		stationObj["Use"] = site->getEnable();
 		stationObj["UseForTele"] = site->getUseForTeleseismic();

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -29,6 +29,10 @@
 #define USE true
 #define USEFORTELE true
 
+#define BADLATITUDE 1000.0
+#define BADLONGITUDE 1000.0
+#define BADELEVATION -550000.0
+
 // NOTE: Need to consider testing nucleate function, but that would need a
 // much more involved set of real nodes and data, not these dummy nodes.
 // Maybe consider performing this test at a higher level?
@@ -320,4 +324,53 @@ TEST(SiteTest, NodeOperations) {
 	testSite->removeNode(testNode->getID());
 	expectedSize = 1;
 	ASSERT_EQ(expectedSize, testSite->getNodeLinksCount())<< "Removed Node";
+}
+
+
+// tests various failure conditions
+TEST(SiteTest, FailTests) {
+	glass3::util::Logger::disable();
+
+	// construct a site
+	glasscore::CSite * testSite = new glasscore::CSite();
+
+	// missing station
+	ASSERT_FALSE(testSite->initialize(std::string(""), std::string(COMP),
+							std::string(NET), std::string(LOC), LATITUDE, LONGITUDE,
+							ELEVATION,
+							QUALITY,
+							USE,
+							USEFORTELE));
+
+	// missing network
+	ASSERT_FALSE(testSite->initialize(std::string(SITE), std::string(COMP),
+							std::string(""), std::string(LOC), LATITUDE, LONGITUDE,
+							ELEVATION,
+							QUALITY,
+							USE,
+							USEFORTELE));
+
+	// bad latitude
+	ASSERT_FALSE(testSite->initialize(std::string(SITE), std::string(COMP),
+							std::string(NET), std::string(LOC), BADLATITUDE, LONGITUDE,
+							ELEVATION,
+							QUALITY,
+							USE,
+							USEFORTELE));
+
+	// bad longitude
+	ASSERT_FALSE(testSite->initialize(std::string(SITE), std::string(COMP),
+							std::string(NET), std::string(LOC), LATITUDE, BADLONGITUDE,
+							ELEVATION,
+							QUALITY,
+							USE,
+							USEFORTELE));
+
+	// bad elevation
+	ASSERT_FALSE(testSite->initialize(std::string(SITE), std::string(COMP),
+							std::string(NET), std::string(LOC), LATITUDE, LONGITUDE,
+							BADELEVATION,
+							QUALITY,
+							USE,
+							USEFORTELE));
 }

--- a/glasscore/tests/site_unittest.cpp
+++ b/glasscore/tests/site_unittest.cpp
@@ -79,6 +79,21 @@ void checkdata(glasscore::CSite * siteobject, const std::string &testinfo) {
 	double expectedelevation = GEOCENTRIC_ELEVATION;
 	ASSERT_NEAR(siteelevation, expectedelevation, 0.000001);
 
+	// check raw latitude
+	double rawlatitude = siteobject->getRawLatitude();
+	double expectedrawlatitude = LATITUDE;
+	ASSERT_NEAR(rawlatitude, expectedrawlatitude, 0.000001);
+
+	// check raw longitude
+	double rawlongitude = siteobject->getRawLongitude();
+	double expectedrawlongitude = LONGITUDE;
+	ASSERT_NEAR(rawlongitude, expectedrawlongitude, 0.000001);
+
+	// check raw elevation
+	double rawelevation = siteobject->getRawElevation();
+	double expectedrawelevation = ELEVATION;
+	ASSERT_NEAR(rawelevation, expectedrawelevation, 0.000001);
+
 	// check use
 	bool siteuse = siteobject->getUse();
 	bool expecteduse = USE;

--- a/parse/CMakeLists.txt
+++ b/parse/CMakeLists.txt
@@ -20,9 +20,6 @@ include(${CMAKE_DIR}/base.cmake)
 # SuperEasyJSON
 include(${CMAKE_DIR}/include_SuperEasyJSON.cmake)
 
-# rapid-json
-include(${CMAKE_DIR}/include_rapidjson.cmake)
-
 # detection-formats
 include(${CMAKE_DIR}/include_DetectionFormats.cmake)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** 
This PR fixes a bug in glass-broker-app involving the station list update functions.


* **What is the current behavior?**
glass-broker-app writes an updated station list file to disk every 2 hours reflecting any/all station lookups or updates that may have occurred. A bug was identified in the conversion between the internal glass elevation and what the station list required (surface meters). This meant that each time glass-broker-app restarted (and reloaded the updated station list) the station elevation was more and more incorrect.


* **What is the new behavior?**
The Site class has been modified such that it caches the input station coordinates (latitude, longitude, and elevation) separate from the internal glass coordinates, to eliminate the chance that a back-conversion will corrupt the values read from the station list. Additionally, sanity checks were added to the Site initialization function for latitude, longitude, and elevation to catch, log, and reject values out of expected ranges. 


* **Does this PR introduce a breaking change?** 
No


* **Other information**:
Unit tests were added to check the new latitude, longitude, and elevation validation logic. A cmake build issue with importing DetectionFormats v0.9.7 was also fixed.
