### PR TITLE
Depth fix

### DIFF
--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <atomic>
 #include "TTT.h"
+#include "ZoneStats.h"
 
 namespace glasscore {
 
@@ -113,7 +114,8 @@ class CHypo {
 			std::shared_ptr<traveltime::CTravelTime> secondTrav,
 			std::shared_ptr<traveltime::CTTT> ttt, double resolution = 100,
 			double aziTaper = 360.0, double maxDepth = 800.0,
-			CSiteList *pSiteList = NULL);
+			CSiteList *pSiteList = NULL,
+			std::shared_ptr<traveltime::CZoneStats> m_pZoneStats = NULL);
 
 	/**
 	 * \brief CHypo advanced constructor
@@ -151,7 +153,8 @@ class CHypo {
 			std::shared_ptr<traveltime::CTravelTime> firstTrav,
 			std::shared_ptr<traveltime::CTravelTime> secondTrav,
 			std::shared_ptr<traveltime::CTTT> ttt, double resolution = 100,
-			double aziTaper = 360.0, double maxDepth = 800.0);
+			double aziTaper = 360.0, double maxDepth = 800.0,
+			std::shared_ptr<traveltime::CZoneStats> m_pZoneStats = NULL);
 
 	/**
 	 * \brief CHypo advanced constructor
@@ -235,9 +238,10 @@ class CHypo {
 					double thresh, int cut,
 					std::shared_ptr<traveltime::CTravelTime> firstTrav,
 					std::shared_ptr<traveltime::CTravelTime> secondTrav,
-					std::shared_ptr<traveltime::CTTT> ttt, double resolution =
-							100,
-					double aziTaper = 360.0, double maxDepth = 800.0);
+					std::shared_ptr<traveltime::CTTT> ttt,
+					double resolution = 100,
+					double aziTaper = 360.0, double maxDepth = 800.0,
+					std::shared_ptr<traveltime::CZoneStats> m_pZoneStats = NULL);
 
 	/**
 	 * \brief Add pick reference to this hypo
@@ -1207,7 +1211,7 @@ class CHypo {
 	/**
 	 * \brief The maximum threshold for the location taper
 	 */
-	static constexpr double k_dLocationMaxTaperThreshold = 30.0;
+	static constexpr double k_dLocationMaxTaperThreshold = 50.0;
 
 	/**
 	 * \brief The small nPick threshold to skip during location
@@ -1227,12 +1231,12 @@ class CHypo {
 	/**
 	 * \brief The nPick threshold indicating a small hypo during location
 	 */
-	static const int k_iLocationNPickThresholdSmall = 25;
+	static const int k_iLocationNPickThresholdSmall = 50;
 
 	/**
 	 * \brief The nPick threshold indicating a medium hypo during location
 	 */
-	static const int k_iLocationNPickThresholdMedium = 50;
+	static const int k_iLocationNPickThresholdMedium = 100;
 
 	/**
 	 * \brief The nPick threshold indicating a large hypo during location
@@ -1371,7 +1375,7 @@ class CHypo {
  	 * that are beyond teleseismic distances as determined by the limit from
  	 * CGlass as of the last call of calculateStatistics
  	 */
-        std::atomic<int> m_iTeleseismicPhaseCount;
+     std::atomic<int> m_iTeleseismicPhaseCount;
 
 	/**
 	 * \brief A double value containing this hypo's distance standard deviation
@@ -1478,6 +1482,11 @@ class CHypo {
 	 * functions
 	 */
 	std::shared_ptr<traveltime::CTTT> m_pTravelTimeTables;
+
+	/**
+	 * \brief A pointer to a zonestats pointer
+	 */
+	std::shared_ptr<traveltime::CZoneStats> m_pZoneStats;
 
 	/**
 	 * \brief A recursive_mutex to control threading access to CHypo.

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -18,6 +18,7 @@
 #include "ZoneStats.h"
 #include "taper.h"
 
+
 namespace glasscore {
 
 // forward declarations
@@ -1509,10 +1510,16 @@ class CHypo {
 	 */
 	std::shared_ptr<traveltime::CZoneStats> m_pZoneStats;
 
-
+	/**
+	 * \brief Taper for event depth being larger than zonestats
+	 */
 	glass3::util::Taper m_taperDepth;
-
+	
+	/**
+	 * \brief Taper for large azimuthal gap
+	 */
 	glass3::util::Taper m_taperGap;
+
 
 	/**
 	 * \brief A recursive_mutex to control threading access to CHypo.

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -16,6 +16,7 @@
 #include <atomic>
 #include "TTT.h"
 #include "ZoneStats.h"
+#include "taper.h"
 
 namespace glasscore {
 
@@ -1487,6 +1488,11 @@ class CHypo {
 	 * \brief A pointer to a zonestats pointer
 	 */
 	std::shared_ptr<traveltime::CZoneStats> m_pZoneStats;
+
+
+	glass3::util::Taper m_taperDepth;
+
+	glass3::util::Taper m_taperGap;
 
 	/**
 	 * \brief A recursive_mutex to control threading access to CHypo.

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -17,7 +17,10 @@
 #include "TTT.h"
 #include "ZoneStats.h"
 #include "taper.h"
+<<<<<<< HEAD
 
+=======
+>>>>>>> added depth taper based on zone stats, where bayes is downweighted to .25 at 1.5* max zonestats depth. Also moved these to calculateBayes function for consistency throughout the algorithm
 
 namespace glasscore {
 

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -1276,6 +1276,16 @@ class CHypo {
 	 */
 	static constexpr double k_dSearchRadiusFactor = 0.5;
 
+	/**
+	 * \brief The factor for dividing when computing the location search radius
+	 */
+	static constexpr double k_SPhaseDownweight = 0.5;
+
+	/**
+	 * \brief The factor for dividing when computing the location search radius
+	 */
+	static constexpr double k_OtherPhaseDownweight = 0.1;
+
  private:
 	/**
 	 * \brief  A std::string with the name of the web used during the nucleation
@@ -1294,6 +1304,16 @@ class CHypo {
 	 * used during the nucleation process
 	 */
 	std::atomic<double> m_dNucleationStackThreshold;
+
+	/**
+	 * \brief A double for all other phases (not P or S) downweight in bayes/location
+	 */
+	std::atomic<double> m_OtherPhaseDownweight;
+
+	/**
+	 * \brief A double for S phase downweight in bayes/location
+	 */
+	std::atomic<double> m_SPhaseDownweight;
 
 	/**
 	 * \brief A double value containing the the taper to use on the bayseian

--- a/glasscore/glasslib/include/Hypo.h
+++ b/glasscore/glasslib/include/Hypo.h
@@ -17,10 +17,6 @@
 #include "TTT.h"
 #include "ZoneStats.h"
 #include "taper.h"
-<<<<<<< HEAD
-
-=======
->>>>>>> added depth taper based on zone stats, where bayes is downweighted to .25 at 1.5* max zonestats depth. Also moved these to calculateBayes function for consistency throughout the algorithm
 
 namespace glasscore {
 

--- a/glasscore/glasslib/include/Web.h
+++ b/glasscore/glasslib/include/Web.h
@@ -546,6 +546,13 @@ class CWeb : public glass3::util::ThreadBaseClass {
 	double getASeismicNucleationStackThreshold() const;
 
 	/**
+	 * \brief gets the zonestats pointer for the web
+	 * \return returns a zonestats pointer or null
+	 *
+	 */
+	const std::shared_ptr<traveltime::CZoneStats>& getZoneStatsPointer() const;  // NOLINT
+
+	/**
 	 * \brief Gets the aseismic nucleation data (picks) minimum threshold used for
 	 * this web
 	 * \return Returns an integer value containing the aseismic nucleation data minimum

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -619,12 +619,12 @@ void CHypo::annealingLocateBayes(int nIter, double dStart, double dStop,
 			currentLocationMaxDepthFromZoneStats > m_dMaxDepth) {
 		currentLocationMaxDepthFromZoneStats = m_dMaxDepth;
 	}
-	currentLocationMaxDepthFromZoneStats = 1.;
+
 	// build taper for depth, from 0 to currentLocationMaxDepthFromZoneStats
 	// it equals 1, from currentLocationMaxDepthFromZoneStats to 1.5 *
 	// currentLocationMaxDepthFromZoneStats it tapers to zero
 	m_taperDepth = glass3::util::Taper(0.0, 0.0,
-			currentLocationMaxDepthFromZoneStats,
+			currentLocationMaxDepthFromZoneStats*1.,
 			currentLocationMaxDepthFromZoneStats*1.5);
 
 	// these hold the values of the initial, current, and best stack location
@@ -2007,7 +2007,10 @@ double CHypo::calculateBayes(double xlat, double xlon, double xZ, double oT,
 		// calculate and add to the stack
 		value += glass3::util::GlassMath::sig(resi, sigma);
 	}
-	return value * taperGap.calculateValue(calculateGap(xlat, xlon, xZ)) * taperDepth.calculateValue(xZ);
+
+	return value
+			* m_taperGap.calculateValue(calculateGap(xlat, xlon, xZ))
+			* ((m_taperDepth.calculateValue(xZ)*.75)+.25);
 }
 
 // --------------------------------------------------------getInitialBayesValue

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -69,9 +69,10 @@ CHypo::CHypo(double lat, double lon, double z, double time, std::string pid,
 				std::shared_ptr<traveltime::CTravelTime> firstTrav,
 				std::shared_ptr<traveltime::CTravelTime> secondTrav,
 				std::shared_ptr<traveltime::CTTT> ttt, double resolution,
-				double aziTap, double maxDep) {
+				double aziTap, double maxDep,
+				std::shared_ptr<traveltime::CZoneStats> zoneStats) {
 	if (!initialize(lat, lon, z, time, pid, web, bayes, thresh, cut, firstTrav,
-					secondTrav, ttt, resolution, aziTap, maxDep)) {
+					secondTrav, ttt, resolution, aziTap, maxDep, zoneStats)) {
 		clear();
 	}
 }
@@ -81,7 +82,8 @@ CHypo::CHypo(std::shared_ptr<json::Object> detection, double thresh, int cut,
 				std::shared_ptr<traveltime::CTravelTime> firstTrav,
 				std::shared_ptr<traveltime::CTravelTime> secondTrav,
 				std::shared_ptr<traveltime::CTTT> ttt, double resolution,
-				double aziTap, double maxDep, CSiteList *pSiteList) {
+				double aziTap, double maxDep, CSiteList *pSiteList,
+				std::shared_ptr<traveltime::CZoneStats> zoneStats) {
 	// null check json
 	if (detection == NULL) {
 		glass3::util::Logger::log("error",
@@ -198,7 +200,7 @@ CHypo::CHypo(std::shared_ptr<json::Object> detection, double thresh, int cut,
 
 	if (!initialize(lat, lon, z, time, glass3::util::GlassID::getID(),
 					"Detection", bayes, thresh, cut, firstTrav, secondTrav, ttt,
-					resolution, aziTap, maxDep)) {
+					resolution, aziTap, maxDep, zoneStats)) {
 		clear();
 	}
 
@@ -276,7 +278,8 @@ CHypo::CHypo(std::shared_ptr<CTrigger> trigger,
 					trigger->getWeb()->getNucleationTravelTime2(), ttt,
 					trigger->getWebResolution(),
 					trigger->getWeb()->getAzimuthTaper(),
-					trigger->getWeb()->getMaxDepth())) {
+					trigger->getWeb()->getMaxDepth(),
+					trigger->getWeb()->getZoneStatsPointer())) {
 		clear();
 	}
 }
@@ -592,18 +595,45 @@ void CHypo::annealingLocateBayes(int nIter, double dStart, double dStop,
 	}
 
 	// taper to lower calculateValue if large azimuthal gap
-	glass3::util::Taper taperGap;
-	taperGap = glass3::util::Taper(0.0, 0.0, m_dAzimuthTaper,
+	m_taperGap = glass3::util::Taper(0.0, 0.0, m_dAzimuthTaper,
 									k_dGapTaperDownEnd);
+
+	// first set the max amount to be large, so basically the taper is always 1.
+	// if m_pWeb is NULL
+	double currentLocationMaxDepthFromZoneStats = 999999.;
+	// use the getZoneStatMaxDepth to set the start of the taper
+
+	if(m_pZoneStats != NULL) {
+    	currentLocationMaxDepthFromZoneStats =
+    			m_pZoneStats->getMaxDepthForLatLon(m_dLatitude,m_dLongitude);
+    }
+
+	// if its too small set to moho-ish depth
+	if(m_pZoneStats != NULL &&
+			currentLocationMaxDepthFromZoneStats < 35.) {
+		currentLocationMaxDepthFromZoneStats = 35.;
+	}
+
+	// if it is larger than the web max depth, use web's max depth
+	if(m_pZoneStats != NULL &&
+			currentLocationMaxDepthFromZoneStats > m_dMaxDepth) {
+		currentLocationMaxDepthFromZoneStats = m_dMaxDepth;
+	}
+	currentLocationMaxDepthFromZoneStats = 1.;
+	// build taper for depth, from 0 to currentLocationMaxDepthFromZoneStats
+	// it equals 1, from currentLocationMaxDepthFromZoneStats to 1.5 *
+	// currentLocationMaxDepthFromZoneStats it tapers to zero
+	m_taperDepth = glass3::util::Taper(0.0, 0.0,
+			currentLocationMaxDepthFromZoneStats,
+			currentLocationMaxDepthFromZoneStats*1.5);
 
 	// these hold the values of the initial, current, and best stack location
 	double valStart = 0;
 	double valBest = 0;
 	// calculate the value of the stack at the current location
 	valStart = calculateBayes(m_dLatitude, m_dLongitude, m_dDepth, m_tOrigin,
-								nucleate)
-			* taperGap.calculateValue(
-					calculateGap(m_dLatitude, m_dLongitude, m_dDepth));
+								nucleate);
+
 
 	char sLog[glass3::util::Logger::k_nMaxLogEntrySize];
 
@@ -682,8 +712,7 @@ void CHypo::annealingLocateBayes(int nIter, double dStart, double dStop,
 		double oT = m_tOrigin + dt;
 
 		// get the stack value for this hypocenter
-		double bayes = calculateBayes(xlat, xlon, xz, oT, nucleate)
-				* taperGap.calculateValue(calculateGap(xlat, xlon, xz));
+		double bayes = calculateBayes(xlat, xlon, xz, oT, nucleate);
 
 		// if testing locator print iteration
 		if (CGlass::getTestLocator()) {
@@ -1978,7 +2007,7 @@ double CHypo::calculateBayes(double xlat, double xlon, double xZ, double oT,
 		// calculate and add to the stack
 		value += glass3::util::GlassMath::sig(resi, sigma);
 	}
-	return value;
+	return value * taperGap.calculateValue(calculateGap(xlat, xlon, xZ)) * taperDepth.calculateValue(xZ);
 }
 
 // --------------------------------------------------------getInitialBayesValue
@@ -2649,7 +2678,8 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 						std::shared_ptr<traveltime::CTravelTime> firstTrav,
 						std::shared_ptr<traveltime::CTravelTime> secondTrav,
 						std::shared_ptr<traveltime::CTTT> ttt,
-						double resolution, double aziTap, double maxDep) {
+						double resolution, double aziTap, double maxDep,
+						std::shared_ptr<traveltime::CZoneStats> zoneStats) {
 	// lock mutex for this scope
 	std::lock_guard < std::recursive_mutex > guard(m_HypoMutex);
 
@@ -2669,9 +2699,13 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 	m_dNucleationStackThreshold = thresh;
 	m_iNucleationDataThreshold = cut;
 	m_dWebResolution = resolution;
+	m_pZoneStats = zoneStats;
 	if (m_dWebResolution == 0.0) {
 		m_dWebResolution = 100.0;
 	}
+
+	m_taperGap = glass3::util::Taper(0.0, 0.0, 999., 999.);
+	m_taperDepth = glass3::util::Taper(0.0, 0.0, 999., 999.);
 
 	// init the performance timing audit struct to 0's
 	memset(&m_hapsAudit, 0, sizeof(m_hapsAudit));

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -69,9 +69,10 @@ CHypo::CHypo(double lat, double lon, double z, double time, std::string pid,
 				std::shared_ptr<traveltime::CTravelTime> firstTrav,
 				std::shared_ptr<traveltime::CTravelTime> secondTrav,
 				std::shared_ptr<traveltime::CTTT> ttt, double resolution,
-				double aziTap, double maxDep) {
+				double aziTap, double maxDep,
+				std::shared_ptr<traveltime::CZoneStats> zoneStats) {
 	if (!initialize(lat, lon, z, time, pid, web, bayes, thresh, cut, firstTrav,
-					secondTrav, ttt, resolution, aziTap, maxDep)) {
+					secondTrav, ttt, resolution, aziTap, maxDep, zoneStats)) {
 		clear();
 	}
 }
@@ -81,7 +82,8 @@ CHypo::CHypo(std::shared_ptr<json::Object> detection, double thresh, int cut,
 				std::shared_ptr<traveltime::CTravelTime> firstTrav,
 				std::shared_ptr<traveltime::CTravelTime> secondTrav,
 				std::shared_ptr<traveltime::CTTT> ttt, double resolution,
-				double aziTap, double maxDep, CSiteList *pSiteList) {
+				double aziTap, double maxDep, CSiteList *pSiteList,
+				std::shared_ptr<traveltime::CZoneStats> zoneStats) {
 	// null check json
 	if (detection == NULL) {
 		glass3::util::Logger::log("error",
@@ -198,7 +200,7 @@ CHypo::CHypo(std::shared_ptr<json::Object> detection, double thresh, int cut,
 
 	if (!initialize(lat, lon, z, time, glass3::util::GlassID::getID(),
 					"Detection", bayes, thresh, cut, firstTrav, secondTrav, ttt,
-					resolution, aziTap, maxDep)) {
+					resolution, aziTap, maxDep, zoneStats)) {
 		clear();
 	}
 
@@ -276,7 +278,8 @@ CHypo::CHypo(std::shared_ptr<CTrigger> trigger,
 					trigger->getWeb()->getNucleationTravelTime2(), ttt,
 					trigger->getWebResolution(),
 					trigger->getWeb()->getAzimuthTaper(),
-					trigger->getWeb()->getMaxDepth())) {
+					trigger->getWeb()->getMaxDepth(),
+					trigger->getWeb()->getZoneStatsPointer())) {
 		clear();
 	}
 }
@@ -592,18 +595,45 @@ void CHypo::annealingLocateBayes(int nIter, double dStart, double dStop,
 	}
 
 	// taper to lower calculateValue if large azimuthal gap
-	glass3::util::Taper taperGap;
-	taperGap = glass3::util::Taper(0.0, 0.0, m_dAzimuthTaper,
+	m_taperGap = glass3::util::Taper(0.0, 0.0, m_dAzimuthTaper,
 									k_dGapTaperDownEnd);
+
+	// first set the max amount to be large, so basically the taper is always 1.
+	// if m_pWeb is NULL
+	double currentLocationMaxDepthFromZoneStats = 999999.;
+	// use the getZoneStatMaxDepth to set the start of the taper
+
+	if(m_pZoneStats != NULL) {
+    	currentLocationMaxDepthFromZoneStats =
+    			m_pZoneStats->getMaxDepthForLatLon(m_dLatitude,m_dLongitude);
+    }
+
+	// if its too small set to moho-ish depth
+	if(m_pZoneStats != NULL &&
+			currentLocationMaxDepthFromZoneStats < 35.) {
+		currentLocationMaxDepthFromZoneStats = 35.;
+	}
+
+	// if it is larger than the web max depth, use web's max depth
+	if(m_pZoneStats != NULL &&
+			currentLocationMaxDepthFromZoneStats > m_dMaxDepth) {
+		currentLocationMaxDepthFromZoneStats = m_dMaxDepth;
+	}
+	currentLocationMaxDepthFromZoneStats = 1.;
+	// build taper for depth, from 0 to currentLocationMaxDepthFromZoneStats
+	// it equals 1, from currentLocationMaxDepthFromZoneStats to 1.5 *
+	// currentLocationMaxDepthFromZoneStats it tapers to zero
+	m_taperDepth = glass3::util::Taper(0.0, 0.0,
+			currentLocationMaxDepthFromZoneStats,
+			currentLocationMaxDepthFromZoneStats*1.5);
 
 	// these hold the values of the initial, current, and best stack location
 	double valStart = 0;
 	double valBest = 0;
 	// calculate the value of the stack at the current location
 	valStart = calculateBayes(m_dLatitude, m_dLongitude, m_dDepth, m_tOrigin,
-								nucleate)
-			* taperGap.calculateValue(
-					calculateGap(m_dLatitude, m_dLongitude, m_dDepth));
+								nucleate);
+
 
 	char sLog[glass3::util::Logger::k_nMaxLogEntrySize];
 
@@ -682,8 +712,7 @@ void CHypo::annealingLocateBayes(int nIter, double dStart, double dStop,
 		double oT = m_tOrigin + dt;
 
 		// get the stack value for this hypocenter
-		double bayes = calculateBayes(xlat, xlon, xz, oT, nucleate)
-				* taperGap.calculateValue(calculateGap(xlat, xlon, xz));
+		double bayes = calculateBayes(xlat, xlon, xz, oT, nucleate);
 
 		// if testing locator print iteration
 		if (CGlass::getTestLocator()) {
@@ -1978,7 +2007,7 @@ double CHypo::calculateBayes(double xlat, double xlon, double xZ, double oT,
 		// calculate and add to the stack
 		value += glass3::util::GlassMath::sig(resi, sigma);
 	}
-	return value;
+	return value * taperGap.calculateValue(calculateGap(xlat, xlon, xZ)) * taperDepth.calculateValue(xZ);
 }
 
 // --------------------------------------------------------getInitialBayesValue
@@ -2650,7 +2679,8 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 						std::shared_ptr<traveltime::CTravelTime> firstTrav,
 						std::shared_ptr<traveltime::CTravelTime> secondTrav,
 						std::shared_ptr<traveltime::CTTT> ttt,
-						double resolution, double aziTap, double maxDep) {
+						double resolution, double aziTap, double maxDep,
+						std::shared_ptr<traveltime::CZoneStats> zoneStats) {
 	// lock mutex for this scope
 	std::lock_guard < std::recursive_mutex > guard(m_HypoMutex);
 
@@ -2670,9 +2700,13 @@ bool CHypo::initialize(double lat, double lon, double z, double time,
 	m_dNucleationStackThreshold = thresh;
 	m_iNucleationDataThreshold = cut;
 	m_dWebResolution = resolution;
+	m_pZoneStats = zoneStats;
 	if (m_dWebResolution == 0.0) {
 		m_dWebResolution = 100.0;
 	}
+
+	m_taperGap = glass3::util::Taper(0.0, 0.0, 999., 999.);
+	m_taperDepth = glass3::util::Taper(0.0, 0.0, 999., 999.);
 
 	// init the performance timing audit struct to 0's
 	memset(&m_hapsAudit, 0, sizeof(m_hapsAudit));

--- a/glasscore/glasslib/src/Hypo.cpp
+++ b/glasscore/glasslib/src/Hypo.cpp
@@ -56,7 +56,7 @@ const int CHypo::k_iLocationNumIterationsMedium;
 const int CHypo::k_iLocationNumIterationsLarge;
 constexpr double CHypo::k_dSearchRadiusResolutionFactor;
 constexpr double CHypo::k_dSearchRadiusTaperFactor;
-constexpr double CHypo::k_dSearchRadiusFactor;
+
 
 // ---------------------------------------------------------CHypo
 CHypo::CHypo() {
@@ -2263,14 +2263,14 @@ double CHypo::calculateWeightedResidual(std::string sPhase, double tObs,
 		// this value was selected by testing specific
 		// events with issues
 		// NOTE: Hard Coded
-		return ((tObs - tCal) * 2.0);
+		return ((tObs - tCal) * (1./k_SPhaseDownweight));
 	} else {
 		// Down weighting all other phases
 		// Value was chosen so that other phases would
 		// still contribute (reducing instabilities)
 		// but remain insignificant
 		// NOTE: Hard Coded
-		return ((tObs - tCal) * 10.0);
+		return ((tObs - tCal) * (1./k_OtherPhaseDownweight));
 	}
 }
 

--- a/glasscore/glasslib/src/Web.cpp
+++ b/glasscore/glasslib/src/Web.cpp
@@ -2443,6 +2443,12 @@ double CWeb::getZoneStatsMaxDepth(double dLat, double dLon) {
 	return(depth);
 }
 
+// -------------------------------------------getZoneStatPointer
+const std::shared_ptr<traveltime::CZoneStats>& CWeb::getZoneStatsPointer() const {  // NOLINT
+	// std::lock_guard<std::recursive_mutex> webGuard(m_WebMutex);
+	return(m_pZoneStats);
+	}
+
 // -------------------------------------getAseismicNucleationStackThreshold
 double CWeb::getASeismicNucleationStackThreshold() const {
 	return (m_dASeismicNucleationStackThreshold);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change adds a taper applied to the Bayes function. If an event's depth exceeds the maximum zone stats depth + some wiggle room, it gets down-weighted. This should prevent super deep events. There is also a little refactoring / changing values to be variables. 


* **What is the current behavior?** (You can also link to an open issue here)
We got ridiculously deep events at times. 


* **What is the new behavior (if this is a feature change)?**
These should be either forced to be the more appropriate shallow fit, or canceled. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not that I am aware of. 

* **Other information**:
**Please look at this carefully.** I made these changes a while ago. 