### PR TITLE
Two pick (instead of station) nucleation. 

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
 # version.cmake - a CMake script that defines the overall project version
 set (PROJECT_VERSION_MAJOR 1)
-set (PROJECT_VERSION_MINOR 1)
+set (PROJECT_VERSION_MINOR 2)
 set (PROJECT_VERSION_PATCH 1)

--- a/glasscore/glasslib/include/Node.h
+++ b/glasscore/glasslib/include/Node.h
@@ -171,21 +171,19 @@ class CNode {
 	 * \brief CNode significance function
 	 *
 	 * Given an observed time and a link to a site, compute the best
-	 * significance value from the traveltime(s) contained in the link to this
+	 * significance value from the traveltime contained in the link to this
 	 * node.
 	 *
 	 * \param tObservedTT - A double value containing the observed travel time
-	 * \param travelTime1 - A double value containing the first calculated
-	 * travel time
-	 * \param travelTime2 - A double value containing the first calculated
+	 * \param travelTime - A double value containing the first calculated
 	 * travel time
 	 * \param distDeg - A double value containing the distance between the
 	 * station and the node in degrees
-	 * \return Returns best significance if there is at least one valid travel
+	 * \return Returns  significance if there is a valid travel
 	 * time, -1.0 otherwise
 	 */
-	double getBestSignificance(double tObservedTT, double travelTime1,
-								double travelTime2, double distDeg);
+	double getSignificance(double tObservedTT, double travelTime,
+							double distDeg);
 
 	/**
 	 * \brief CNode site used function

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -275,10 +275,12 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 	// search through each site linked to this node
 	for (const auto &link : m_vSiteLinkList) {
 		// init sigbest
-		double dSigBest = -1.0;
+		double dSigBest_phase1 = -1.0;
+		double dSigBest_phase2 = -1.0;
 
 		// the best nucleating pick
-		std::shared_ptr<CPick> pickBest;
+		std::shared_ptr<CPick> pickBest_phase1;
+		std::shared_ptr<CPick> pickBest_phase2;
 
 		// get shared pointer to site
 		std::shared_ptr<CSite> site = std::get < LINK_PTR > (link);
@@ -363,6 +365,9 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 		for (auto it = lower; (it != site->getEnd()); ++it) {
 			auto pick = *it;
 
+			bool phase1set = false;
+			bool phase2set = false;
+
 			if (pick == NULL) {
 				continue;
 			}
@@ -442,13 +447,11 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 					if (pick->getClassifiedPhase() == phase1) {
 						// match, we only consider traveltime1, disable
 						// traveltime2
-						travelTime2 =
-								traveltime::CTravelTime::k_dTravelTimeInvalid;
+						phase1set = true;
 					} else if (pick->getClassifiedPhase() == phase2) {
 						// match, we only consider traveltime2, disable
 						// traveltime1
-						travelTime1 =
-								traveltime::CTravelTime::k_dTravelTimeInvalid;
+						phase2set = true;
 					}
 					// otherwise there is no match and it's business as usual
 				}
@@ -512,21 +515,27 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 				}
 			}
 
-			// get the best significance from the observed time and the
-			// link hmmm... at this point we don't know which TT got us here,
-			// or which one
-			double dSig = getBestSignificance(tObs, travelTime1, travelTime2,
-												distDeg);
+			// get the best significance from the observed time and link
 
-			// only count if this pick is significant (better than
-			// previous)
-			if (dSig > dSigBest) {
-				// keep the new best significance
-				dSigBest = dSig;
+			double dSig1 = getSignificance(tObs, travelTime1, distDeg);
+			double dSig2 = getSignificance(tObs, travelTime2, distDeg);
 
-				// remember the best pick
-				pickBest = pick;
+			if(phase1set) {
+				dSig2 = -1.;
 			}
+			if(phase2set) {
+				dSig1 = -1.;
+			}
+			if (dSig1 >= dSig2 && dSig1 > dSigBest_phase1) {
+				dSigBest_phase1 = dSig1;
+				pickBest_phase1 = pick;
+
+			}
+			if (dSig2 > dSig1 && dSig2 > dSigBest_phase2) {
+				dSigBest_phase2 = dSig2;
+				pickBest_phase2 = pick;
+			}
+
 		}  // ---- end search through each pick at this site ----
 
 		site->getPickMutex().unlock();
@@ -534,19 +543,29 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 		// check to see if the pick with the highest significance at this site
 		// should be added to the overall sum from this site
 		// NOTE: This significance threshold is hard coded.
-		if ((dSigBest >= 0.1) && (pickBest != NULL)) {
+		if ((dSigBest_phase1 >= 0.1) && (pickBest_phase1 != NULL)) {
 			// count this site
 			nCount++;
 
 			// add the best pick significance to the node
 			// significance sum
-			dSum += dSigBest;
+			dSum += dSigBest_phase1;
 
 			// add the pick to the pick vector
-			vPick.push_back(pickBest);
+			vPick.push_back(pickBest_phase1);
+		}
+		if ((dSigBest_phase2 >= 0.1) && (pickBest_phase2 != NULL)) {
+			// count this site
+			nCount++;
+			// add the best pick significance to the node
+			// significance sum
+			dSum += dSigBest_phase2;
+
+			// add the pick to the pick vector
+			vPick.push_back(pickBest_phase2);
 		}
 	}  // ---- end search through each site this node is linked to ----
-
+	// std::cout << "ncount: " << nCount << std::endl;
 	// make sure the number of significant picks
 	// exceeds the nucleation threshold
 	if (nCount < nCut) {
@@ -571,19 +590,14 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 	return (trigger);
 }
 
-// ---------------------------------------------------------getBestSignificance
-double CNode::getBestSignificance(double tObservedTT, double travelTime1,
-									double travelTime2, double distDeg) {
+// ---------------------------------------------------------getSignificance
+double CNode::getSignificance(double tObservedTT, double travelTime,
+								double distDeg) {
 	// use observed travel time, travel times to site
-	double tRes1 = -1;
-	if (travelTime1 > 0) {
+	double tRes = -1;
+	if (travelTime > 0) {
 		// calculate time residual
-		tRes1 = std::abs(tObservedTT - travelTime1);
-	}
-	double tRes2 = -1;
-	if (travelTime2 > 0) {
-		// calculate time residual
-		tRes2 = std::abs(tObservedTT - travelTime2);
+		tRes = std::abs(tObservedTT - travelTime);
 	}
 
 	// compute significances using residuals and web resolution
@@ -594,33 +608,14 @@ double CNode::getBestSignificance(double tObservedTT, double travelTime1,
 	// the form of a residual allowance which calculates the maximum off grid
 	// distance assuming the nodes form a cuboid and multiply but compute
 	// slowness at that region, then multiplies by a factor (2) for slop.
-	double dSig1 = 0;
-	if (tRes1 > 0) {
-		dSig1 =
+	double dSig = 0;
+	if (tRes > 0) {
+		dSig =
 				glass3::util::GlassMath::sig(
 						std::max(
 								0.0,
-								(tRes1
-										- (travelTime1 / distDeg)
-												* (std::sqrt(
-														3.
-																* (m_dResolution
-																		* m_dResolution)
-																+ (k_dDepthShellResolutionKm
-																		* k_dDepthShellResolutionKm))
-														* .5)
-												* glass3::util::Geo::k_KmToDegrees
-												* k_residualDistanceAllowanceFactor)),
-						CGlass::k_dNucleationSecondsPerSigma);
-	}
-	double dSig2 = 0;
-	if (tRes2 > 0) {
-		dSig2 =
-				glass3::util::GlassMath::sig(
-						std::max(
-								0.0,
-								(tRes2
-										- (travelTime2 / distDeg)
+								(tRes
+										- (travelTime / distDeg)
 												* (std::sqrt(
 														3.
 																* (m_dResolution
@@ -633,12 +628,7 @@ double CNode::getBestSignificance(double tObservedTT, double travelTime1,
 						CGlass::k_dNucleationSecondsPerSigma);
 	}
 
-	// return the higher of the two significances
-	if (dSig1 > dSig2) {
-		return (dSig1);
-	} else {
-		return (dSig2);
-	}
+	return (dSig);
 }
 
 // ---------------------------------------------------------getSite

--- a/glasscore/glasslib/src/Node.cpp
+++ b/glasscore/glasslib/src/Node.cpp
@@ -529,13 +529,11 @@ std::shared_ptr<CTrigger> CNode::nucleate(double tOrigin) {
 			if (dSig1 >= dSig2 && dSig1 > dSigBest_phase1) {
 				dSigBest_phase1 = dSig1;
 				pickBest_phase1 = pick;
-
 			}
 			if (dSig2 > dSig1 && dSig2 > dSigBest_phase2) {
 				dSigBest_phase2 = dSig2;
 				pickBest_phase2 = pick;
 			}
-
 		}  // ---- end search through each pick at this site ----
 
 		site->getPickMutex().unlock();


### PR DESCRIPTION
Previously it was tied to the number of stations, so only one P or S pick could be used for nucleation. This hampered the sensitivity. The result of this change will increase the sensitivity of two-phase nucleation for a given configuration as compared to previous versions. This is significant.

What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Change to the core algorithm.

What is the current behavior? (You can also link to an open issue here)
Only one pick could be used per stations in the nucleation stage, i.e. nucleation was station based.

What is the new behavior (if this is a feature change)?
Two picks (ex. P and S) can be used for nucleation, making nucleation pick based

Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Nope

Other information:
Configurations may need to be adjusted to account for the increased nucleation sensitivity that results from switching to pick based nucleation.