### PR TITLE
Stabilized Locator

### DIFF
--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -1194,7 +1194,7 @@ class CHypo {
 	/**
 	 * \brief The factor for dividing when computing the location search radius
 	 */
-	static constexpr double k_dSearchRadiusFactor = 2.0;
+	static constexpr double k_dSearchRadiusFactor = 0.5;
 
  private:
 	/**

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -1102,7 +1102,7 @@ class CHypo {
 	/**
 	 * \brief The initial step reduction factor for anneal
 	 */
-	static constexpr double k_dInitialAnnealStepReducationFactor = 2.0;
+	static constexpr double k_dInitialAnnealStepReducationFactor = .5;
 
 	/**
 	 * \brief The final step reduction factor for anneal
@@ -1177,13 +1177,13 @@ class CHypo {
 	/**
 	 * \brief The large number of location iterations to perform for a hypo
 	 */
-	static const int k_iLocationNumIterationsLarge = 5000;
+	static const int k_iLocationNumIterationsLarge = 10000;
 
 	/**
 	 * \brief The factor for dividing the web resolution when computing the
 	 * location search radius
 	 */
-	static constexpr double k_dSearchRadiusResolutionFactor = 4.0;
+	static constexpr double k_dSearchRadiusResolutionFactor = 1.0;
 
 	/**
 	 * \brief The factor for multiplying the taper when computing the location

--- a/glasscore/glasslib/include/Pick.h
+++ b/glasscore/glasslib/include/Pick.h
@@ -571,12 +571,12 @@ class CPick {
 	/**
 	 * \brief The number of anneal iterations to run when nucleating
 	 */
-	static const unsigned int k_nNucleateNumberOfAnnealIterations = 10000;
+	static const unsigned int k_nNucleateNumberOfAnnealIterations = 20000;
 
 	/**
 	 * \brief The initial anneal step size to use when nucleating
 	 */
-	static constexpr double k_dNucleateInitialAnnealTimeStepSize = 5.0;
+	static constexpr double k_dNucleateInitialAnnealTimeStepSize = 10.0;
 
 	/**
 	 * \brief The final anneal step size to use when nucleating

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -694,13 +694,7 @@ void CHypo::annealingLocateBayes(int nIter, double dStart, double dStop,
 
 		// is this stacked bayesian value (calculateValue) better than the
 		// previous best  (valBest)
-		if (bayes > valBest
-				|| (bayes > m_dNucleationStackThreshold
-						&& (valBest - bayes)
-								< (pow(glass3::util::GlassMath::gauss(
-										0, k_dBayesFactorMaximumRange),
-										k_dBayesFactorExponent)
-										/ (k_dBayesFactorStepSizeReduction / dkm)))) {
+		if (bayes > valBest) {
 			// then this is the new best value
 			valBest = bayes;
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The iterations and search distance for the locator has been increased in response to marginal events not always being detected. The changes should stabilize the output of glass3. There is a slight performance decrease. Changes such as this should be configurable in the future. 


* **What is the current behavior?** (You can also link to an open issue here)
The operational instances of GLASS3 were finding different events.

* **What is the new behavior (if this is a feature change)?**
The output should be stabilized between the two instances. 

* **Other information**:
I tested these changes on the CEUS dataset. All test events were detected. 30 new events were detected as compared to V1.0.1, a potential slight increase in noise and splits, but a marginal change overall. 

After these changes are implemented we should check the Kafka feed to ensure that the output between the two instances is stabilized. 
